### PR TITLE
feat: add AI Apps cleanup category for Ollama and LM Studio

### DIFF
--- a/PureMac/Models/Models.swift
+++ b/PureMac/Models/Models.swift
@@ -6,6 +6,7 @@ enum CleaningCategory: String, CaseIterable, Identifiable, Codable {
     case smartScan = "Smart Scan"
     case systemJunk = "System Junk"
     case userCache = "User Cache"
+    case aiApps = "AI Apps"
     case mailAttachments = "Mail Files"
     case trashBins = "Trash Bins"
     case largeFiles = "Large & Old Files"
@@ -20,6 +21,7 @@ enum CleaningCategory: String, CaseIterable, Identifiable, Codable {
         case .smartScan: return "sparkles"
         case .systemJunk: return "gearshape.fill"
         case .userCache: return "internaldrive.fill"
+        case .aiApps: return "cpu.fill"
         case .mailAttachments: return "envelope.fill"
         case .trashBins: return "trash.fill"
         case .largeFiles: return "doc.fill"
@@ -34,6 +36,7 @@ enum CleaningCategory: String, CaseIterable, Identifiable, Codable {
         case .smartScan: return "Scan everything at once"
         case .systemJunk: return "System caches, logs, and temporary files"
         case .userCache: return "Application caches and browser data"
+        case .aiApps: return "Logs, caches, and temporary files from local AI apps"
         case .mailAttachments: return "Downloaded mail attachments"
         case .trashBins: return "Files in your Trash"
         case .largeFiles: return "Files over 100 MB or older than 1 year"
@@ -48,6 +51,7 @@ enum CleaningCategory: String, CaseIterable, Identifiable, Codable {
         case .smartScan: return .pmAccent
         case .systemJunk: return .pmGradientEnd
         case .userCache: return .pmInfo
+        case .aiApps: return Color(hex: "14b8a6")
         case .mailAttachments: return .pmWarning
         case .trashBins: return .pmDanger
         case .largeFiles: return Color(hex: "f97316")

--- a/PureMac/Services/ScanEngine.swift
+++ b/PureMac/Services/ScanEngine.swift
@@ -4,6 +4,11 @@ actor ScanEngine {
     private let fileManager = FileManager.default
     private let home = FileManager.default.homeDirectoryForCurrentUser.path
 
+    private struct CleanupTarget {
+        let name: String
+        let path: String
+    }
+
     // MARK: - Public API
 
     func scanCategory(_ category: CleaningCategory) async -> CategoryResult {
@@ -11,21 +16,23 @@ actor ScanEngine {
         case .smartScan:
             return CategoryResult(category: category, items: [], totalSize: 0)
         case .systemJunk:
-            return await scanSystemJunk()
+            return scanSystemJunk()
         case .userCache:
-            return await scanUserCache()
+            return scanUserCache()
+        case .aiApps:
+            return scanAIApps()
         case .mailAttachments:
-            return await scanMailAttachments()
+            return scanMailAttachments()
         case .trashBins:
-            return await scanTrash()
+            return scanTrash()
         case .largeFiles:
-            return await scanLargeFiles()
+            return scanLargeFiles()
         case .purgeableSpace:
-            return await scanPurgeableSpace()
+            return scanPurgeableSpace()
         case .xcodeJunk:
-            return await scanXcodeJunk()
+            return scanXcodeJunk()
         case .brewCache:
-            return await scanBrewCache()
+            return scanBrewCache()
         }
     }
 
@@ -52,7 +59,7 @@ actor ScanEngine {
 
     // MARK: - Scanners
 
-    private func scanSystemJunk() async -> CategoryResult {
+    private func scanSystemJunk() -> CategoryResult {
         var items: [CleanableItem] = []
         var totalSize: Int64 = 0
 
@@ -74,8 +81,21 @@ actor ScanEngine {
         return CategoryResult(category: .systemJunk, items: items, totalSize: totalSize)
     }
 
-    private func scanUserCache() async -> CategoryResult {
+    private func scanUserCache() -> CategoryResult {
         var items: [CleanableItem] = []
+        let excludedRootPaths = Set([
+            "\(home)/Library/Caches/com.apple.Safari",
+            "\(home)/Library/Caches/Google",
+            "\(home)/Library/Caches/Firefox",
+            "\(home)/Library/Caches/com.spotify.client",
+            "\(home)/Library/Caches/com.microsoft.VSCode",
+            "\(home)/Library/Caches/Slack",
+            "\(home)/Library/Caches/Homebrew",
+            "\(home)/Library/Caches/com.apple.dt.Xcode",
+            "\(home)/Library/Caches/pip",
+            "\(home)/Library/Caches/com.electron.ollama",
+            "\(home)/Library/Caches/ollama",
+        ].map(normalizePath))
 
         let cachePaths = [
             "\(home)/Library/Caches",
@@ -88,7 +108,13 @@ actor ScanEngine {
         ]
 
         for path in cachePaths {
-            let scanned = scanDirectory(path: path, category: .userCache, recursive: false, maxDepth: 1)
+            let scanned = scanDirectory(
+                path: path,
+                category: .userCache,
+                recursive: false,
+                maxDepth: 1,
+                excluding: path == "\(home)/Library/Caches" ? excludedRootPaths : Set<String>()
+            )
             items.append(contentsOf: scanned)
         }
 
@@ -102,26 +128,56 @@ actor ScanEngine {
         ]
 
         for path in devCaches {
-            if fileManager.fileExists(atPath: path) {
-                let size = directorySize(path: path)
-                if size > 0 {
-                    items.append(CleanableItem(
-                        name: URL(fileURLWithPath: path).lastPathComponent,
-                        path: path,
-                        size: size,
-                        category: .userCache,
-                        isSelected: true,
-                        lastModified: nil
-                    ))
-                }
+            if let item = makeCleanupItem(
+                name: URL(fileURLWithPath: path).lastPathComponent,
+                path: path,
+                category: .userCache
+            ) {
+                items.append(item)
             }
         }
 
-        let totalSize = items.reduce(0) { $0 + $1.size }
-        return CategoryResult(category: .userCache, items: items, totalSize: totalSize)
+        let uniqueItems = deduplicatedItems(items)
+        let totalSize = uniqueItems.reduce(0) { $0 + $1.size }
+        return CategoryResult(category: .userCache, items: uniqueItems, totalSize: totalSize)
     }
 
-    private func scanMailAttachments() async -> CategoryResult {
+    private func scanAIApps() -> CategoryResult {
+        let targets = [
+            CleanupTarget(
+                name: "Ollama Logs",
+                path: "\(home)/.ollama/logs"
+            ),
+            CleanupTarget(
+                name: "Ollama Cache",
+                path: "\(home)/Library/Caches/ollama"
+            ),
+            CleanupTarget(
+                name: "Ollama Electron Cache",
+                path: "\(home)/Library/Caches/com.electron.ollama"
+            ),
+            CleanupTarget(
+                name: "Ollama WebKit Data",
+                path: "\(home)/Library/WebKit/com.electron.ollama"
+            ),
+            CleanupTarget(
+                name: "Ollama Saved State",
+                path: "\(home)/Library/Saved Application State/com.electron.ollama.savedState"
+            ),
+            CleanupTarget(
+                name: "LM Studio Server Logs",
+                path: "\(home)/.lmstudio/server-logs"
+            ),
+        ]
+
+        let items = deduplicatedItems(targets.compactMap { target in
+            makeCleanupItem(name: target.name, path: target.path, category: .aiApps)
+        })
+        let totalSize = items.reduce(0) { $0 + $1.size }
+        return CategoryResult(category: .aiApps, items: items.sorted { $0.size > $1.size }, totalSize: totalSize)
+    }
+
+    private func scanMailAttachments() -> CategoryResult {
         var items: [CleanableItem] = []
 
         let mailPaths = [
@@ -138,7 +194,7 @@ actor ScanEngine {
         return CategoryResult(category: .mailAttachments, items: items, totalSize: totalSize)
     }
 
-    private func scanTrash() async -> CategoryResult {
+    private func scanTrash() -> CategoryResult {
         var items: [CleanableItem] = []
 
         let trashPath = "\(home)/.Trash"
@@ -149,7 +205,7 @@ actor ScanEngine {
         return CategoryResult(category: .trashBins, items: items, totalSize: totalSize)
     }
 
-    private func scanLargeFiles() async -> CategoryResult {
+    private func scanLargeFiles() -> CategoryResult {
         var items: [CleanableItem] = []
         let minSize: Int64 = 100 * 1024 * 1024 // 100 MB
         let oneYearAgo = Calendar.current.date(byAdding: .year, value: -1, to: Date())!
@@ -198,7 +254,7 @@ actor ScanEngine {
         return CategoryResult(category: .largeFiles, items: items, totalSize: totalSize)
     }
 
-    private func scanPurgeableSpace() async -> CategoryResult {
+    private func scanPurgeableSpace() -> CategoryResult {
         var items: [CleanableItem] = []
         var totalSize: Int64 = 0
 
@@ -235,7 +291,7 @@ actor ScanEngine {
         return CategoryResult(category: .purgeableSpace, items: items, totalSize: totalSize)
     }
 
-    private func scanXcodeJunk() async -> CategoryResult {
+    private func scanXcodeJunk() -> CategoryResult {
         var items: [CleanableItem] = []
 
         let xcodePaths = [
@@ -265,7 +321,7 @@ actor ScanEngine {
         return CategoryResult(category: .xcodeJunk, items: items, totalSize: totalSize)
     }
 
-    private func scanBrewCache() async -> CategoryResult {
+    private func scanBrewCache() -> CategoryResult {
         var items: [CleanableItem] = []
 
         // Homebrew cache locations (Apple Silicon + Intel)
@@ -299,7 +355,13 @@ actor ScanEngine {
 
     // MARK: - Helpers
 
-    private func scanDirectory(path: String, category: CleaningCategory, recursive: Bool, maxDepth: Int) -> [CleanableItem] {
+    private func scanDirectory(
+        path: String,
+        category: CleaningCategory,
+        recursive: Bool,
+        maxDepth: Int,
+        excluding excludedPaths: Set<String> = []
+    ) -> [CleanableItem] {
         var items: [CleanableItem] = []
 
         guard fileManager.fileExists(atPath: path),
@@ -309,6 +371,9 @@ actor ScanEngine {
             let contents = try fileManager.contentsOfDirectory(atPath: path)
             for item in contents {
                 let fullPath = (path as NSString).appendingPathComponent(item)
+                if excludedPaths.contains(normalizePath(fullPath)) {
+                    continue
+                }
 
                 var isDir: ObjCBool = false
                 guard fileManager.fileExists(atPath: fullPath, isDirectory: &isDir) else { continue }
@@ -344,6 +409,56 @@ actor ScanEngine {
         }
 
         return items
+    }
+
+    private func makeCleanupItem(name: String, path: String, category: CleaningCategory) -> CleanableItem? {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: path, isDirectory: &isDirectory),
+              fileManager.isReadableFile(atPath: path) else { return nil }
+
+        if isDirectory.boolValue {
+            let size = directorySize(path: path)
+            guard size > 1024 else { return nil }
+            return CleanableItem(
+                name: name,
+                path: path,
+                size: size,
+                category: category,
+                isSelected: true,
+                lastModified: fileModDate(path: path)
+            )
+        }
+
+        guard let attrs = try? fileManager.attributesOfItem(atPath: path),
+              let size = attrs[.size] as? Int64,
+              size > 1024 else { return nil }
+
+        return CleanableItem(
+            name: name,
+            path: path,
+            size: size,
+            category: category,
+            isSelected: true,
+            lastModified: attrs[.modificationDate] as? Date
+        )
+    }
+
+    private func deduplicatedItems(_ items: [CleanableItem]) -> [CleanableItem] {
+        var seenPaths: Set<String> = []
+        var uniqueItems: [CleanableItem] = []
+
+        for item in items {
+            let normalizedPath = normalizePath(item.path)
+            if seenPaths.insert(normalizedPath).inserted {
+                uniqueItems.append(item)
+            }
+        }
+
+        return uniqueItems
+    }
+
+    private func normalizePath(_ path: String) -> String {
+        (path as NSString).standardizingPath
     }
 
     private func directorySize(path: String) -> Int64 {

--- a/PureMac/Services/ScanEngine.swift
+++ b/PureMac/Services/ScanEngine.swift
@@ -100,7 +100,7 @@ actor ScanEngine {
         let cachePaths = [
             "\(home)/Library/Caches",
             "\(home)/Library/Caches/com.apple.Safari",
-            "\(home)/Library/Caches/Google/Chrome",
+            "\(home)/Library/Caches/Google",
             "\(home)/Library/Caches/Firefox",
             "\(home)/Library/Caches/com.spotify.client",
             "\(home)/Library/Caches/com.microsoft.VSCode",

--- a/PureMac/Services/ScanEngine.swift
+++ b/PureMac/Services/ScanEngine.swift
@@ -83,6 +83,9 @@ actor ScanEngine {
 
     private func scanUserCache() -> CategoryResult {
         var items: [CleanableItem] = []
+        // Exclude vendor roots claimed by dedicated categories from the broad
+        // ~/Library/Caches pass, then re-add the vendor root explicitly below so
+        // unrelated app caches remain visible and we only avoid double-counting.
         let excludedRootPaths = Set([
             "\(home)/Library/Caches/com.apple.Safari",
             "\(home)/Library/Caches/Google",

--- a/PureMac/en.lproj/Localizable.strings
+++ b/PureMac/en.lproj/Localizable.strings
@@ -84,6 +84,7 @@
 /* Cleaning Categories */
 "System Junk" = "System Junk";
 "User Cache" = "User Cache";
+"AI Apps" = "AI Apps";
 "Mail Files" = "Mail Files";
 "Trash Bins" = "Trash Bins";
 "Large & Old Files" = "Large & Old Files";
@@ -95,6 +96,7 @@
 "Scan everything at once" = "Scan everything at once";
 "System caches, logs, and temporary files" = "System caches, logs, and temporary files";
 "Application caches and browser data" = "Application caches and browser data";
+"Logs, caches, and temporary files from local AI apps" = "Logs, caches, and temporary files from local AI apps";
 "Downloaded mail attachments" = "Downloaded mail attachments";
 "Files in your Trash" = "Files in your Trash";
 "Files over 100 MB or older than 1 year" = "Files over 100 MB or older than 1 year";

--- a/PureMac/zh-Hans.lproj/Localizable.strings
+++ b/PureMac/zh-Hans.lproj/Localizable.strings
@@ -84,6 +84,7 @@
 /* Cleaning Categories */
 "System Junk" = "系统垃圾";
 "User Cache" = "用户缓存";
+"AI Apps" = "AI 应用";
 "Mail Files" = "邮件文件";
 "Trash Bins" = "废纸篓";
 "Large & Old Files" = "大型旧文件";
@@ -95,6 +96,7 @@
 "Scan everything at once" = "一次性扫描所有内容";
 "System caches, logs, and temporary files" = "系统缓存、日志和临时文件";
 "Application caches and browser data" = "应用程序缓存和浏览器数据";
+"Logs, caches, and temporary files from local AI apps" = "本地 AI 应用的日志、缓存和临时文件";
 "Downloaded mail attachments" = "下载的邮件附件";
 "Files in your Trash" = "废纸篓中的文件";
 "Files over 100 MB or older than 1 year" = "超过 100 MB 或一年以上的文件";

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ open build/Build/Products/Release/PureMac.app
 - **Smart Scan** - One-click scan across all categories
 - **System Junk** - System caches, logs, and temporary files
 - **User Cache** - Application caches and browser data
+- **AI Apps** - Ollama and LM Studio logs, caches, and temporary app data
 - **Mail Attachments** - Downloaded mail attachments
 - **Trash Bins** - Empty all Trash bins
 - **Large & Old Files** - Files over 100 MB or older than 1 year
@@ -120,6 +121,7 @@ How does PureMac stack up against other Mac cleaning tools?
 |---|---|
 | System Junk | `/Library/Caches`, `/Library/Logs`, `/tmp`, `~/Library/Logs` |
 | User Cache | `~/Library/Caches`, npm/pip/yarn/pnpm caches |
+| AI Apps | `~/.ollama/logs`, Ollama caches/WebKit/saved state, `~/.lmstudio/server-logs` |
 | Mail Attachments | `~/Library/Mail Downloads` |
 | Trash | `~/.Trash` |
 | Large Files | `~/Downloads`, `~/Documents`, `~/Desktop` (>100MB or >1yr old) |
@@ -131,6 +133,7 @@ How does PureMac stack up against other Mac cleaning tools?
 
 - Never deletes system-critical files
 - Only removes caches, logs, temporary files, and user-selected items
+- AI Apps excludes Ollama models, LM Studio models, and LM Studio conversations
 - Large & Old Files are **not auto-selected** - you choose what to remove
 - All operations are non-destructive to the operating system
 - Purgeable space uses only Time Machine snapshots, not actual free space


### PR DESCRIPTION
## Summary

Add a dedicated `AI Apps` cleanup category for known local AI runtimes on macOS, starting with `Ollama` and `LM Studio`.

## Why

PureMac already cleans broad cache locations, but local AI apps now generate meaningful amounts of removable app-specific data.

This change makes that cleanup more explicit and safer:

- users can inspect AI-app residue in its own category
- app-specific cleanup paths no longer have to rely on generic cache buckets
- primary user data is kept out of cleanup scope

## Scope

Included cleanup targets:

- `~/.ollama/logs`
- `~/Library/Caches/ollama`
- `~/Library/Caches/com.electron.ollama`
- `~/Library/WebKit/com.electron.ollama`
- `~/Library/Saved Application State/com.electron.ollama.savedState`
- `~/.lmstudio/server-logs`

Explicitly excluded from cleanup:

- `~/.ollama/models`
- `~/.lmstudio/models`
- `~/.lmstudio/conversations`

## Implementation

- add a new `AI Apps` category to the cleanup model
- route the category through `ScanEngine`
- scan conservative Ollama and LM Studio cleanup paths only
- reduce double-counting by excluding AI-app cache roots from the broad `User Cache` scan
- keep non-AI Google app caches visible by scanning the `Google` vendor root instead of only `Google/Chrome`
- update English and Simplified Chinese localization
- update README feature and safety documentation

## Clarification on the Google cache change

The `Google` cache handling is **not** part of the AI-app cleanup scope itself.

It is a follow-up safety adjustment to the generic `User Cache` deduplication logic:

- the broad `~/Library/Caches` scan now excludes vendor roots that are handled more explicitly elsewhere
- if `~/Library/Caches/Google` is excluded from that broad scan, re-adding only `Google/Chrome` would accidentally hide other Google app caches from scan results
- scanning the `Google` vendor root keeps unrelated Google app caches visible while still preventing double-counting in the generic cache pass

## Validation

- built locally with `./script/build_and_run.sh --verify`
- confirmed the project still compiles successfully after the category and scanner changes

## Notes

- This PR intentionally does not include local helper files or Codex run-button configuration.
- Manual verification on a machine with Ollama and LM Studio installed would still be useful before marking ready for review.
