### PR TITLE
Add pt-BR localization support

### DIFF
--- a/PureMac.xcodeproj/project.pbxproj
+++ b/PureMac.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		798B80977D14647A5691B0A0 /* AppFilesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFilesView.swift; sourceTree = "<group>"; };
 		9F04B811BB0012F6D2F07F91 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9F510F232341EE18F11DC934 /* MainWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindow.swift; sourceTree = "<group>"; };
+		A0A3F10C6C9B4DE5802D6DFA /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		A711CDF5285F68775D9B5513 /* ScanEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanEngine.swift; sourceTree = "<group>"; };
 		AC0FEE7141871ED5F9E36121 /* AppPathFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPathFinder.swift; sourceTree = "<group>"; };
 		B2EA41E1096FA8E3B916AD13 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -276,6 +277,7 @@
 			knownRegions = (
 				Base,
 				en,
+				"pt-BR",
 				"zh-Hans",
 				"zh-Hant",
 			);
@@ -345,6 +347,7 @@
 			isa = PBXVariantGroup;
 			children = (
 				9F04B811BB0012F6D2F07F91 /* en */,
+				A0A3F10C6C9B4DE5802D6DFA /* pt-BR */,
 				2641C6376DD6F5889F35510E /* zh-Hans */,
 				02E502E2B5C6AECC76E5CFEF /* zh-Hant */,
 			);

--- a/PureMac.xcodeproj/project.pbxproj
+++ b/PureMac.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		47C5ECD49C4DD75F271DB6CE /* StringNormalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3AC5F17D7CA94FAB1E8D7A /* StringNormalization.swift */; };
 		48D1431A7C99C19EEBDB056B /* CleaningEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A8DE5D45BA19E2670B57DC5 /* CleaningEngine.swift */; };
 		4F754D89F4CE5142BE384062 /* AppConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31F91226CDCFBB8E303B7DA /* AppConstants.swift */; };
+		59B3096E2AE8ED0397B16798 /* AppLanguagePreferencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491771F923C93FD61A263893 /* AppLanguagePreferencesTests.swift */; };
 		75B5F0401D37F2872B1AD85A /* AppListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E6BC61614B27C065BB18C9 /* AppListView.swift */; };
 		76B132F9C499225D33E0D075 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 424F7B28624C271620E13BBC /* EmptyStateView.swift */; };
 		826A750D2D7EC14C2AE306A3 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3667D46D8E2004EB4D73835A /* Models.swift */; };
@@ -31,12 +32,23 @@
 		D9445C2641A8637B65DA5ACE /* ScanEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A711CDF5285F68775D9B5513 /* ScanEngine.swift */; };
 		DDD6BA35DBF32E7A6B5F6F8B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B2EA41E1096FA8E3B916AD13 /* Assets.xcassets */; };
 		DDDA5879006CB97D5D7BDD87 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5785762276FB5E3209C6DE4D /* Logger.swift */; };
+		E2403D82F00D749C9AD4A6D4 /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 752603285F7DBBA12BB3AA91 /* AppStateTests.swift */; };
 		E60B0A2C5D0A6CAE35BF4DFB /* Locations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D3D9A9BC52839E6D0A22BC /* Locations.swift */; };
 		EDEF28CAD23E936FBED1783B /* PureMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63581B70F9B10231964E3602 /* PureMacApp.swift */; };
 		F1F506C146E17D6CEC4A12F3 /* AppInfoFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23486A54A82EE3865B784D1C /* AppInfoFetcher.swift */; };
 		F2FA881A4B2209CC2A6342FB /* CLI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B2C5F66B6D812572BD4F05 /* CLI.swift */; };
 		FDA30FE6349CA01C8D859F04 /* OrphanListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71E8F62DB76D85F41F9A2E9 /* OrphanListView.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		8D91DC174C821BE74C4B518C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 37BE87544E2EC9F6FF1CD280 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B19E38DEAA0144A77120F39C;
+			remoteInfo = PureMac;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		01B2C5F66B6D812572BD4F05 /* CLI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLI.swift; sourceTree = "<group>"; };
@@ -54,16 +66,20 @@
 		3D4FD34378988D430A582ED0 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		424F7B28624C271620E13BBC /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		46660271CFF167AB0FE7371D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		491771F923C93FD61A263893 /* AppLanguagePreferencesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLanguagePreferencesTests.swift; sourceTree = "<group>"; };
 		4AE790496C936424EF98320A /* OrphanSafetyPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrphanSafetyPolicy.swift; sourceTree = "<group>"; };
 		5664D2BDAEAA9AE3A53DB364 /* PureMac.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PureMac.entitlements; sourceTree = "<group>"; };
 		5785762276FB5E3209C6DE4D /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		5A5C80929EE4A430272674BC /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
+		607B9A8C7B34D6A7DCF4FFE2 /* PureMacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PureMacTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		60E6BC61614B27C065BB18C9 /* AppListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppListView.swift; sourceTree = "<group>"; };
 		63581B70F9B10231964E3602 /* PureMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PureMacApp.swift; sourceTree = "<group>"; };
+		752603285F7DBBA12BB3AA91 /* AppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
 		77D3D9A9BC52839E6D0A22BC /* Locations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locations.swift; sourceTree = "<group>"; };
 		798B80977D14647A5691B0A0 /* AppFilesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFilesView.swift; sourceTree = "<group>"; };
+		8D5E63D733D1A3BDEDF4DCA5 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		9F04B811BB0012F6D2F07F91 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9F510F232341EE18F11DC934 /* MainWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindow.swift; sourceTree = "<group>"; };
-		A0A3F10C6C9B4DE5802D6DFA /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		A711CDF5285F68775D9B5513 /* ScanEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanEngine.swift; sourceTree = "<group>"; };
 		AC0FEE7141871ED5F9E36121 /* AppPathFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPathFinder.swift; sourceTree = "<group>"; };
 		B2EA41E1096FA8E3B916AD13 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -81,8 +97,18 @@
 			isa = PBXGroup;
 			children = (
 				E383F69184F4552E5A41D010 /* PureMac */,
+				261FB8D961FEC76F15EA523A /* PureMacTests */,
 				4562CA9E5625FA4EEEFECB6D /* Products */,
 			);
+			sourceTree = "<group>";
+		};
+		261FB8D961FEC76F15EA523A /* PureMacTests */ = {
+			isa = PBXGroup;
+			children = (
+				491771F923C93FD61A263893 /* AppLanguagePreferencesTests.swift */,
+				752603285F7DBBA12BB3AA91 /* AppStateTests.swift */,
+			);
+			path = PureMacTests;
 			sourceTree = "<group>";
 		};
 		3CF46713F75B81F0F86D1C6F /* Models */ = {
@@ -98,6 +124,7 @@
 			isa = PBXGroup;
 			children = (
 				311078221878708524283765 /* PureMac.app */,
+				607B9A8C7B34D6A7DCF4FFE2 /* PureMacTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -256,6 +283,24 @@
 			productReference = 311078221878708524283765 /* PureMac.app */;
 			productType = "com.apple.product-type.application";
 		};
+		FBA8B0DE95746207A043B802 /* PureMacTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 25F40856927F2EE5BC50A0FB /* Build configuration list for PBXNativeTarget "PureMacTests" */;
+			buildPhases = (
+				A6847DD7D5552F4AA6B17BA8 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0E97FDF7F6FA15845FCE6737 /* PBXTargetDependency */,
+			);
+			name = PureMacTests;
+			packageProductDependencies = (
+			);
+			productName = PureMacTests;
+			productReference = 607B9A8C7B34D6A7DCF4FFE2 /* PureMacTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -269,6 +314,10 @@
 						DevelopmentTeam = H3WXHVTP97;
 						ProvisioningStyle = Automatic;
 					};
+					FBA8B0DE95746207A043B802 = {
+						DevelopmentTeam = H3WXHVTP97;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 2ABAFAE07AA42044AE58F688 /* Build configuration list for PBXProject "PureMac" */;
@@ -277,6 +326,7 @@
 			knownRegions = (
 				Base,
 				en,
+				ja,
 				"pt-BR",
 				"zh-Hans",
 				"zh-Hant",
@@ -289,6 +339,7 @@
 			projectRoot = "";
 			targets = (
 				B19E38DEAA0144A77120F39C /* PureMac */,
+				FBA8B0DE95746207A043B802 /* PureMacTests */,
 			);
 		};
 /* End PBXProject section */
@@ -340,14 +391,32 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A6847DD7D5552F4AA6B17BA8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				59B3096E2AE8ED0397B16798 /* AppLanguagePreferencesTests.swift in Sources */,
+				E2403D82F00D749C9AD4A6D4 /* AppStateTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		0E97FDF7F6FA15845FCE6737 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B19E38DEAA0144A77120F39C /* PureMac */;
+			targetProxy = 8D91DC174C821BE74C4B518C /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		241E0895B09C71AB423B2F9E /* Localizable.strings */ = {
 			isa = PBXVariantGroup;
 			children = (
 				9F04B811BB0012F6D2F07F91 /* en */,
-				A0A3F10C6C9B4DE5802D6DFA /* pt-BR */,
+				5A5C80929EE4A430272674BC /* ja */,
+				8D5E63D733D1A3BDEDF4DCA5 /* pt-BR */,
 				2641C6376DD6F5889F35510E /* zh-Hans */,
 				02E502E2B5C6AECC76E5CFEF /* zh-Hant */,
 			);
@@ -447,6 +516,36 @@
 			};
 			name = Debug;
 		};
+		6AC7FF3E26B642C05D435ADB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				SDKROOT = macosx;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PureMac.app/Contents/MacOS/PureMac";
+			};
+			name = Debug;
+		};
+		8632219D8F7DC9932C9DCC9F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				SDKROOT = macosx;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PureMac.app/Contents/MacOS/PureMac";
+			};
+			name = Release;
+		};
 		D1B9D379DD6CC0DA24E58BCF /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -532,6 +631,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		25F40856927F2EE5BC50A0FB /* Build configuration list for PBXNativeTarget "PureMacTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6AC7FF3E26B642C05D435ADB /* Debug */,
