### PR TITLE
fix(scanning): synchronize collectionSet read in shouldSkipItem

### DIFF
--- a/PureMac/Logic/Scanning/AppPathFinder.swift
+++ b/PureMac/Logic/Scanning/AppPathFinder.swift
@@ -266,7 +266,7 @@ class AppPathFinder {
     // MARK: - Skip Logic
 
     private func shouldSkipItem(_ normalizedName: String, at url: URL) -> Bool {
-        if collectionSet.contains(url) { return true }
+        if collectionQueue.sync(execute: { collectionSet.contains(url) }) { return true }
 
         for skip in skipConditions {
             for path in skip.skipPaths {


### PR DESCRIPTION
## What does this PR do?

Fixes a `EXC_BAD_ACCESS / KERN_INVALID_ADDRESS` crash in `AppPathFinder` during app scanning.

`findPathsAsync` fans out `processLocation` across `DispatchQueue.global(.userInitiated)` (`PureMac/Logic/Scanning/AppPathFinder.swift:107`). Writes to the shared `collectionSet` are serialized through `collectionQueue.sync { collectionSet.formUnion(...) }` (line 185-187), but the read in `shouldSkipItem` (line 269) was unsynchronized:

```swift
if collectionSet.contains(url) { return true }
```

`Set<URL>` is not thread-safe. When one thread called `formUnion` while another was walking the hash buckets via `contains`, the reader could land on a freshly-deallocated `URL` reference — `URL.==` then called `swift_getObjectType` on a nil pointer.

### Stack (from the crash report this reproduces)

```
Thread 19 Crashed:
0 libswiftCore.dylib          swift_getObjectType + 40
1 Foundation                  static URL.== infix(_:_:) + 52
2 PureMac                     specialized Set.contains(_:) + 284
3 PureMac                     AppPathFinder.shouldSkipItem(_:at:) + 100
4 PureMac                     AppPathFinder.processLocation(...) + 1872
```

The crash report showed ~50 worker threads inside `processLocation` simultaneously, all reading/writing the same `collectionSet`.

## Fix

Route the read through the same serial queue that already guards writes:

```swift
if collectionQueue.sync(execute: { collectionSet.contains(url) }) { return true }
```

One-line change; keeps the existing serialization model intact. A broader refactor (per-task local sets merged in `group.notify`, or a concurrent queue with barrier writes) is a follow-up — the queue now serializes every recursive directory listing behind one lock, which may show up in Instruments on large scans.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] UI/UX enhancement
- [ ] Documentation
- [ ] Other (describe)

## Testing

- [x] `xcodebuild` — succeeds
- [x] Tested on macOS Sequoia (26.4.1) — reproduced the crash before the fix on an app scan, no crash after
- [ ] Tested on macOS Ventura (13.x)
- [ ] Tested on macOS Sonoma (14.x)

## Screenshots

N/A — behavior change, no UI.
