### PR TITLE
fix: clear deselectedItems on new scan to fix item selection (issue #19)

### DIFF
--- a/PureMac/ViewModels/AppViewModel.swift
+++ b/PureMac/ViewModels/AppViewModel.swift
@@ -123,6 +123,7 @@ class AppViewModel: ObservableObject {
         categoryResults = [:]
         totalJunkSize = 0
         scanProgress = 0
+        deselectedItems.removeAll()
 
         Task {
             let categories = CleaningCategory.scannable
@@ -153,6 +154,7 @@ class AppViewModel: ObservableObject {
 
         Task {
             scanProgress = 0.5
+            deselectedItems.removeAll()
             let result = await scanEngine.scanCategory(category)
             categoryResults[category] = result
 


### PR DESCRIPTION
Fixes issue #19: items in Large & Old Files cannot be selected after "Deselect All"

**Root cause:** When `scanSingleCategory()` replaces `categoryResults[category]` with new scan results, the `deselectedItems` set was not cleared. If the same category was scanned previously and items were deselected (added to `deselectedItems`), the old UUIDs could persist and interfere with the new scan state. Additionally, `deselectedItems` is a global set that is not scoped to categories - items from different categories could have UUID collisions.

**Fix:** Call `deselectedItems.removeAll()` in two places:
1. `startSmartScan()` - when starting a full scan, clear all deselected items since all categories are refreshed
2. `scanSingleCategory()` - when scanning a specific category, clear deselected items so the new items start fresh (all selected by default)

This ensures items from a new scan are always in a clean selected state.