+				8632219D8F7DC9932C9DCC9F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		2754925F163D15C85EDF494D /* Build configuration list for PBXNativeTarget "PureMac" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/PureMac.xcodeproj/xcshareddata/xcschemes/PureMac.xcscheme
+++ b/PureMac.xcodeproj/xcshareddata/xcschemes/PureMac.xcscheme
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B19E38DEAA0144A77120F39C"
+               BuildableName = "PureMac.app"
+               BlueprintName = "PureMac"
+               ReferencedContainer = "container:PureMac.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FBA8B0DE95746207A043B802"
+               BuildableName = "PureMacTests.xctest"
+               BlueprintName = "PureMacTests"
+               ReferencedContainer = "container:PureMac.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B19E38DEAA0144A77120F39C"
+            BuildableName = "PureMac.app"
+            BlueprintName = "PureMac"
+            ReferencedContainer = "container:PureMac.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FBA8B0DE95746207A043B802"
+               BuildableName = "PureMacTests.xctest"
+               BlueprintName = "PureMacTests"
+               ReferencedContainer = "container:PureMac.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B19E38DEAA0144A77120F39C"
+            BuildableName = "PureMac.app"
+            BlueprintName = "PureMac"
+            ReferencedContainer = "container:PureMac.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B19E38DEAA0144A77120F39C"
+            BuildableName = "PureMac.app"
+            BlueprintName = "PureMac"
+            ReferencedContainer = "container:PureMac.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/PureMac/PureMacApp.swift
+++ b/PureMac/PureMacApp.swift
@@ -16,7 +16,8 @@ struct PureMacApp: App {
     @AppStorage("PureMac.OnboardingComplete") private var onboardingComplete = false
 
     init() {
-        if CommandLine.arguments.count > 1 {
+        let cliArguments = CommandLine.arguments.dropFirst().filter { !$0.hasPrefix("-psn_") }
+        if !cliArguments.isEmpty {
             CLI.run()
         }
     }

--- a/PureMac/PureMacApp.swift
+++ b/PureMac/PureMacApp.swift
@@ -16,6 +16,8 @@ struct PureMacApp: App {
     @AppStorage("PureMac.OnboardingComplete") private var onboardingComplete = false
 
     init() {
+        // XCTest injects launch arguments that should not trigger CLI mode.
+        guard ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil else { return }
         let cliArguments = CommandLine.arguments.dropFirst().filter { !$0.hasPrefix("-psn_") }
         if !cliArguments.isEmpty {
             CLI.run()

--- a/PureMac/ViewModels/AppState.swift
+++ b/PureMac/ViewModels/AppState.swift
@@ -304,6 +304,7 @@ final class AppState: ObservableObject {
     func startSmartScan() {
         guard !scanState.isActive else { return }
 
+        currentScanCategory = "Preparing..."
         scanState = .scanning(progress: 0, currentCategory: "Preparing...")
         categoryResults = [:]
         totalJunkSize = 0

--- a/PureMac/ViewModels/AppState.swift
+++ b/PureMac/ViewModels/AppState.swift
@@ -13,6 +13,11 @@ enum AppSection: Hashable {
 
 @MainActor
 final class AppState: ObservableObject {
+    typealias AppFileScanner = @MainActor (
+        _ app: InstalledApp,
+        _ locations: Locations,
+        _ completion: @escaping (Set<URL>) -> Void
+    ) -> Void
 
     // MARK: - Scan / Clean State
 
@@ -42,12 +47,15 @@ final class AppState: ObservableObject {
     @Published var isLoadingApps: Bool = false
     @Published var isScanningAppFiles: Bool = false
     @Published var removalError: String?
+    @Published var appFileScanLocationCount: Int = 0
 
     // MARK: - Services
 
     var scheduler = SchedulerService()
     private let scanEngine = ScanEngine()
     private let cleaningEngine = CleaningEngine()
+    private let locationsProvider: () -> Locations
+    private let appFileScanner: AppFileScanner
 
     // MARK: - Computed
 
@@ -67,16 +75,32 @@ final class AppState: ObservableObject {
         allResults.flatMap { $0.items }.filter { isItemSelected($0) }.reduce(0) { $0 + $1.size }
     }
 
+    var currentAppFileSearchLocationCount: Int {
+        if isScanningAppFiles && appFileScanLocationCount > 0 {
+            return appFileScanLocationCount
+        }
+        return discoveredFiles.count
+    }
+
     // MARK: - Init
 
-    init() {
-        loadDiskInfo()
-        checkFullDiskAccess()
-        loadInstalledApps()
-        scheduler.setTrigger { [weak self] in
-            await self?.runScheduledScan()
+    init(
+        performStartupTasks: Bool = true,
+        locationsProvider: @escaping () -> Locations = Locations.init,
+        appFileScanner: @escaping AppFileScanner = AppState.defaultAppFileScanner
+    ) {
+        self.locationsProvider = locationsProvider
+        self.appFileScanner = appFileScanner
+
+        if performStartupTasks {
+            loadDiskInfo()
+            checkFullDiskAccess()
+            loadInstalledApps()
+            scheduler.setTrigger { [weak self] in
+                await self?.runScheduledScan()
+            }
+            scheduler.start()
         }
-        scheduler.start()
     }
 
     // MARK: - App Loading
@@ -96,21 +120,15 @@ final class AppState: ObservableObject {
         discoveredFiles = []
         selectedFiles = []
         isScanningAppFiles = true
-        let locations = Locations()
-        let appInfo = AppPathFinder.AppInfo(
-            appName: app.appName,
-            bundleIdentifier: app.bundleIdentifier,
-            path: app.path,
-            entitlements: nil,
-            teamIdentifier: nil
-        )
-        let finder = AppPathFinder(appInfo: appInfo, locations: locations)
-        finder.findPathsAsync { [weak self] urls in
+        let locations = locationsProvider()
+        appFileScanLocationCount = locations.appSearch.paths.count
+        appFileScanner(app, locations) { [weak self] urls in
             guard let self else { return }
             let sorted = urls.sorted { $0.path < $1.path }
             self.discoveredFiles = sorted
             self.selectedFiles = urls
             self.isScanningAppFiles = false
+            self.appFileScanLocationCount = 0
         }
     }
 
@@ -475,5 +493,21 @@ final class AppState: ObservableObject {
         )
 
         UNUserNotificationCenter.current().add(request)
+    }
+
+    private static func defaultAppFileScanner(
+        app: InstalledApp,
+        locations: Locations,
+        completion: @escaping (Set<URL>) -> Void
+    ) {
+        let appInfo = AppPathFinder.AppInfo(
+            appName: app.appName,
+            bundleIdentifier: app.bundleIdentifier,
+            path: app.path,
+            entitlements: nil,
+            teamIdentifier: nil
+        )
+        let finder = AppPathFinder(appInfo: appInfo, locations: locations)
+        finder.findPathsAsync(completion: completion)
     }
 }

--- a/PureMac/Views/Apps/AppFilesView.swift
+++ b/PureMac/Views/Apps/AppFilesView.swift
@@ -30,7 +30,7 @@ struct AppFilesView: View {
 
                 if !appState.discoveredFiles.isEmpty {
                     VStack(alignment: .trailing, spacing: 2) {
-                        Text("\(appState.discoveredFiles.count) files")
+                        Text(fileCountText)
                             .font(.callout)
                             .foregroundStyle(.secondary)
                         Text(ByteCountFormatter.string(fromByteCount: totalSelectedSize, countStyle: .file))
@@ -47,7 +47,7 @@ struct AppFilesView: View {
                 VStack(spacing: 12) {
                     Spacer()
                     ProgressView("Scanning for related files...")
-                    Text("Checking \(appState.discoveredFiles.count) locations...")
+                    Text(checkingLocationsText)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                     Spacer()
@@ -81,7 +81,7 @@ struct AppFilesView: View {
                     Spacer()
 
                     if !appState.selectedFiles.isEmpty {
-                        Button("Remove \(appState.selectedFiles.count) files (\(ByteCountFormatter.string(fromByteCount: totalSelectedSize, countStyle: .file)))", role: .destructive) {
+                        Button(uninstallSelectedTitle, role: .destructive) {
                             appState.removeSelectedFiles()
                         }
                         .buttonStyle(.borderedProminent)
@@ -105,6 +105,22 @@ struct AppFilesView: View {
         } message: {
             Text(appState.removalError ?? "")
         }
+    }
+
+    private var fileCountText: String {
+        String(format: String(localized: "%lld files"), Int64(appState.discoveredFiles.count))
+    }
+
+    private var checkingLocationsText: String {
+        String(format: String(localized: "Checking %lld locations..."), Int64(appState.discoveredFiles.count))
+    }
+
+    private var uninstallSelectedTitle: String {
+        String(
+            format: String(localized: "Uninstall %lld files (%@)"),
+            Int64(appState.selectedFiles.count),
+            ByteCountFormatter.string(fromByteCount: totalSelectedSize, countStyle: .file)
+        )
     }
 
     private func fileSelectionBinding(for url: URL) -> Binding<Bool> {

--- a/PureMac/Views/Apps/AppFilesView.swift
+++ b/PureMac/Views/Apps/AppFilesView.swift
@@ -112,7 +112,7 @@ struct AppFilesView: View {
     }
 
     private var checkingLocationsText: String {
-        String(format: String(localized: "Checking %lld locations..."), Int64(appState.discoveredFiles.count))
+        String(format: String(localized: "Checking %lld locations..."), Int64(appState.currentAppFileSearchLocationCount))
     }
 
     private var uninstallSelectedTitle: String {

--- a/PureMac/Views/Apps/AppListView.swift
+++ b/PureMac/Views/Apps/AppListView.swift
@@ -25,7 +25,7 @@ struct AppListView: View {
                 .frame(minWidth: 300)
         }
         .searchable(text: $searchText, prompt: "Search apps")
-        .navigationTitle("Installed Apps (\(appState.installedApps.count))")
+        .navigationTitle(appListTitle)
         .toolbar {
             ToolbarItemGroup {
                 Button {
@@ -35,7 +35,7 @@ struct AppListView: View {
                 }
 
                 if !appState.selectedFiles.isEmpty {
-                    Button("Uninstall (\(appState.selectedFiles.count) files)", role: .destructive) {
+                    Button(uninstallButtonTitle, role: .destructive) {
                         appState.removeSelectedFiles()
                     }
                     .buttonStyle(.borderedProminent)
@@ -43,6 +43,14 @@ struct AppListView: View {
                 }
             }
         }
+    }
+
+    private var appListTitle: String {
+        String(format: String(localized: "Installed Apps (%lld)"), Int64(appState.installedApps.count))
+    }
+
+    private var uninstallButtonTitle: String {
+        String(format: String(localized: "Uninstall (%lld files)"), Int64(appState.selectedFiles.count))
     }
 
     // MARK: - App Table (left side)
@@ -63,7 +71,7 @@ struct AppListView: View {
                     actionLabel: "Retry"
                 )
             } else {
-                Table(filteredApps, selection: $selection) {
+                Table(filteredApps, selection: selectionBinding) {
                     TableColumn("Application") { app in
                         HStack(spacing: 8) {
                             Image(nsImage: app.icon)
@@ -81,15 +89,22 @@ struct AppListView: View {
                     }
                     .width(ideal: 70)
                 }
-                .onChange(of: selection) { newValue in
-                    if let id = newValue,
-                       let app = appState.installedApps.first(where: { $0.id == id }) {
-                        appState.selectedApp = app
-                        appState.scanForAppFiles(app)
-                    }
-                }
             }
         }
+    }
+
+    private var selectionBinding: Binding<InstalledApp.ID?> {
+        Binding(
+            get: { selection },
+            set: { newValue in
+                selection = newValue
+                if let id = newValue,
+                   let app = appState.installedApps.first(where: { $0.id == id }) {
+                    appState.selectedApp = app
+                    appState.scanForAppFiles(app)
+                }
+            }
+        )
     }
 
     // MARK: - File Detail (right side)

--- a/PureMac/Views/CategoryDetailView.swift
+++ b/PureMac/Views/CategoryDetailView.swift
@@ -25,7 +25,7 @@ struct CategoryDetailView: View {
             }
         }
         .searchable(text: $searchText, prompt: "Filter files")
-        .navigationTitle(category.rawValue)
+        .navigationTitle(Text(LocalizedStringKey(category.rawValue)))
         .toolbar {
             ToolbarItem(placement: .automatic) {
                 Button {
@@ -45,12 +45,13 @@ struct CategoryDetailView: View {
                         appState.deselectAllInCategory(category)
                     }
                     Button(action: { sortDescending.toggle() }) {
-                        Label(
-                            sortDescending ? "Largest First" : "Smallest First",
-                            systemImage: "arrow.up.arrow.down"
-                        )
+                        Label {
+                            Text(LocalizedStringKey(sortDescending ? "Largest First" : "Smallest First"))
+                        } icon: {
+                            Image(systemName: "arrow.up.arrow.down")
+                        }
                     }
-                    .help(sortDescending ? "Sorted: Largest First" : "Sorted: Smallest First")
+                    .help(NSLocalizedString(sortDescending ? "Sorted: Largest First" : "Sorted: Smallest First", comment: ""))
                 }
             }
 
@@ -62,16 +63,17 @@ struct CategoryDetailView: View {
                         Button {
                             showConfirmation = true
                         } label: {
-                            Label(
-                                "Clean \(selectedCount) items",
-                                systemImage: "trash"
-                            )
+                            Label {
+                                Text(String(format: String(localized: "Clean %lld items"), Int64(selectedCount)))
+                            } icon: {
+                                Image(systemName: "trash")
+                            }
                         }
                     }
                 }
             }
         }
-        .confirmationDialog("Clean \(ByteCountFormatter.string(fromByteCount: appState.selectedSizeInCategory(category), countStyle: .file))?", isPresented: $showConfirmation, titleVisibility: .visible) {
+        .confirmationDialog(cleanConfirmationTitle, isPresented: $showConfirmation, titleVisibility: .visible) {
             Button("Clean", role: .destructive) {
                 appState.cleanCategory(category)
             }
@@ -79,6 +81,13 @@ struct CategoryDetailView: View {
         } message: {
             Text("This will permanently delete the selected files. This cannot be undone.")
         }
+    }
+
+    private var cleanConfirmationTitle: String {
+        String(
+            format: String(localized: "Clean %@?"),
+            ByteCountFormatter.string(fromByteCount: appState.selectedSizeInCategory(category), countStyle: .file)
+        )
     }
 
     // MARK: - File List
@@ -95,7 +104,13 @@ struct CategoryDetailView: View {
             } header: {
                 let selectedCount = appState.selectedCountInCategory(category)
                 let totalCount = result.itemCount
-                Text("\(selectedCount) of \(totalCount) selected")
+                Text(
+                    String(
+                        format: String(localized: "%lld of %lld selected"),
+                        Int64(selectedCount),
+                        Int64(totalCount)
+                    )
+                )
             }
         }
     }

--- a/PureMac/Views/Components/EmptyStateView.swift
+++ b/PureMac/Views/Components/EmptyStateView.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 
 struct EmptyStateView: View {
-    let title: String
+    let title: LocalizedStringKey
     let systemImage: String
-    let description: String
+    let description: LocalizedStringKey
     var action: (() -> Void)?
-    var actionLabel: String?
+    var actionLabel: LocalizedStringKey?
 
-    init(_ title: String, systemImage: String, description: String, action: (() -> Void)? = nil, actionLabel: String? = nil) {
+    init(_ title: LocalizedStringKey, systemImage: String, description: LocalizedStringKey, action: (() -> Void)? = nil, actionLabel: LocalizedStringKey? = nil) {
         self.title = title
         self.systemImage = systemImage
         self.description = description

--- a/PureMac/Views/MainWindow.swift
+++ b/PureMac/Views/MainWindow.swift
@@ -37,10 +37,14 @@ struct MainWindow: View {
             let grouped = Dictionary(grouping: allSidebarItems, by: \.group)
             let order = ["Applications", "Cleaning"]
             ForEach(order, id: \.self) { group in
-                Section(group) {
+                Section {
                     ForEach(grouped[group] ?? [], id: \.section) { item in
                         HStack {
-                            Label(item.label, systemImage: item.icon)
+                            Label {
+                                Text(LocalizedStringKey(item.label))
+                            } icon: {
+                                Image(systemName: item.icon)
+                            }
                             Spacer()
                             if let badge = item.badge {
                                 Text(badge)
@@ -50,6 +54,8 @@ struct MainWindow: View {
                         }
                         .tag(item.section)
                     }
+                } header: {
+                    Text(LocalizedStringKey(group))
                 }
             }
         }

--- a/PureMac/Views/OnboardingView.swift
+++ b/PureMac/Views/OnboardingView.swift
@@ -137,7 +137,7 @@ struct OnboardingView: View {
         ))
     }
 
-    private func featureCard(icon: String, title: String, desc: String, delay: Double) -> some View {
+    private func featureCard(icon: String, title: LocalizedStringKey, desc: LocalizedStringKey, delay: Double) -> some View {
         VStack(spacing: 8) {
             Image(systemName: icon)
                 .font(.title2)

--- a/PureMac/Views/Orphans/OrphanListView.swift
+++ b/PureMac/Views/Orphans/OrphanListView.swift
@@ -53,7 +53,7 @@ struct OrphanListView: View {
                 }
             }
         }
-        .navigationTitle("Orphaned Files (\(appState.orphanedFiles.count))")
+        .navigationTitle(orphanListTitle)
         .toolbar {
             ToolbarItemGroup {
                 if !appState.orphanedFiles.isEmpty {
@@ -71,7 +71,7 @@ struct OrphanListView: View {
                 }
 
                 if !selectedOrphans.isEmpty {
-                    Button("Remove Selected (\(selectedOrphans.count))", role: .destructive) {
+                    Button(removeSelectedTitle, role: .destructive) {
                         Task {
                             await removeSelectedOrphans()
                         }
@@ -90,6 +90,14 @@ struct OrphanListView: View {
         } message: {
             Text(removalErrorMessage ?? "")
         }
+    }
+
+    private var orphanListTitle: String {
+        String(format: String(localized: "Orphaned Files (%lld)"), Int64(appState.orphanedFiles.count))
+    }
+
+    private var removeSelectedTitle: String {
+        String(format: String(localized: "Remove Selected (%lld)"), Int64(selectedOrphans.count))
     }
 
     private func orphanBinding(for url: URL) -> Binding<Bool> {

--- a/PureMac/Views/Settings/SettingsView.swift
+++ b/PureMac/Views/Settings/SettingsView.swift
@@ -75,6 +75,16 @@ enum AppLanguage: String, CaseIterable, Identifiable {
     }
 }
 
+enum AppLanguagePreferences {
+    static func apply(_ language: AppLanguage, defaults: UserDefaults = .standard) {
+        if language == .system {
+            defaults.removeObject(forKey: "AppleLanguages")
+        } else {
+            defaults.set([language.rawValue], forKey: "AppleLanguages")
+        }
+    }
+}
+
 struct GeneralSettingsView: View {
     @AppStorage("settings.general.launchAtLogin") private var launchAtLogin = false
     @AppStorage("settings.general.searchSensitivity") private var sensitivity: SearchSensitivity = .enhanced
@@ -163,13 +173,7 @@ struct GeneralSettingsView: View {
     }
 
     private func applyLanguage(_ language: AppLanguage) {
-        if language == .system {
-            UserDefaults.standard.removeObject(forKey: "AppleLanguages")
-        } else {
-            UserDefaults.standard.set([language.rawValue], forKey: "AppleLanguages")
-        }
-        UserDefaults.standard.removeObject(forKey: "AppleLocale")
-        UserDefaults.standard.synchronize()
+        AppLanguagePreferences.apply(language)
         languageNeedsRelaunch = true
     }
 

--- a/PureMac/Views/Settings/SettingsView.swift
+++ b/PureMac/Views/Settings/SettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import ServiceManagement
 
@@ -13,7 +14,7 @@ struct SettingsView: View {
             AboutSettingsView()
                 .tabItem { Label("About", systemImage: "info.circle") }
         }
-        .frame(width: 480, height: 360)
+        .frame(width: 480, height: 430)
     }
 }
 
@@ -35,26 +36,64 @@ enum SearchSensitivity: String, CaseIterable, Identifiable, Codable {
     }
 }
 
+enum AppLanguage: String, CaseIterable, Identifiable {
+    case system = "system"
+    case english = "en"
+    case portugueseBrazil = "pt-BR"
+    case simplifiedChinese = "zh-Hans"
+    case traditionalChinese = "zh-Hant"
+
+    static let preferenceKey = "settings.general.appLanguage"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .system: return "System Default"
+        case .english: return "English"
+        case .portugueseBrazil: return "Portuguese (Brazil)"
+        case .simplifiedChinese: return "Chinese (Simplified)"
+        case .traditionalChinese: return "Chinese (Traditional)"
+        }
+    }
+
+    static var current: AppLanguage {
+        if let selectedLanguage = UserDefaults.standard.string(forKey: preferenceKey),
+           let language = AppLanguage(rawValue: selectedLanguage) {
+            return language
+        }
+
+        guard let bundleIdentifier = Bundle.main.bundleIdentifier,
+              let appDefaults = UserDefaults.standard.persistentDomain(forName: bundleIdentifier),
+              let preferredLanguages = appDefaults["AppleLanguages"] as? [String],
+              let preferredLanguage = preferredLanguages.first else {
+            return .system
+        }
+
+        let normalized = preferredLanguage.replacingOccurrences(of: "_", with: "-")
+        return allCases.first { $0.rawValue == normalized } ?? .system
+    }
+}
+
 struct GeneralSettingsView: View {
     @AppStorage("settings.general.launchAtLogin") private var launchAtLogin = false
     @AppStorage("settings.general.searchSensitivity") private var sensitivity: SearchSensitivity = .enhanced
     @AppStorage("settings.general.confirmBeforeDelete") private var confirmBeforeDelete = true
+    @AppStorage(AppLanguage.preferenceKey) private var appLanguageRaw = AppLanguage.current.rawValue
+    @State private var languageNeedsRelaunch = false
 
     var body: some View {
         Form {
             Section("Startup") {
-                Toggle("Launch PureMac at login", isOn: $launchAtLogin)
-                    .onChange(of: launchAtLogin) { newValue in
-                        toggleLaunchAtLogin(newValue)
-                    }
+                Toggle("Launch PureMac at login", isOn: launchAtLoginBinding)
             }
 
             Section("App Scanning") {
                 Picker("Search sensitivity", selection: $sensitivity) {
                     ForEach(SearchSensitivity.allCases) { level in
                         VStack(alignment: .leading) {
-                            Text(level.rawValue)
-                            Text(level.description)
+                            Text(LocalizedStringKey(level.rawValue))
+                            Text(LocalizedStringKey(level.description))
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
@@ -64,11 +103,49 @@ struct GeneralSettingsView: View {
                 .pickerStyle(.radioGroup)
             }
 
+            Section("Language") {
+                Picker("Language", selection: appLanguageBinding) {
+                    ForEach(AppLanguage.allCases) { language in
+                        Text(LocalizedStringKey(language.displayName)).tag(language)
+                    }
+                }
+
+                if languageNeedsRelaunch {
+                    Text("Restart PureMac to apply the selected language.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Button("Relaunch Now") {
+                        relaunchApp()
+                    }
+                }
+            }
+
             Section("Safety") {
                 Toggle("Confirm before deleting files", isOn: $confirmBeforeDelete)
             }
         }
         .formStyle(.grouped)
+    }
+
+    private var launchAtLoginBinding: Binding<Bool> {
+        Binding(
+            get: { launchAtLogin },
+            set: { newValue in
+                launchAtLogin = newValue
+                toggleLaunchAtLogin(newValue)
+            }
+        )
+    }
+
+    private var appLanguageBinding: Binding<AppLanguage> {
+        Binding(
+            get: { AppLanguage(rawValue: appLanguageRaw) ?? .system },
+            set: { newValue in
+                appLanguageRaw = newValue.rawValue
+                applyLanguage(newValue)
+            }
+        )
     }
 
     private func toggleLaunchAtLogin(_ enabled: Bool) {
@@ -82,6 +159,35 @@ struct GeneralSettingsView: View {
             Logger.shared.log("Failed to \(enabled ? "enable" : "disable") launch at login: \(error.localizedDescription)", level: .error)
             // Revert the toggle if operation failed
             launchAtLogin = !enabled
+        }
+    }
+
+    private func applyLanguage(_ language: AppLanguage) {
+        if language == .system {
+            UserDefaults.standard.removeObject(forKey: "AppleLanguages")
+        } else {
+            UserDefaults.standard.set([language.rawValue], forKey: "AppleLanguages")
+        }
+        UserDefaults.standard.removeObject(forKey: "AppleLocale")
+        UserDefaults.standard.synchronize()
+        languageNeedsRelaunch = true
+    }
+
+    private func relaunchApp() {
+        guard Bundle.main.bundleURL.pathExtension == "app" else {
+            NSApp.terminate(nil)
+            return
+        }
+
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        task.arguments = ["-n", Bundle.main.bundleURL.path]
+
+        do {
+            try task.run()
+            NSApp.terminate(nil)
+        } catch {
+            Logger.shared.log("Failed to relaunch PureMac: \(error.localizedDescription)", level: .error)
         }
     }
 }
@@ -100,11 +206,19 @@ struct CleaningSettingsView: View {
             }
 
             Section("Large Files") {
-                Stepper("Minimum size: \(largeFileThresholdMB) MB", value: $largeFileThresholdMB, in: 10...1000, step: 10)
-                Stepper("Files older than: \(oldFileMonths) months", value: $oldFileMonths, in: 1...60)
+                Stepper(minimumSizeTitle, value: $largeFileThresholdMB, in: 10...1000, step: 10)
+                Stepper(oldFilesTitle, value: $oldFileMonths, in: 1...60)
             }
         }
         .formStyle(.grouped)
+    }
+
+    private var minimumSizeTitle: String {
+        String(format: String(localized: "Minimum size: %lld MB"), Int64(largeFileThresholdMB))
+    }
+
+    private var oldFilesTitle: String {
+        String(format: String(localized: "Files older than: %lld months"), Int64(oldFileMonths))
     }
 }
 
@@ -121,7 +235,7 @@ struct ScheduleSettingsView: View {
                 if appState.scheduler.config.isEnabled {
                     Picker("Scan interval", selection: $appState.scheduler.config.interval) {
                         ForEach(ScheduleInterval.allCases) { interval in
-                            Text(interval.rawValue).tag(interval)
+                            Text(LocalizedStringKey(interval.rawValue)).tag(interval)
                         }
                     }
 
@@ -157,7 +271,7 @@ struct AboutSettingsView: View {
                     VStack(alignment: .leading, spacing: 4) {
                         Text("PureMac")
                             .font(.title2.bold())
-                        Text("Version \(Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0")")
+                        Text(versionText)
                             .foregroundStyle(.secondary)
                         Text("Free, open-source macOS app manager.")
                             .foregroundStyle(.secondary)
@@ -177,5 +291,12 @@ struct AboutSettingsView: View {
             }
         }
         .formStyle(.grouped)
+    }
+
+    private var versionText: String {
+        String(
+            format: String(localized: "Version %@"),
+            Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0"
+        )
     }
 }

--- a/PureMac/Views/SmartScanView.swift
+++ b/PureMac/Views/SmartScanView.swift
@@ -86,7 +86,7 @@ struct SmartScanView: View {
                 .font(.title2)
 
             ProgressView(value: appState.scanProgress) {
-                Text(appState.currentScanCategory)
+                Text(LocalizedStringKey(appState.currentScanCategory))
                     .foregroundStyle(.secondary)
             } currentValueLabel: {
                 Text("\(Int(appState.scanProgress * 100))%")
@@ -140,7 +140,7 @@ struct SmartScanView: View {
 
                 HStack(spacing: 12) {
                     if appState.totalSelectedSize > 0 {
-                        Button("Clean Selected (\(ByteCountFormatter.string(fromByteCount: appState.totalSelectedSize, countStyle: .file)))") {
+                        Button(cleanSelectedTitle) {
                             showConfirmation = true
                         }
                         .buttonStyle(.borderedProminent)
@@ -152,7 +152,7 @@ struct SmartScanView: View {
                     }
                     .controlSize(.large)
                 }
-                .confirmationDialog("Clean \(ByteCountFormatter.string(fromByteCount: appState.totalSelectedSize, countStyle: .file))?", isPresented: $showConfirmation, titleVisibility: .visible) {
+                .confirmationDialog(cleanConfirmationTitle, isPresented: $showConfirmation, titleVisibility: .visible) {
                     Button("Clean", role: .destructive) {
                         appState.cleanAll()
                     }
@@ -214,6 +214,20 @@ struct SmartScanView: View {
             .controlSize(.large)
         }
     }
+
+    private var cleanSelectedTitle: String {
+        String(
+            format: String(localized: "Clean Selected (%@)"),
+            ByteCountFormatter.string(fromByteCount: appState.totalSelectedSize, countStyle: .file)
+        )
+    }
+
+    private var cleanConfirmationTitle: String {
+        String(
+            format: String(localized: "Clean %@?"),
+            ByteCountFormatter.string(fromByteCount: appState.totalSelectedSize, countStyle: .file)
+        )
+    }
 }
 
 // MARK: - Category Toggle Row
@@ -242,7 +256,7 @@ private struct CategoryToggleRow: View {
                     .frame(width: 20)
                 Text(LocalizedStringKey(result.category.rawValue))
                 Spacer()
-                Text("\(result.itemCount) items")
+                Text(String(format: String(localized: "%lld items"), Int64(result.itemCount)))
                     .foregroundStyle(.secondary)
                 Text(result.formattedSize)
                     .fontWeight(.medium)

--- a/PureMac/en.lproj/Localizable.strings
+++ b/PureMac/en.lproj/Localizable.strings
@@ -1,7 +1,27 @@
-/* Full Disk Access Banner */
+/* Navigation */
+"Applications" = "Applications";
+"Cleaning" = "Cleaning";
+"Installed Apps" = "Installed Apps";
+"Installed Apps (%lld)" = "Installed Apps (%lld)";
+"Orphaned Files" = "Orphaned Files";
+"Orphaned Files (%lld)" = "Orphaned Files (%lld)";
+"Select a category from the sidebar to get started." = "Select a category from the sidebar to get started.";
+
+/* Full Disk Access */
 "Full Disk Access Required" = "Full Disk Access Required";
