### PR TITLE
feat: add Node Cache category for npm/yarn/pnpm (#3)

### DIFF
--- a/PureMac/Models/Models.swift
+++ b/PureMac/Models/Models.swift
@@ -12,6 +12,7 @@ enum CleaningCategory: String, CaseIterable, Identifiable, Codable {
     case purgeableSpace = "Purgeable Space"
     case xcodeJunk = "Xcode Junk"
     case brewCache = "Brew Cache"
+    case nodeCache = "Node Cache"
 
     var id: String { rawValue }
 
@@ -26,6 +27,7 @@ enum CleaningCategory: String, CaseIterable, Identifiable, Codable {
         case .purgeableSpace: return "arrow.3.trianglepath"
         case .xcodeJunk: return "hammer.fill"
         case .brewCache: return "mug.fill"
+        case .nodeCache: return "leaf.fill"
         }
     }
 
@@ -40,6 +42,7 @@ enum CleaningCategory: String, CaseIterable, Identifiable, Codable {
         case .purgeableSpace: return "APFS purgeable disk space"
         case .xcodeJunk: return "Derived data, archives, and simulators"
         case .brewCache: return "Homebrew download cache"
+        case .nodeCache: return "npm, yarn, and pnpm download caches"
         }
     }
 
@@ -54,6 +57,7 @@ enum CleaningCategory: String, CaseIterable, Identifiable, Codable {
         case .purgeableSpace: return .green
         case .xcodeJunk: return .cyan
         case .brewCache: return .mint
+        case .nodeCache: return .pink
         }
     }
 

--- a/PureMac/Services/ScanEngine.swift
+++ b/PureMac/Services/ScanEngine.swift
@@ -31,6 +31,8 @@ actor ScanEngine {
             return scanXcodeJunk()
         case .brewCache:
             return scanBrewCache()
+        case .nodeCache:
+            return scanNodeCache()
         }
     }
 
@@ -335,6 +337,123 @@ actor ScanEngine {
 
         let totalSize = items.reduce(0) { $0 + $1.size }
         return CategoryResult(category: .brewCache, items: items, totalSize: totalSize)
+    }
+
+    private func scanNodeCache() -> CategoryResult {
+        // Each entry is `(displayName, defaultPath, optional CLI for cache-dir
+        // detection)`. The CLI invocation overrides `defaultPath` if the user
+        // has set a custom location (e.g. via `npm config set cache`).
+        struct ManagerCache {
+            let name: String
+            let defaultPath: String
+            let detectionCommand: (cli: String, args: [String])?
+        }
+
+        let managers: [ManagerCache] = [
+            ManagerCache(
+                name: "npm cache",
+                defaultPath: "\(home)/.npm",
+                detectionCommand: (cli: "npm", args: ["config", "get", "cache"])
+            ),
+            ManagerCache(
+                name: "yarn classic cache",
+                defaultPath: "\(home)/Library/Caches/Yarn",
+                detectionCommand: (cli: "yarn", args: ["cache", "dir"])
+            ),
+            // Yarn Berry / v2+ uses a per-project .yarn/cache. We don't try to
+            // chase those — they're inside user projects and shouldn't be
+            // touched by a system cleaner. The classic cache above remains the
+            // global, safe-to-clean location.
+            ManagerCache(
+                name: "pnpm content-addressable store",
+                defaultPath: "\(home)/Library/pnpm/store",
+                detectionCommand: (cli: "pnpm", args: ["store", "path"])
+            ),
+        ]
+
+        var items: [CleanableItem] = []
+
+        // Common $PATH locations on macOS where these CLIs land.
+        let cliSearchPaths = [
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "\(home)/.local/bin",
+            "\(home)/.volta/bin",
+            "\(home)/.nvm/versions/node",
+        ]
+
+        for manager in managers {
+            var paths: [String] = []
+            paths.append(manager.defaultPath)
+
+            if let cmd = manager.detectionCommand,
+               let cliPath = locateExecutable(named: cmd.cli, searchPaths: cliSearchPaths),
+               let detected = runCommandReadingStdout(executable: cliPath, args: cmd.args) {
+                let normalized = detected.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !normalized.isEmpty,
+                   !paths.map(normalizePath).contains(normalizePath(normalized)) {
+                    paths.append(normalized)
+                }
+            }
+
+            for path in paths {
+                guard fileManager.fileExists(atPath: path) else { continue }
+                let size = directorySize(path: path)
+                guard size > 0 else { continue }
+                items.append(CleanableItem(
+                    name: manager.name,
+                    path: path,
+                    size: size,
+                    category: .nodeCache,
+                    isSelected: true,
+                    lastModified: nil
+                ))
+            }
+        }
+
+        let totalSize = items.reduce(0) { $0 + $1.size }
+        return CategoryResult(category: .nodeCache, items: items, totalSize: totalSize)
+    }
+
+    // -- Process helpers (used by scanNodeCache) --
+
+    private func locateExecutable(named name: String, searchPaths: [String]) -> String? {
+        for dir in searchPaths {
+            let candidate = (dir as NSString).appendingPathComponent(name)
+            if fileManager.isExecutableFile(atPath: candidate) {
+                return candidate
+            }
+            // For nvm: ~/.nvm/versions/node/<version>/bin/<name>
+            if dir.hasSuffix("/.nvm/versions/node"),
+               let versions = try? fileManager.contentsOfDirectory(atPath: dir) {
+                for v in versions {
+                    let nested = (dir as NSString).appendingPathComponent("\(v)/bin/\(name)")
+                    if fileManager.isExecutableFile(atPath: nested) {
+                        return nested
+                    }
+                }
+            }
+        }
+        return nil
+    }
+
+    private func runCommandReadingStdout(executable: String, args: [String]) -> String? {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: executable)
+        task.arguments = args
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = Pipe()
+        do {
+            try task.run()
+            task.waitUntilExit()
+        } catch {
+            Logger.shared.log("\(executable) \(args.joined(separator: " ")) failed: \(error.localizedDescription)", level: .warning)
+            return nil
+        }
+        guard task.terminationStatus == 0 else { return nil }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)
     }
 
     // MARK: - Helpers

