### PR TITLE
fix: build Universal Binary for Intel CPU support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,13 +18,14 @@ jobs:
       - name: Generate Xcode project
         run: xcodegen generate
 
-      - name: Build
+      - name: Build (Universal Binary)
         run: |
           xcodebuild -project PureMac.xcodeproj \
             -scheme PureMac \
             -configuration Release \
             -derivedDataPath build \
             build \
+            ARCHS="arm64 x86_64" \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO

--- a/project.yml
+++ b/project.yml
@@ -11,6 +11,7 @@ settings:
   base:
     SWIFT_VERSION: "5.9"
     MACOSX_DEPLOYMENT_TARGET: "13.0"
+    ARCHS: "arm64 x86_64"
     CODE_SIGN_IDENTITY: "-"
     CODE_SIGN_STYLE: "Automatic"
     DEVELOPMENT_TEAM: "H3WXHVTP97"


### PR DESCRIPTION
## Summary
- Added `ARCHS: "arm64 x86_64"` to `project.yml` build settings
- Updated CI workflow to pass `ARCHS="arm64 x86_64"` to xcodebuild
- This produces a Universal Binary that runs natively on both Intel and Apple Silicon Macs

## Root Cause
The project had no explicit `ARCHS` setting, so Xcode defaulted to building only for the host architecture (`arm64` on Apple Silicon). Intel Mac users got an incompatible binary.

Closes #7