+"Full Disk Access" = "Full Disk Access";
 "PureMac needs Full Disk Access to scan Trash, Mail, Desktop, Documents, and Homebrew cache." = "PureMac needs Full Disk Access to scan Trash, Mail, Desktop, Documents, and Homebrew cache.";
+"PureMac needs Full Disk Access to scan all caches, Trash, and app data." = "PureMac needs Full Disk Access to scan all caches, Trash, and app data.";
+"Full Disk Access is granted. You're all set!" = "Full Disk Access is granted. You're all set!";
 "Open Settings" = "Open Settings";
+"Open System Settings" = "Open System Settings";
+"Open System Settings > Privacy & Security" = "Open System Settings > Privacy & Security";
+"Select Full Disk Access" = "Select Full Disk Access";
+"Enable PureMac" = "Enable PureMac";
+"Full Disk Access: %@" = "Full Disk Access: %@";
+"Granted" = "Granted";
+"Not Granted" = "Not Granted";
+"Some features may be limited without Full Disk Access." = "Some features may be limited without Full Disk Access.";
 
 /* Top Bar */
 "Macintosh HD" = "Macintosh HD";
@@ -15,41 +35,141 @@
 /* Smart Scan */
 "Smart Scan" = "Smart Scan";
 "Click Scan to start" = "Click Scan to start";