--- a/PureMac/en.lproj/Localizable.strings
+++ b/PureMac/en.lproj/Localizable.strings
@@ -116,3 +116,10 @@
 
 /* Notifications */
 "Found %@ of junk files." = "Found %@ of junk files.";
+
+/* Node Cache */
+"Node Cache" = "Node Cache";
+"npm, yarn, and pnpm download caches" = "npm, yarn, and pnpm download caches";
+"npm cache" = "npm cache";
+"yarn classic cache" = "yarn classic cache";
+"pnpm content-addressable store" = "pnpm content-addressable store";

--- a/PureMac/zh-Hans.lproj/Localizable.strings
+++ b/PureMac/zh-Hans.lproj/Localizable.strings
@@ -116,3 +116,10 @@
 
 /* Notifications */
 "Found %@ of junk files." = "发现了 %@ 的垃圾文件。";
+
+/* Node Cache */
+"Node Cache" = "Node 缓存";
+"npm, yarn, and pnpm download caches" = "npm、yarn 和 pnpm 下载缓存";
+"npm cache" = "npm 缓存";
+"yarn classic cache" = "yarn 经典缓存";
+"pnpm content-addressable store" = "pnpm 内容寻址存储";


### PR DESCRIPTION
## Summary

Closes #3.

Adds a new \`nodeCache\` \`CleaningCategory\` that scans the global caches of the three major Node package managers.

### What it scans

| Manager | Default path | Detection command |
|---|---|---|
| **npm** | \`~/.npm\` | \`npm config get cache\` |
| **yarn (classic)** | \`~/Library/Caches/Yarn\` | \`yarn cache dir\` |
| **pnpm** | \`~/Library/pnpm/store\` | \`pnpm store path\` |

For each manager:

1. Scan the conventional default path.
2. If the corresponding CLI is installed, ask it where the cache *actually* is and add that location too — so users with custom paths (e.g. \`npm config set cache /Volumes/External/npm-cache\`) still see their real cache size.

CLI detection looks in standard macOS locations (Homebrew, \`/usr/local/bin\`, \`~/.local/bin\`, \`~/.volta/bin\`, and per-version directories under \`~/.nvm/versions/node\`). If no CLI is on disk the default path is still scanned, so the category isn't useless for users without a global install.

### Deliberately *not* in scope

Yarn Berry / v2+ per-project \`.yarn/cache\` directories. Those live inside user repos, not the user's home cache, and shouldn't be touched by a system cleaner. A separate per-project cleanup is a different feature.

### Localization

Added entries for both \`en.lproj\` and \`zh-Hans.lproj\`:
- \"Node Cache\"
- \"npm, yarn, and pnpm download caches\"
- Per-manager display labels.

### Test plan

- [x] \`xcodebuild -project PureMac.xcodeproj -scheme PureMac -configuration Debug build\` — succeeds.
- [x] All existing \`CleaningCategory\` switches updated (Models, ScanEngine).
- [x] No new dependencies.

### AI-assisted disclosure

Drafted with Claude Code. I followed the same pattern as the existing brewCache scanner (default path + optional CLI override), verified the CLI cache-dir commands, and built the project locally to confirm. I understand what the code does.