### PR TITLE
feat: add size sort toggle button to category detail view

### DIFF
--- a/PureMac/Views/CategoryDetailView.swift
+++ b/PureMac/Views/CategoryDetailView.swift
@@ -1,8 +1,11 @@
 import SwiftUI
 
+
 struct CategoryDetailView: View {
     @EnvironmentObject var vm: AppViewModel
     let category: CleaningCategory
+
+    @State private var sortDescending: Bool = true
 
     var result: CategoryResult? {
         vm.categoryResults[category]
@@ -109,6 +112,14 @@ struct CategoryDetailView: View {
                 .font(.system(size: 11, weight: .medium))
                 .foregroundColor(.pmAccentLight)
                 .buttonStyle(.plain)
+
+                Button(action: { sortDescending.toggle() }) {
+                    Image(systemName: "arrow.up.arrow.down")
+                        .font(.system(size: 14))
+                        .foregroundColor(.pmAccentLight)
+                }
+                .buttonStyle(.plain)
+                .help(sortDescending ? "Sorted: Largest First" : "Sorted: Smallest First")
             }
             .padding(.horizontal, 48)
             .padding(.vertical, 8)
@@ -119,7 +130,7 @@ struct CategoryDetailView: View {
 
             ScrollView {
                 LazyVStack(spacing: 4) {
-                    ForEach(result.items) { item in
+                    ForEach(sortedItems(result.items)) { item in
                         FileRow(item: item, color: category.color)
                     }
                 }
@@ -171,6 +182,12 @@ struct CategoryDetailView: View {
                 .foregroundColor(.pmTextMuted)
             Spacer()
         }
+    }
+
+    // MARK: - Sort
+
+    private func sortedItems(_ items: [CleanableItem]) -> [CleanableItem] {
+        items.sorted { sortDescending ? $0.size > $1.size : $0.size < $1.size }
     }
 
     // MARK: - Action Bar


### PR DESCRIPTION
## Summary

- Add a sort toggle button (↑↓ icon) to the file list toolbar in CategoryDetailView, next to "Deselect All"
- Clicking the button toggles between descending (largest first) and ascending (smallest first) order by file size
- Defaults to largest-first sorting, with a tooltip indicating the current sort order

## Changes

- **PureMac/Views/CategoryDetailView.swift**: 
  - Added `@State private var sortDescending` to track sort direction
  - Added sort toggle button with `arrow.up.arrow.down` SF Symbol icon
  - Added `sortedItems(_:)` helper to sort items by size
  - Updated `ForEach` to use sorted items

## Test plan

- [ ] Build and run the app
- [ ] Navigate to any category detail view with scanned items
- [ ] Verify items default to largest-first order
- [ ] Click the sort button and verify items reorder to smallest-first
- [ ] Click again and verify it toggles back
- [ ] Hover over the sort button and verify tooltip shows correct sort order