+"Ready to Scan" = "Ready to Scan";
+"Disk Usage" = "Disk Usage";
+"Start Scan" = "Start Scan";
+"Preparing..." = "Preparing...";
+"Results Found" = "Results Found";
 "Total" = "Total";
 "Used" = "Used";
 "Free" = "Free";
 "Purgeable" = "Purgeable";
 "junk found" = "junk found";
 "Your Mac is clean!" = "Your Mac is clean!";
+"Your Mac is clean" = "Your Mac is clean";
 "freed up" = "freed up";
+"freed" = "freed";
 "Cleaning..." = "Cleaning...";
 "Scanning..." = "Scanning...";
 "%lld/%lld items" = "%lld/%lld items";
+"%lld items" = "%lld items";
+"%lld files" = "%lld files";
+"Clean Selected (%@)" = "Clean Selected (%@)";
+"Clean %@?" = "Clean %@?";
+"This will permanently delete the selected files. This cannot be undone." = "This will permanently delete the selected files. This cannot be undone.";
 
 /* Category Detail */
 "All Clean!" = "All Clean!";
+"All Clean" = "All Clean";
 "No junk files found in this category." = "No junk files found in this category.";
 "Not scanned yet" = "Not scanned yet";
+"Not Scanned" = "Not Scanned";
 "Click Scan to analyze this category" = "Click Scan to analyze this category";
+"Run a scan to analyze this category." = "Run a scan to analyze this category.";
+"Scan Now" = "Scan Now";
+"Filter files" = "Filter files";
 "%lld of %lld selected" = "%lld of %lld selected";
 "Select All" = "Select All";
 "Deselect All" = "Deselect All";
-"%lld items" = "%lld items";
+"Largest First" = "Largest First";
+"Smallest First" = "Smallest First";
+"Sorted: Largest First" = "Sorted: Largest First";
+"Sorted: Smallest First" = "Sorted: Smallest First";
+"Clean %lld items" = "Clean %lld items";
+"Reveal in Finder" = "Reveal in Finder";
 
 /* Buttons */
 "Scan" = "Scan";
 "Re-scan" = "Re-scan";
 "Scan Again" = "Scan Again";
 "Done" = "Done";
+"Clean" = "Clean";
+"Cancel" = "Cancel";
 "Clean (%@)" = "Clean (%@)";
 "Clean %lld items (%@)" = "Clean %lld items (%@)";
+
+/* App Uninstaller */
+"Search apps" = "Search apps";
+"Refresh" = "Refresh";
+"Uninstall (%lld files)" = "Uninstall (%lld files)";
+"Loading installed apps..." = "Loading installed apps...";
+"No Apps Found" = "No Apps Found";
+"Could not find any installed applications." = "Could not find any installed applications.";
+"Retry" = "Retry";
+"Application" = "Application";
+"Size" = "Size";
+"Select an App" = "Select an App";
+"Select an app from the list to see all its related files across your system." = "Select an app from the list to see all its related files across your system.";
+"Scanning for related files..." = "Scanning for related files...";
+"Checking %lld locations..." = "Checking %lld locations...";
+"No Related Files" = "No Related Files";
+"No additional files found for %@." = "No additional files found for %@.";
+"Uninstall %lld files (%@)" = "Uninstall %lld files (%@)";
+
+/* Orphaned Files */
+"Scanning for orphaned files..." = "Scanning for orphaned files...";
+"No Orphaned Files" = "No Orphaned Files";
+"No leftover files from uninstalled apps were found." = "No leftover files from uninstalled apps were found.";
+"Scan for Orphans" = "Scan for Orphans";
+"Remove Selected (%lld)" = "Remove Selected (%lld)";
+
+/* Onboarding */
+"Back" = "Back";
+"Next" = "Next";
+"Get Started" = "Get Started";
+"Welcome to PureMac" = "Welcome to PureMac";
+"Free, open-source macOS app manager and system cleaner." = "Free, open-source macOS app manager and system cleaner.";
+"App Uninstaller" = "App Uninstaller";
+"Find junk files across your system" = "Find junk files across your system";
+"Remove apps and all their files" = "Remove apps and all their files";
+"Orphan Finder" = "Orphan Finder";
+"Find leftovers from deleted apps" = "Find leftovers from deleted apps";
+"You're Ready" = "You're Ready";
+
+/* Settings - General */
+"General" = "General";
+"Startup" = "Startup";
+"Launch PureMac at login" = "Launch PureMac at login";
+"App Scanning" = "App Scanning";
+"Search sensitivity" = "Search sensitivity";
+"Language" = "Language";
+"System Default" = "System Default";
+"English" = "English";
+"Portuguese (Brazil)" = "Portuguese (Brazil)";
+"Chinese (Simplified)" = "Chinese (Simplified)";
+"Chinese (Traditional)" = "Chinese (Traditional)";
+"Restart PureMac to apply the selected language." = "Restart PureMac to apply the selected language.";
+"Relaunch Now" = "Relaunch Now";
+"Strict" = "Strict";
+"Enhanced" = "Enhanced";
+"Deep" = "Deep";
+"Exact bundle ID and name matches only. Safest option." = "Exact bundle ID and name matches only. Safest option.";
+"Includes partial name matching and bundle ID components." = "Includes partial name matching and bundle ID components.";
+"Includes company name, entitlements, and team identifier matching." = "Includes company name, entitlements, and team identifier matching.";
+"App Behavior" = "App Behavior";
+"Launch at login" = "Launch at login";
+"Show in Dock" = "Show in Dock";
+"Show menu bar icon" = "Show menu bar icon";
+"Safety" = "Safety";
+"Confirm before deleting files" = "Confirm before deleting files";
+"PureMac will never delete system-critical files. Only caches, logs, temporary files, and user-selected items are removed." = "PureMac will never delete system-critical files. Only caches, logs, temporary files, and user-selected items are removed.";
+
+/* Settings - Cleaning */
+"File Discovery" = "File Discovery";
+"Skip hidden files during scan" = "Skip hidden files during scan";
+"Large Files" = "Large Files";
+"Minimum size: %lld MB" = "Minimum size: %lld MB";
+"Files older than: %lld months" = "Files older than: %lld months";
 
 /* Settings - Schedule */
 "Schedule" = "Schedule";
 "Automatic Cleaning" = "Automatic Cleaning";
