### PR TITLE
feat(updater): add Sparkle — minimal UpdateService (opt-in)

### DIFF
--- a/PureMac/PureMacApp.swift
+++ b/PureMac/PureMacApp.swift
@@ -49,6 +49,12 @@ struct PureMacApp: App {
         .defaultSize(width: 1000, height: 680)
         .commands {
             CommandGroup(replacing: .newItem) {}
+            CommandMenu("Updates") {
+                Button("Check for Updates") {
+                    UpdateService.shared.checkForUpdates()
+                }
+                .keyboardShortcut("u", modifiers: [.command, .shift])
+            }
         }
 
         Settings {

--- a/PureMac/Services/UpdateService.swift
+++ b/PureMac/Services/UpdateService.swift
@@ -1,0 +1,43 @@
+import Foundation
+import AppKit
+
+#if canImport(Sparkle)
+import Sparkle
+#endif
+
+final class UpdateService: ObservableObject {
+    static let shared = UpdateService()
+
+    #if canImport(Sparkle)
+    private var updaterController: SPUStandardUpdaterController?
+    #endif
+
+    private init() {
+        #if canImport(Sparkle)
+        // Do not start automatic checking by default; keep control minimal.
+        updaterController = SPUStandardUpdaterController(startingUpdater: false, updaterDelegate: nil, userDriverDelegate: nil)
+        #endif
+    }
+
+    func checkForUpdates() {
+        #if canImport(Sparkle)
+        DispatchQueue.main.async {
+            // Only start the Sparkle updater if an appcast/feed URL is configured.
+            if let _ = Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String {
+                self.updaterController?.startUpdater()
+                self.updaterController?.updater.checkForUpdates()
+            } else {
+                // Fallback: open Releases page when no feed is configured.
+                if let url = URL(string: "https://github.com/momenbasel/PureMac/releases/latest") {
+                    NSWorkspace.shared.open(url)
+                }
+            }
+        }
+        #else
+        // Fallback: open Releases page
+        if let url = URL(string: "https://github.com/momenbasel/PureMac/releases/latest") {
+            NSWorkspace.shared.open(url)
+        }
+        #endif
+    }
+}

--- a/PureMac/ViewModels/AppState.swift
+++ b/PureMac/ViewModels/AppState.swift
@@ -182,7 +182,9 @@ final class AppState: ObservableObject {
                     try FileManager.default.trashItem(at: url, resultingItemURL: &resulting)
                     removed.append(url)
                 } catch {
-                    Logger.shared.log("Trash failed for \(url.path): \(error.localizedDescription)", level: .error)
+                        Task { @MainActor in
+                        Logger.shared.log("Trash failed for \(url.path): \(error.localizedDescription)", level: .error)
+                        }
                     failed.append(url)
                 }
             }

--- a/project.yml
+++ b/project.yml
@@ -1,4 +1,8 @@
 name: PureMac
+packages:
+  Sparkle:
+    url: https://github.com/sparkle-project/Sparkle
+    from: 2.0.0
 options:
   bundleIdPrefix: com.puremac
   deploymentTarget:
@@ -31,6 +35,9 @@ targets:
     platform: macOS
     sources:
       - PureMac
+    dependencies:
+      - package: Sparkle
+        product: Sparkle
     settings:
       base:
         PRODUCT_NAME: PureMac


### PR DESCRIPTION
feat(updater): add Sparkle - minimal UpdateService (opt-in)

Summary

- Adds a minimal, opt-in in-app updater using Sparkle (SPM). This Stage 1 change wires an `UpdateService` into the app and adds a `Check for Updates` menu item under an `Updates` command menu.
- Stage 1 is intentionally conservative: it does not configure a feed URL, does not include appcast generation or signed update artifacts, and falls back to the GitHub Releases page when no `SUFeedURL` is configured.

Files changed

- `project.yml` — added Sparkle SPM dependency and target link
- `PureMac/Services/UpdateService.swift` — new minimal updater service
- `PureMac/PureMacApp.swift` — wired menu item to `UpdateService`
- `PureMac/ViewModels/AppState.swift` — small concurrency fix to avoid background-main actor warnings

Why this change

- Introduces a safe integration so maintainers can review the UI and updater wiring without requiring new CI secrets or signing infrastructure.

Testing

- Built the app locally (`xcodegen generate` → open in Xcode → build). **Build succeeded**.
- Tested runtime behavior on macOS Tahoe (26). The updater is inert unless `SUFeedURL` is set; when not set, `Check for Updates` opens the GitHub Releases page as a fallback.

Next steps (Stage 2, separate PR)

- Add appcast generation and signing (Ed25519) in CI.
- Store private signing key in repository secrets and update the release workflow to publish signed appcast and update artifacts.

Notes for reviewers

- This PR is intentionally small and non-invasive. If maintainers want Stage 2, I can prepare a separate PR with CI changes and documentation for key management.
