### PR TITLE
fix(cli): only enter CLI mode for known commands

### DIFF
--- a/PureMac/Logic/Utilities/CLI.swift
+++ b/PureMac/Logic/Utilities/CLI.swift
@@ -1,6 +1,16 @@
 import Foundation
 
 struct CLI {
+    private static let knownCommands: Set<String> = [
+        "scan", "disk-info", "list",
+        "help", "--help", "-h",
+        "version", "--version", "-v",
+    ]
+
+    static func isKnownCommand(_ arg: String) -> Bool {
+        knownCommands.contains(arg)
+    }
+
     static func run() -> Never {
         let args = Array(CommandLine.arguments.dropFirst())
 

--- a/PureMac/PureMacApp.swift
+++ b/PureMac/PureMacApp.swift
@@ -16,7 +16,11 @@ struct PureMacApp: App {
     @AppStorage("PureMac.OnboardingComplete") private var onboardingComplete = false
 
     init() {
-        if CommandLine.arguments.count > 1 {
+        // Enter CLI mode only when the first arg is a known command. Xcode and
+        // LaunchServices inject args like -NSDocumentRevisionsDebugMode and
+        // -psn_<pid> that must not be interpreted as CLI commands.
+        if let first = CommandLine.arguments.dropFirst().first,
+           CLI.isKnownCommand(first) {
             CLI.run()
         }
     }


### PR DESCRIPTION
## What does this PR do?

`PureMacApp.init` currently enters CLI mode on any `CommandLine.arguments.count > 1`. Xcode's default Run scheme injects `-NSDocumentRevisionsDebugMode YES`, and LaunchServices injects `-psn_<pid>` args — either one makes the GUI build exit with `"Unknown command: -NSDocumentRevisionsDebugMode"` instead of opening the window.

#42 addressed the `-psn_` variant but only as part of a larger localization PR; the dispatch path itself still treats any first argument as a CLI command.

This PR gates CLI mode on the first positional argument matching a known command (`scan`, `disk-info`, `list`, `help`/`--help`/`-h`, `version`/`--version`/`-v`). Anything else — Apple-injected flags, unknown user input — falls through to the GUI.

## Changes

- `PureMacApp.swift`: swap the `count > 1` check for `CLI.isKnownCommand(first)`
- `CLI.swift`: expose a `knownCommands` set and an `isKnownCommand(_:)` helper; `run()`'s existing `default:` case keeps its "Unknown command" behavior for the CLI entry path (e.g., `puremac foo`)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] UI/UX enhancement
- [ ] Documentation
- [ ] Other (describe)

## Testing

- [x] `xcodebuild` — succeeds
- [x] Tested on macOS Sequoia (26.4.1): `Run` from Xcode now opens the GUI instead of exiting with `"Unknown command: -NSDocumentRevisionsDebugMode"`
- [x] `puremac scan`, `puremac list`, `puremac --help`, `puremac foo` all behave identically to before
- [ ] Tested on macOS Ventura (13.x)
- [ ] Tested on macOS Sonoma (14.x)

## Screenshots

N/A — dispatch logic change, no UI.