+"Automatic Scanning" = "Automatic Scanning";
 "Automatically scan and clean your Mac on a schedule" = "Automatically scan and clean your Mac on a schedule";
 "Scan Interval" = "Scan Interval";
+"Scan interval" = "Scan interval";
 "Automation" = "Automation";
+"Enable scheduled scanning" = "Enable scheduled scanning";
 "Auto-clean after scan" = "Auto-clean after scan";
 "Minimum junk size to trigger clean:" = "Minimum junk size to trigger clean:";
 "50 MB" = "50 MB";
@@ -59,26 +179,21 @@
 "1 GB" = "1 GB";
 "Auto-purge purgeable space" = "Auto-purge purgeable space";
 "Show notification on completion" = "Show notification on completion";
+"Notify on completion" = "Notify on completion";
 "Status" = "Status";
 "Last run" = "Last run";
 "Next run" = "Next run";
 "Never" = "Never";
 "Not scheduled" = "Not scheduled";
 
-/* Settings - General */
-"General" = "General";
-"App Behavior" = "App Behavior";
-"Launch at login" = "Launch at login";
-"Show in Dock" = "Show in Dock";
-"Show menu bar icon" = "Show menu bar icon";
-"Safety" = "Safety";
-"PureMac will never delete system-critical files. Only caches, logs, temporary files, and user-selected items are removed." = "PureMac will never delete system-critical files. Only caches, logs, temporary files, and user-selected items are removed.";
-
 /* Settings - About */
 "About" = "About";
 "Version 1.0.0" = "Version 1.0.0";
+"Version %@" = "Version %@";
 "A free, open-source Mac cleaning utility.\nKeep your Mac fast, clean, and optimized." = "A free, open-source Mac cleaning utility.\nKeep your Mac fast, clean, and optimized.";
+"Free, open-source macOS app manager." = "Free, open-source macOS app manager.";
 "GitHub Repository" = "GitHub Repository";
+"Report an Issue" = "Report an Issue";
 "MIT License" = "MIT License";
 
 /* Cleaning Categories */

--- a/PureMac/pt-BR.lproj/Localizable.strings
+++ b/PureMac/pt-BR.lproj/Localizable.strings
@@ -1,0 +1,233 @@
+/* Navigation */
+"Applications" = "Aplicativos";
+"Cleaning" = "Limpeza";
+"Installed Apps" = "Apps instalados";
+"Installed Apps (%lld)" = "Apps instalados (%lld)";
+"Orphaned Files" = "Arquivos órfãos";
+"Orphaned Files (%lld)" = "Arquivos órfãos (%lld)";
+"Select a category from the sidebar to get started." = "Selecione uma categoria na barra lateral para começar.";
+
+/* Full Disk Access */
+"Full Disk Access Required" = "Acesso Total ao Disco necessário";
+"Full Disk Access" = "Acesso Total ao Disco";
+"PureMac needs Full Disk Access to scan Trash, Mail, Desktop, Documents, and Homebrew cache." = "O PureMac precisa de Acesso Total ao Disco para escanear o Lixo, Mail, Mesa, Documentos e o cache do Homebrew.";
+"PureMac needs Full Disk Access to scan all caches, Trash, and app data." = "O PureMac precisa de Acesso Total ao Disco para escanear todos os caches, o Lixo e os dados dos apps.";
+"Full Disk Access is granted. You're all set!" = "O Acesso Total ao Disco foi concedido. Tudo pronto!";
+"Open Settings" = "Abrir Ajustes";
+"Open System Settings" = "Abrir Ajustes do Sistema";
+"Open System Settings > Privacy & Security" = "Abra Ajustes do Sistema > Privacidade e Segurança";
+"Select Full Disk Access" = "Selecione Acesso Total ao Disco";
+"Enable PureMac" = "Ative o PureMac";
+"Full Disk Access: %@" = "Acesso Total ao Disco: %@";
+"Granted" = "Concedido";
+"Not Granted" = "Não concedido";
+"Some features may be limited without Full Disk Access." = "Alguns recursos podem ficar limitados sem Acesso Total ao Disco.";
+
+/* Top Bar */
+"Macintosh HD" = "Macintosh HD";
+"%@ free" = "%@ livres";
+"Auto-clean: " = "Limpeza automática: ";
+
+/* Sidebar */
+"CLEANING" = "LIMPEZA";
+"Last cleaned: %@" = "Última limpeza: %@";
+
+/* Smart Scan */
+"Smart Scan" = "Escaneamento Inteligente";
+"Click Scan to start" = "Clique em Escanear para começar";
+"Ready to Scan" = "Pronto para escanear";
+"Disk Usage" = "Uso do disco";
+"Start Scan" = "Iniciar escaneamento";
+"Preparing..." = "Preparando...";
+"Results Found" = "Resultados encontrados";
+"Total" = "Total";
+"Used" = "Usado";
+"Free" = "Livre";
+"Purgeable" = "Liberável";
+"junk found" = "lixo encontrado";
+"Your Mac is clean!" = "Seu Mac está limpo!";
+"Your Mac is clean" = "Seu Mac está limpo";
+"freed up" = "liberados";
+"freed" = "liberados";
+"Cleaning..." = "Limpando...";
+"Scanning..." = "Escaneando...";
+"%lld/%lld items" = "%lld/%lld itens";
+"%lld items" = "%lld itens";
+"%lld files" = "%lld arquivos";
+"Clean Selected (%@)" = "Limpar selecionados (%@)";
+"Clean %@?" = "Limpar %@?";
+"This will permanently delete the selected files. This cannot be undone." = "Isso excluirá permanentemente os arquivos selecionados. Essa ação não pode ser desfeita.";
+
+/* Category Detail */
+"All Clean!" = "Tudo limpo!";
+"All Clean" = "Tudo limpo";
+"No junk files found in this category." = "Nenhum arquivo desnecessário encontrado nesta categoria.";
+"Not scanned yet" = "Ainda não escaneado";
+"Not Scanned" = "Não escaneado";
+"Click Scan to analyze this category" = "Clique em Escanear para analisar esta categoria";
+"Run a scan to analyze this category." = "Execute um escaneamento para analisar esta categoria.";
+"Scan Now" = "Escanear agora";
+"Filter files" = "Filtrar arquivos";
+"%lld of %lld selected" = "%lld de %lld selecionados";
+"Select All" = "Selecionar tudo";
+"Deselect All" = "Desmarcar tudo";
+"Largest First" = "Maiores primeiro";
+"Smallest First" = "Menores primeiro";
+"Sorted: Largest First" = "Ordenado: maiores primeiro";
+"Sorted: Smallest First" = "Ordenado: menores primeiro";
+"Clean %lld items" = "Limpar %lld itens";
+"Reveal in Finder" = "Mostrar no Finder";
+
+/* Buttons */
+"Scan" = "Escanear";
+"Re-scan" = "Escanear novamente";
+"Scan Again" = "Escanear novamente";
+"Done" = "Concluído";
+"Clean" = "Limpar";
+"Cancel" = "Cancelar";
+"Clean (%@)" = "Limpar (%@)";
+"Clean %lld items (%@)" = "Limpar %lld itens (%@)";
+
+/* App Uninstaller */
+"Search apps" = "Buscar apps";
+"Refresh" = "Atualizar";
+"Uninstall (%lld files)" = "Desinstalar (%lld arquivos)";
+"Loading installed apps..." = "Carregando apps instalados...";
+"No Apps Found" = "Nenhum app encontrado";
+"Could not find any installed applications." = "Não foi possível encontrar aplicativos instalados.";
+"Retry" = "Tentar novamente";
+"Application" = "Aplicativo";
+"Size" = "Tamanho";
+"Select an App" = "Selecione um app";
+"Select an app from the list to see all its related files across your system." = "Selecione um app na lista para ver todos os arquivos relacionados a ele no sistema.";
+"Scanning for related files..." = "Escaneando arquivos relacionados...";
+"Checking %lld locations..." = "Verificando %lld locais...";
+"No Related Files" = "Nenhum arquivo relacionado";
+"No additional files found for %@." = "Nenhum arquivo adicional encontrado para %@.";
+"Uninstall %lld files (%@)" = "Desinstalar %lld arquivos (%@)";
+
+/* Orphaned Files */
+"Scanning for orphaned files..." = "Escaneando arquivos órfãos...";
+"No Orphaned Files" = "Nenhum arquivo órfão";
+"No leftover files from uninstalled apps were found." = "Nenhum arquivo restante de apps desinstalados foi encontrado.";
+"Scan for Orphans" = "Buscar arquivos órfãos";
+"Remove Selected (%lld)" = "Remover selecionados (%lld)";
+
+/* Onboarding */
+"Back" = "Voltar";
+"Next" = "Avançar";
+"Get Started" = "Começar";
+"Welcome to PureMac" = "Boas-vindas ao PureMac";
+"Free, open-source macOS app manager and system cleaner." = "Gerenciador de apps e limpador de sistema para macOS, gratuito e de código aberto.";
+"App Uninstaller" = "Desinstalador de apps";
+"Find junk files across your system" = "Encontre arquivos desnecessários no sistema";
+"Remove apps and all their files" = "Remova apps e todos os seus arquivos";
+"Orphan Finder" = "Localizador de órfãos";
+"Find leftovers from deleted apps" = "Encontre sobras de apps excluídos";
+"You're Ready" = "Tudo pronto";
+
+/* Settings - General */
+"General" = "Geral";
+"Startup" = "Inicialização";
+"Launch PureMac at login" = "Abrir o PureMac ao iniciar sessão";
+"App Scanning" = "Escaneamento de apps";
+"Search sensitivity" = "Sensibilidade da busca";
+"Language" = "Idioma";
+"System Default" = "Padrão do sistema";
+"English" = "Inglês";
+"Portuguese (Brazil)" = "Português (Brasil)";
+"Chinese (Simplified)" = "Chinês simplificado";
+"Chinese (Traditional)" = "Chinês tradicional";
+"Restart PureMac to apply the selected language." = "Reinicie o PureMac para aplicar o idioma selecionado.";
+"Relaunch Now" = "Reiniciar agora";
+"Strict" = "Restrita";
+"Enhanced" = "Aprimorada";
+"Deep" = "Profunda";
+"Exact bundle ID and name matches only. Safest option." = "Somente correspondências exatas de ID do pacote e nome. Opção mais segura.";
+"Includes partial name matching and bundle ID components." = "Inclui correspondência parcial de nomes e componentes do ID do pacote.";
+"Includes company name, entitlements, and team identifier matching." = "Inclui correspondência de nome da empresa, permissões e identificador da equipe.";
+"App Behavior" = "Comportamento do app";
+"Launch at login" = "Abrir ao iniciar sessão";
+"Show in Dock" = "Mostrar no Dock";
+"Show menu bar icon" = "Mostrar ícone na barra de menus";
+"Safety" = "Segurança";
+"Confirm before deleting files" = "Confirmar antes de excluir arquivos";
+"PureMac will never delete system-critical files. Only caches, logs, temporary files, and user-selected items are removed." = "O PureMac nunca excluirá arquivos críticos do sistema. Apenas caches, logs, arquivos temporários e itens selecionados pelo usuário são removidos.";
+
+/* Settings - Cleaning */
+"File Discovery" = "Descoberta de arquivos";
+"Skip hidden files during scan" = "Ignorar arquivos ocultos durante o escaneamento";
+"Large Files" = "Arquivos grandes";
+"Minimum size: %lld MB" = "Tamanho mínimo: %lld MB";
+"Files older than: %lld months" = "Arquivos com mais de %lld meses";
+
+/* Settings - Schedule */
+"Schedule" = "Agendamento";
+"Automatic Cleaning" = "Limpeza automática";
+"Automatic Scanning" = "Escaneamento automático";
+"Automatically scan and clean your Mac on a schedule" = "Escaneie e limpe seu Mac automaticamente em um agendamento";
+"Scan Interval" = "Intervalo de escaneamento";
+"Scan interval" = "Intervalo de escaneamento";
+"Automation" = "Automação";
+"Enable scheduled scanning" = "Ativar escaneamento agendado";
+"Auto-clean after scan" = "Limpar automaticamente após escanear";
+"Minimum junk size to trigger clean:" = "Tamanho mínimo de lixo para acionar a limpeza:";
+"50 MB" = "50 MB";
+"100 MB" = "100 MB";
+"250 MB" = "250 MB";
+"500 MB" = "500 MB";
+"1 GB" = "1 GB";
+"Auto-purge purgeable space" = "Liberar espaço liberável automaticamente";
+"Show notification on completion" = "Mostrar notificação ao concluir";
+"Notify on completion" = "Notificar ao concluir";
+"Status" = "Status";
+"Last run" = "Última execução";
+"Next run" = "Próxima execução";
+"Never" = "Nunca";
+"Not scheduled" = "Não agendado";
+
+/* Settings - About */
+"About" = "Sobre";
+"Version 1.0.0" = "Versão 1.0.0";
+"Version %@" = "Versão %@";
+"A free, open-source Mac cleaning utility.\nKeep your Mac fast, clean, and optimized." = "Um utilitário gratuito e de código aberto para limpar o Mac.\nMantenha seu Mac rápido, limpo e otimizado.";
+"Free, open-source macOS app manager." = "Gerenciador de apps do macOS gratuito e de código aberto.";
+"GitHub Repository" = "Repositório no GitHub";
+"Report an Issue" = "Relatar um problema";
+"MIT License" = "Licença MIT";
+
+/* Cleaning Categories */
+"System Junk" = "Lixo do sistema";
+"User Cache" = "Cache do usuário";
+"AI Apps" = "Apps de IA";
+"Mail Files" = "Arquivos de e-mail";
+"Trash Bins" = "Lixo";
+"Large & Old Files" = "Arquivos grandes e antigos";
+"Purgeable Space" = "Espaço liberável";
+"Xcode Junk" = "Lixo do Xcode";
+"Brew Cache" = "Cache do Brew";
+
+/* Category Descriptions */
+"Scan everything at once" = "Escaneie tudo de uma vez";
+"System caches, logs, and temporary files" = "Caches, logs e arquivos temporários do sistema";
+"Application caches and browser data" = "Caches de aplicativos e dados de navegadores";
+"Logs, caches, and temporary files from local AI apps" = "Logs, caches e arquivos temporários de apps locais de IA";
+"Downloaded mail attachments" = "Anexos de e-mail baixados";
+"Files in your Trash" = "Arquivos no Lixo";
+"Files over 100 MB or older than 1 year" = "Arquivos com mais de 100 MB ou mais de 1 ano";
+"APFS purgeable disk space" = "Espaço em disco liberável do APFS";
+"Derived data, archives, and simulators" = "Dados derivados, arquivos e simuladores";
+"Homebrew download cache" = "Cache de downloads do Homebrew";
+
+/* Schedule Intervals */
+"Every Hour" = "A cada hora";
+"Every 3 Hours" = "A cada 3 horas";
+"Every 6 Hours" = "A cada 6 horas";
+"Every 12 Hours" = "A cada 12 horas";
+"Daily" = "Diariamente";
+"Weekly" = "Semanalmente";
+"Every 2 Weeks" = "A cada 2 semanas";
+"Monthly" = "Mensalmente";
+
+/* Notifications */
+"Found %@ of junk files." = "Foram encontrados %@ em arquivos desnecessários.";

--- a/PureMac/zh-Hans.lproj/Localizable.strings
+++ b/PureMac/zh-Hans.lproj/Localizable.strings
@@ -1,7 +1,27 @@
-/* Full Disk Access Banner */
+/* Navigation */
+"Applications" = "应用程序";
+"Cleaning" = "清理";
+"Installed Apps" = "已安装应用";
+"Installed Apps (%lld)" = "已安装应用（%lld）";
+"Orphaned Files" = "孤立文件";
+"Orphaned Files (%lld)" = "孤立文件（%lld）";
+"Select a category from the sidebar to get started." = "从边栏选择一个类别即可开始。";
+
+/* Full Disk Access */
 "Full Disk Access Required" = "需要完整磁盘访问权限";
+"Full Disk Access" = "完整磁盘访问权限";
 "PureMac needs Full Disk Access to scan Trash, Mail, Desktop, Documents, and Homebrew cache." = "PureMac 需要完整磁盘访问权限才能扫描废纸篓、邮件、桌面、文稿和 Homebrew 缓存。";
+"PureMac needs Full Disk Access to scan all caches, Trash, and app data." = "PureMac 需要完整磁盘访问权限才能扫描所有缓存、废纸篓和应用数据。";
+"Full Disk Access is granted. You're all set!" = "已授予完整磁盘访问权限。设置完成！";
 "Open Settings" = "打开设置";
+"Open System Settings" = "打开系统设置";
+"Open System Settings > Privacy & Security" = "打开系统设置 > 隐私与安全性";
+"Select Full Disk Access" = "选择完整磁盘访问权限";
+"Enable PureMac" = "启用 PureMac";
+"Full Disk Access: %@" = "完整磁盘访问权限：%@";
+"Granted" = "已授予";
+"Not Granted" = "未授予";
+"Some features may be limited without Full Disk Access." = "没有完整磁盘访问权限时，某些功能可能会受限。";
 
 /* Top Bar */
 "Macintosh HD" = "Macintosh HD";
@@ -15,41 +35,141 @@
 /* Smart Scan */
 "Smart Scan" = "智能扫描";
 "Click Scan to start" = "点击扫描开始";
+"Ready to Scan" = "准备扫描";
+"Disk Usage" = "磁盘使用情况";
+"Start Scan" = "开始扫描";
+"Preparing..." = "正在准备...";
+"Results Found" = "已找到结果";
 "Total" = "总计";
 "Used" = "已用";
 "Free" = "可用";
 "Purgeable" = "可清除";
-"junk found" = "垃圾文件";
+"junk found" = "发现垃圾文件";
 "Your Mac is clean!" = "您的 Mac 很干净！";
+"Your Mac is clean" = "您的 Mac 很干净";
 "freed up" = "已释放";
+"freed" = "已释放";
 "Cleaning..." = "正在清理...";
 "Scanning..." = "正在扫描...";
 "%lld/%lld items" = "%lld/%lld 个项目";
+"%lld items" = "%lld 个项目";
+"%lld files" = "%lld 个文件";
+"Clean Selected (%@)" = "清理已选项目（%@）";
+"Clean %@?" = "清理 %@？";
+"This will permanently delete the selected files. This cannot be undone." = "这将永久删除所选文件。此操作无法撤销。";
 
 /* Category Detail */
 "All Clean!" = "全部干净！";
+"All Clean" = "全部干净";
 "No junk files found in this category." = "此类别未发现垃圾文件。";
 "Not scanned yet" = "尚未扫描";
+"Not Scanned" = "未扫描";
 "Click Scan to analyze this category" = "点击扫描分析此类别";
+"Run a scan to analyze this category." = "运行扫描以分析此类别。";
+"Scan Now" = "立即扫描";
+"Filter files" = "筛选文件";
 "%lld of %lld selected" = "已选 %lld / %lld";
 "Select All" = "全选";
 "Deselect All" = "取消全选";
-"%lld items" = "%lld 个项目";
+"Largest First" = "最大优先";
+"Smallest First" = "最小优先";
+"Sorted: Largest First" = "排序：最大优先";
+"Sorted: Smallest First" = "排序：最小优先";
+"Clean %lld items" = "清理 %lld 个项目";
+"Reveal in Finder" = "在访达中显示";
 
 /* Buttons */
 "Scan" = "扫描";
 "Re-scan" = "重新扫描";
 "Scan Again" = "再次扫描";
 "Done" = "完成";
+"Clean" = "清理";
+"Cancel" = "取消";
 "Clean (%@)" = "清理（%@）";
 "Clean %lld items (%@)" = "清理 %lld 个项目（%@）";
+
+/* App Uninstaller */
+"Search apps" = "搜索应用";
+"Refresh" = "刷新";
+"Uninstall (%lld files)" = "卸载（%lld 个文件）";
+"Loading installed apps..." = "正在加载已安装应用...";
+"No Apps Found" = "未找到应用";
+"Could not find any installed applications." = "无法找到任何已安装的应用程序。";
+"Retry" = "重试";
+"Application" = "应用程序";
+"Size" = "大小";
+"Select an App" = "选择一个应用";
+"Select an app from the list to see all its related files across your system." = "从列表中选择一个应用，即可查看系统中所有相关文件。";
+"Scanning for related files..." = "正在扫描相关文件...";
+"Checking %lld locations..." = "正在检查 %lld 个位置...";
+"No Related Files" = "没有相关文件";
+"No additional files found for %@." = "未找到 %@ 的其他文件。";
+"Uninstall %lld files (%@)" = "卸载 %lld 个文件（%@）";
+
+/* Orphaned Files */
+"Scanning for orphaned files..." = "正在扫描孤立文件...";
+"No Orphaned Files" = "没有孤立文件";
+"No leftover files from uninstalled apps were found." = "未发现已卸载应用的残留文件。";
+"Scan for Orphans" = "扫描孤立文件";
+"Remove Selected (%lld)" = "移除已选项目（%lld）";
+
+/* Onboarding */
+"Back" = "返回";
+"Next" = "下一步";
+"Get Started" = "开始使用";
+"Welcome to PureMac" = "欢迎使用 PureMac";
+"Free, open-source macOS app manager and system cleaner." = "免费、开源的 macOS 应用管理器和系统清理工具。";
+"App Uninstaller" = "应用卸载器";
+"Find junk files across your system" = "查找系统中的垃圾文件";
+"Remove apps and all their files" = "移除应用及其所有文件";
+"Orphan Finder" = "孤立文件查找器";
+"Find leftovers from deleted apps" = "查找已删除应用的残留文件";
+"You're Ready" = "准备就绪";
+
+/* Settings - General */
+"General" = "通用";
+"Startup" = "启动";
+"Launch PureMac at login" = "登录时启动 PureMac";
+"App Scanning" = "应用扫描";
+"Search sensitivity" = "搜索灵敏度";
+"Language" = "语言";
+"System Default" = "系统默认";
+"English" = "英语";
+"Portuguese (Brazil)" = "葡萄牙语（巴西）";
+"Chinese (Simplified)" = "简体中文";
+"Chinese (Traditional)" = "繁体中文";
+"Restart PureMac to apply the selected language." = "重启 PureMac 以应用所选语言。";
+"Relaunch Now" = "立即重新启动";
+"Strict" = "严格";
+"Enhanced" = "增强";
+"Deep" = "深度";
+"Exact bundle ID and name matches only. Safest option." = "仅匹配精确的包 ID 和名称。最安全的选项。";
+"Includes partial name matching and bundle ID components." = "包含部分名称匹配和包 ID 组件。";
+"Includes company name, entitlements, and team identifier matching." = "包含公司名称、权限和团队标识符匹配。";
+"App Behavior" = "应用程序行为";
+"Launch at login" = "登录时启动";
+"Show in Dock" = "在程序坞中显示";
+"Show menu bar icon" = "显示菜单栏图标";
+"Safety" = "安全";
+"Confirm before deleting files" = "删除文件前确认";
+"PureMac will never delete system-critical files. Only caches, logs, temporary files, and user-selected items are removed." = "PureMac 永远不会删除系统关键文件。只会删除缓存、日志、临时文件和用户选择的项目。";
+
+/* Settings - Cleaning */
+"File Discovery" = "文件发现";
+"Skip hidden files during scan" = "扫描时跳过隐藏文件";
+"Large Files" = "大文件";
+"Minimum size: %lld MB" = "最小大小：%lld MB";
+"Files older than: %lld months" = "超过 %lld 个月的文件";
 
 /* Settings - Schedule */
 "Schedule" = "计划";
 "Automatic Cleaning" = "自动清理";
+"Automatic Scanning" = "自动扫描";
 "Automatically scan and clean your Mac on a schedule" = "按计划自动扫描和清理您的 Mac";
 "Scan Interval" = "扫描间隔";
+"Scan interval" = "扫描间隔";
 "Automation" = "自动化";
+"Enable scheduled scanning" = "启用计划扫描";
 "Auto-clean after scan" = "扫描后自动清理";
 "Minimum junk size to trigger clean:" = "触发清理的最小垃圾大小：";
 "50 MB" = "50 MB";
@@ -59,26 +179,21 @@
 "1 GB" = "1 GB";
 "Auto-purge purgeable space" = "自动清除可清除空间";
 "Show notification on completion" = "完成时显示通知";
+"Notify on completion" = "完成时通知";
 "Status" = "状态";
 "Last run" = "上次运行";
 "Next run" = "下次运行";
 "Never" = "从未";
 "Not scheduled" = "未计划";
 
-/* Settings - General */
-"General" = "通用";
-"App Behavior" = "应用程序行为";
-"Launch at login" = "登录时启动";
-"Show in Dock" = "在程序坞中显示";
-"Show menu bar icon" = "显示菜单栏图标";
-"Safety" = "安全";
-"PureMac will never delete system-critical files. Only caches, logs, temporary files, and user-selected items are removed." = "PureMac 永远不会删除系统关键文件。只会删除缓存、日志、临时文件和用户选择的项目。";
-
 /* Settings - About */
 "About" = "关于";
 "Version 1.0.0" = "版本 1.0.0";
+"Version %@" = "版本 %@";
 "A free, open-source Mac cleaning utility.\nKeep your Mac fast, clean, and optimized." = "免费、开源的 Mac 清理工具。\n让您的 Mac 保持快速、干净和优化。";
+"Free, open-source macOS app manager." = "免费、开源的 macOS 应用管理器。";
 "GitHub Repository" = "GitHub 仓库";
+"Report an Issue" = "报告问题";
 "MIT License" = "MIT 许可证";
 
 /* Cleaning Categories */

--- a/PureMac/zh-Hant.lproj/Localizable.strings
+++ b/PureMac/zh-Hant.lproj/Localizable.strings
@@ -1,7 +1,27 @@
-/* Full Disk Access Banner */
+/* Navigation */
+"Applications" = "應用程式";
+"Cleaning" = "清理";
+"Installed Apps" = "已安裝應用程式";
+"Installed Apps (%lld)" = "已安裝應用程式（%lld）";
+"Orphaned Files" = "孤立檔案";
+"Orphaned Files (%lld)" = "孤立檔案（%lld）";
+"Select a category from the sidebar to get started." = "從側邊欄選取類別即可開始。";
+
+/* Full Disk Access */
 "Full Disk Access Required" = "需要完整磁碟存取權限";
+"Full Disk Access" = "完整磁碟存取權限";
 "PureMac needs Full Disk Access to scan Trash, Mail, Desktop, Documents, and Homebrew cache." = "PureMac 需要完整磁碟存取權限才能掃描垃圾桶、郵件、桌面、文件及 Homebrew 快取。";
+"PureMac needs Full Disk Access to scan all caches, Trash, and app data." = "PureMac 需要完整磁碟存取權限才能掃描所有快取、垃圾桶及應用程式資料。";
+"Full Disk Access is granted. You're all set!" = "已授予完整磁碟存取權限。設定完成！";
 "Open Settings" = "開啟設定";
+"Open System Settings" = "開啟系統設定";
+"Open System Settings > Privacy & Security" = "開啟系統設定 > 隱私權與安全性";
+"Select Full Disk Access" = "選取完整磁碟存取權限";
+"Enable PureMac" = "啟用 PureMac";
+"Full Disk Access: %@" = "完整磁碟存取權限：%@";
+"Granted" = "已授予";
+"Not Granted" = "未授予";
+"Some features may be limited without Full Disk Access." = "沒有完整磁碟存取權限時，部分功能可能會受限。";
 
 /* Top Bar */
 "Macintosh HD" = "Macintosh HD";
@@ -15,41 +35,141 @@
 /* Smart Scan */
 "Smart Scan" = "智慧掃描";
 "Click Scan to start" = "點一下「掃描」開始";
+"Ready to Scan" = "準備掃描";
+"Disk Usage" = "磁碟使用情況";
+"Start Scan" = "開始掃描";
+"Preparing..." = "正在準備…";
+"Results Found" = "已找到結果";
 "Total" = "總計";
 "Used" = "已使用";
 "Free" = "可用";
 "Purgeable" = "可清除";
 "junk found" = "發現垃圾檔案";
 "Your Mac is clean!" = "您的 Mac 很乾淨！";
+"Your Mac is clean" = "您的 Mac 很乾淨";
 "freed up" = "已釋出";
+"freed" = "已釋出";
 "Cleaning..." = "正在清理…";
 "Scanning..." = "正在掃描…";
 "%lld/%lld items" = "%lld/%lld 個項目";
+"%lld items" = "%lld 個項目";
+"%lld files" = "%lld 個檔案";
+"Clean Selected (%@)" = "清理已選項目（%@）";
+"Clean %@?" = "清理 %@？";
+"This will permanently delete the selected files. This cannot be undone." = "這會永久刪除所選檔案。此操作無法復原。";
 
 /* Category Detail */
 "All Clean!" = "全部乾淨！";
+"All Clean" = "全部乾淨";
 "No junk files found in this category." = "此類別未發現垃圾檔案。";
 "Not scanned yet" = "尚未掃描";
+"Not Scanned" = "未掃描";
 "Click Scan to analyze this category" = "點一下「掃描」以分析此類別";
+"Run a scan to analyze this category." = "執行掃描以分析此類別。";
+"Scan Now" = "立即掃描";
+"Filter files" = "篩選檔案";
 "%lld of %lld selected" = "已選取 %lld / %lld";
 "Select All" = "全選";
 "Deselect All" = "取消全選";
-"%lld items" = "%lld 個項目";
+"Largest First" = "最大優先";
+"Smallest First" = "最小優先";
+"Sorted: Largest First" = "排序：最大優先";
+"Sorted: Smallest First" = "排序：最小優先";
+"Clean %lld items" = "清理 %lld 個項目";
+"Reveal in Finder" = "在 Finder 中顯示";
 
 /* Buttons */
 "Scan" = "掃描";
 "Re-scan" = "重新掃描";
 "Scan Again" = "再次掃描";
 "Done" = "完成";
+"Clean" = "清理";
+"Cancel" = "取消";
 "Clean (%@)" = "清理（%@）";
 "Clean %lld items (%@)" = "清理 %lld 個項目（%@）";
+
+/* App Uninstaller */
+"Search apps" = "搜尋應用程式";
+"Refresh" = "重新整理";
+"Uninstall (%lld files)" = "解除安裝（%lld 個檔案）";
+"Loading installed apps..." = "正在載入已安裝應用程式…";
+"No Apps Found" = "找不到應用程式";
+"Could not find any installed applications." = "找不到任何已安裝的應用程式。";
+"Retry" = "重試";
+"Application" = "應用程式";
+"Size" = "大小";
+"Select an App" = "選取應用程式";
+"Select an app from the list to see all its related files across your system." = "從列表中選取應用程式，即可查看系統中的所有相關檔案。";
+"Scanning for related files..." = "正在掃描相關檔案…";
+"Checking %lld locations..." = "正在檢查 %lld 個位置…";
+"No Related Files" = "沒有相關檔案";
+"No additional files found for %@." = "找不到 %@ 的其他檔案。";
+"Uninstall %lld files (%@)" = "解除安裝 %lld 個檔案（%@）";
+
+/* Orphaned Files */
+"Scanning for orphaned files..." = "正在掃描孤立檔案…";
+"No Orphaned Files" = "沒有孤立檔案";
+"No leftover files from uninstalled apps were found." = "未發現已解除安裝應用程式的殘留檔案。";
+"Scan for Orphans" = "掃描孤立檔案";
+"Remove Selected (%lld)" = "移除已選項目（%lld）";
+
+/* Onboarding */
+"Back" = "返回";
+"Next" = "下一步";
+"Get Started" = "開始使用";
+"Welcome to PureMac" = "歡迎使用 PureMac";
+"Free, open-source macOS app manager and system cleaner." = "免費、開放原始碼的 macOS 應用程式管理器與系統清理工具。";
+"App Uninstaller" = "應用程式解除安裝器";
+"Find junk files across your system" = "尋找系統中的垃圾檔案";
+"Remove apps and all their files" = "移除應用程式及其所有檔案";
+"Orphan Finder" = "孤立檔案尋找器";
+"Find leftovers from deleted apps" = "尋找已刪除應用程式的殘留檔案";
+"You're Ready" = "準備就緒";
+
+/* Settings - General */
+"General" = "一般";
+"Startup" = "啟動";
+"Launch PureMac at login" = "登入時啟動 PureMac";
+"App Scanning" = "應用程式掃描";
+"Search sensitivity" = "搜尋靈敏度";
+"Language" = "語言";
+"System Default" = "系統預設";
+"English" = "英文";
+"Portuguese (Brazil)" = "葡萄牙文（巴西）";
+"Chinese (Simplified)" = "簡體中文";
+"Chinese (Traditional)" = "繁體中文";
+"Restart PureMac to apply the selected language." = "重新啟動 PureMac 以套用所選語言。";
+"Relaunch Now" = "立即重新啟動";
+"Strict" = "嚴格";
+"Enhanced" = "增強";
+"Deep" = "深度";
+"Exact bundle ID and name matches only. Safest option." = "僅比對精確的套件 ID 與名稱。最安全的選項。";
+"Includes partial name matching and bundle ID components." = "包含部分名稱比對與套件 ID 元件。";
+"Includes company name, entitlements, and team identifier matching." = "包含公司名稱、權限與團隊識別碼比對。";
+"App Behavior" = "應用程式行為";
+"Launch at login" = "登入時啟動";
+"Show in Dock" = "於 Dock 中顯示";
+"Show menu bar icon" = "顯示選單列圖示";
+"Safety" = "安全性";
+"Confirm before deleting files" = "刪除檔案前先確認";
+"PureMac will never delete system-critical files. Only caches, logs, temporary files, and user-selected items are removed." = "PureMac 絕不會刪除系統關鍵檔案。僅會移除快取、記錄檔、暫存檔案及使用者選取的項目。";
+
+/* Settings - Cleaning */
+"File Discovery" = "檔案探索";
+"Skip hidden files during scan" = "掃描時略過隱藏檔案";
+"Large Files" = "大型檔案";
+"Minimum size: %lld MB" = "最小大小：%lld MB";
+"Files older than: %lld months" = "超過 %lld 個月的檔案";
 
 /* Settings - Schedule */
 "Schedule" = "排程";
 "Automatic Cleaning" = "自動清理";
+"Automatic Scanning" = "自動掃描";
 "Automatically scan and clean your Mac on a schedule" = "依排程自動掃描與清理您的 Mac";
 "Scan Interval" = "掃描間隔";
+"Scan interval" = "掃描間隔";
 "Automation" = "自動化";
+"Enable scheduled scanning" = "啟用排程掃描";
 "Auto-clean after scan" = "掃描後自動清理";
 "Minimum junk size to trigger clean:" = "觸發清理的最小垃圾大小：";
 "50 MB" = "50 MB";
@@ -59,26 +179,21 @@
 "1 GB" = "1 GB";
 "Auto-purge purgeable space" = "自動清除可清除空間";
 "Show notification on completion" = "完成時顯示通知";
+"Notify on completion" = "完成時通知";
 "Status" = "狀態";
 "Last run" = "上次執行";
 "Next run" = "下次執行";
 "Never" = "從未";
 "Not scheduled" = "未排程";
 
-/* Settings - General */
-"General" = "一般";
-"App Behavior" = "應用程式行為";
-"Launch at login" = "登入時啟動";
-"Show in Dock" = "於 Dock 中顯示";
-"Show menu bar icon" = "顯示選單列圖示";
-"Safety" = "安全性";
-"PureMac will never delete system-critical files. Only caches, logs, temporary files, and user-selected items are removed." = "PureMac 絕不會刪除系統關鍵檔案。僅會移除快取、記錄檔、暫存檔案及使用者選取的項目。";
-
 /* Settings - About */
 "About" = "關於";
 "Version 1.0.0" = "版本 1.0.0";
+"Version %@" = "版本 %@";
 "A free, open-source Mac cleaning utility.\nKeep your Mac fast, clean, and optimized." = "免費、開放原始碼的 Mac 清理工具。\n讓您的 Mac 保持快速、乾淨且最佳化。";
+"Free, open-source macOS app manager." = "免費、開放原始碼的 macOS 應用程式管理器。";
 "GitHub Repository" = "GitHub 儲存庫";
+"Report an Issue" = "回報問題";
 "MIT License" = "MIT 授權";
 
 /* Cleaning Categories */
@@ -96,7 +211,7 @@
 "Scan everything at once" = "一次掃描所有項目";
 "System caches, logs, and temporary files" = "系統快取、記錄檔及暫存檔案";
 "Application caches and browser data" = "應用程式快取與瀏覽器資料";
-"Logs, caches, and temporary files from local AI apps" = "來自本機 AI 應用程式的日誌、快取和暫存檔案";
+"Logs, caches, and temporary files from local AI apps" = "本機 AI 應用程式的記錄檔、快取與暫存檔案";
 "Downloaded mail attachments" = "已下載的郵件附件";
 "Files in your Trash" = "垃圾桶中的檔案";
 "Files over 100 MB or older than 1 year" = "超過 100 MB 或超過一年未使用的檔案";

--- a/PureMacTests/AppLanguagePreferencesTests.swift
+++ b/PureMacTests/AppLanguagePreferencesTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import PureMac
+
+final class AppLanguagePreferencesTests: XCTestCase {
+    func testApplyCustomLanguageSetsAppleLanguagesAndPreservesLocale() {
+        let context = makeDefaults()
+        let defaults = context.defaults
+        defaults.set("pt_BR", forKey: "AppleLocale")
+
+        AppLanguagePreferences.apply(.english, defaults: defaults)
+
+        XCTAssertEqual(defaults.array(forKey: "AppleLanguages") as? [String], ["en"])
+        XCTAssertEqual(defaults.string(forKey: "AppleLocale"), "pt_BR")
+    }
+
+    func testApplySystemLanguageRemovesAppleLanguagesAndPreservesLocale() {
+        let context = makeDefaults()
+        let defaults = context.defaults
+        defaults.set(["en"], forKey: "AppleLanguages")
+        defaults.set("pt_BR", forKey: "AppleLocale")
+
+        AppLanguagePreferences.apply(.system, defaults: defaults)
+
+        XCTAssertNil(defaults.persistentDomain(forName: context.suiteName)?["AppleLanguages"])
+        XCTAssertEqual(defaults.string(forKey: "AppleLocale"), "pt_BR")
+    }
+
+    private func makeDefaults() -> (defaults: UserDefaults, suiteName: String) {
+        let suiteName = "PureMacTests.AppLanguagePreferences.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return (defaults, suiteName)
+    }
+}

--- a/PureMacTests/AppStateTests.swift
+++ b/PureMacTests/AppStateTests.swift
@@ -1,0 +1,61 @@
+import AppKit
+import XCTest
+@testable import PureMac
+
+@MainActor
+final class AppStateTests: XCTestCase {
+    func testScanForAppFilesTracksLocationsWhileResultsArePending() throws {
+        var completion: ((Set<URL>) -> Void)?
+        let expectedLocations = ["/one", "/two", "/three"]
+        let appState = AppState(
+            performStartupTasks: false,
+            locationsProvider: {
+                StubLocations(paths: expectedLocations)
+            },
+            appFileScanner: { _, locations, pendingCompletion in
+                XCTAssertEqual(locations.appSearch.paths, expectedLocations)
+                completion = pendingCompletion
+            }
+        )
+
+        appState.scanForAppFiles(makeApp())
+
+        XCTAssertTrue(appState.isScanningAppFiles)
+        XCTAssertTrue(appState.discoveredFiles.isEmpty)
+        XCTAssertEqual(appState.currentAppFileSearchLocationCount, expectedLocations.count)
+
+        let pendingCompletion = try XCTUnwrap(completion)
+        let urls: Set<URL> = [
+            URL(fileURLWithPath: "/tmp/B"),
+            URL(fileURLWithPath: "/tmp/A")
+        ]
+
+        pendingCompletion(urls)
+
+        XCTAssertFalse(appState.isScanningAppFiles)
+        XCTAssertEqual(
+            appState.discoveredFiles,
+            urls.sorted { $0.path < $1.path }
+        )
+        XCTAssertEqual(appState.selectedFiles, urls)
+        XCTAssertEqual(appState.currentAppFileSearchLocationCount, urls.count)
+    }
+
+    private func makeApp() -> InstalledApp {
+        InstalledApp(
+            id: UUID(),
+            appName: "PureMac",
+            bundleIdentifier: "com.puremac.app",
+            path: URL(fileURLWithPath: "/Applications/PureMac.app"),
+            icon: NSImage(size: NSSize(width: 32, height: 32)),
+            size: 1
+        )
+    }
+}
+
+private final class StubLocations: Locations {
+    init(paths: [String]) {
+        super.init()
+        appSearch = SearchCategory(name: "Apps", paths: paths)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -40,3 +40,21 @@ targets:
         Debug:
           CODE_SIGNING_ALLOWED: "NO"
           CODE_SIGNING_REQUIRED: "NO"
+  PureMacTests:
+    type: bundle.unit-test
+    platform: macOS
+    sources:
+      - PureMacTests
+    dependencies:
+      - target: PureMac
+
+schemes:
+  PureMac:
+    build:
+      targets:
+        PureMac: all
+        PureMacTests:
+          - test
+    test:
+      targets:
+        - name: PureMacTests


### PR DESCRIPTION
## Summary

This PR adds Brazilian Portuguese (`pt-BR`) localization support and broadens the app's localization infrastructure so the UI can be translated consistently across supported languages.

The main changes are:

- Adds a new `PureMac/pt-BR.lproj/Localizable.strings` file with Brazilian Portuguese translations for the current localized UI surface.
- Registers `pt-BR` in the Xcode project so the new localization is included in the app bundle.
- Expands the English localization table to cover the UI strings touched by the app's main flows.
- Completes the Simplified Chinese (`zh-Hans`) and Traditional Chinese (`zh-Hant`) localization files so all supported locale files have matching key sets.
- Preserves format specifiers such as `%@` and `%lld` across localized strings used by formatted labels.
- Updates SwiftUI views to use localization-aware APIs, including `LocalizedStringKey` and `String(localized:)`, where strings are displayed or formatted dynamically.
- Adds a language picker under Settings > General with options for:
  - System Default
  - English
  - Portuguese (Brazil)
  - Chinese (Simplified)
  - Chinese (Traditional)
- Persists the user's language selection with a dedicated app preference key, while applying `AppleLanguages` as the macOS localization override.
- Keeps first launch behavior aligned with the system language by defaulting the language picker to System Default unless the user chooses an app-specific language.
- Adds a relaunch prompt and relaunch action after changing the app language, since bundle localization is applied on app startup.
- Adjusts app launch argument handling so LaunchServices `-psn_...` arguments do not accidentally trigger CLI mode when the app is opened normally.
- Removes deprecated single-parameter `.onChange` usage by replacing those flows with explicit SwiftUI bindings.

## Notes for reviewers

- The localization files were checked for key parity against English. `pt-BR`, `zh-Hans`, and `zh-Hant` all contain the same keys as `en`.
- The language picker intentionally includes a System Default option so existing users and first-time users continue to follow macOS language preferences unless they explicitly choose an app language.
- The app-specific language preference is stored separately from `AppleLanguages`; `AppleLanguages` is treated as an implementation detail for macOS bundle localization.
- Some legacy keys remain in the localization files even if they are not currently referenced by Swift code, so this PR preserves compatibility instead of deleting existing translation surface area.

## Verification

Ran the following checks successfully before opening this PR:

- `git diff --check upstream/main...HEAD`
- `plutil -lint PureMac/en.lproj/Localizable.strings PureMac/pt-BR.lproj/Localizable.strings PureMac/zh-Hans.lproj/Localizable.strings PureMac/zh-Hant.lproj/Localizable.strings`
- Locale key parity check comparing `pt-BR`, `zh-Hans`, and `zh-Hant` against `en`
- `rg -n '\.onChange\(' PureMac` confirmed there are no remaining `.onChange` usages
- `xcodebuild -project PureMac.xcodeproj -scheme PureMac -configuration Debug -derivedDataPath .build/XcodeDerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY= build`

The Xcode build completed with `BUILD SUCCEEDED`.

## AI assistance disclosure

This contribution was implemented by an AI coding agent, OpenAI Codex, under human oversight. The human maintainer directed the requirements, selected the `pt-BR` localization scope, reviewed behavior during development, requested corrections, and approved publishing this branch for review.
