### PR TITLE
fix: stop showing root "/" as purgeable-space target (#112)

### DIFF
--- a/PureMac/Services/CleaningEngine.swift
+++ b/PureMac/Services/CleaningEngine.swift
@@ -28,6 +28,11 @@ actor CleaningEngine {
                 let purged = await purgePurgeableSpace()
                 result.freedSpace += purged
                 if purged > 0 { result.itemsCleaned += 1 }
+                // Purgeable space is a one-shot reclaim action, not a file
+                // unlink. Mark it handled so it isn't later mistaken for an
+                // item that "couldn't be removed" (the purge ran regardless of
+                // how much APFS chose to release). See issue #112.
+                result.cleanedPaths.insert(item.path)
                 continue
             }
 

--- a/PureMac/Services/ScanEngine.swift
+++ b/PureMac/Services/ScanEngine.swift
@@ -286,9 +286,16 @@ actor ScanEngine {
         // Detect APFS purgeable space via URLResourceValues (no admin needed)
         let diskInfo = getDiskInfo()
         if diskInfo.purgeableSpace > 0 {
+            // Purgeable space is reclaimed via `diskutil apfs purgePurgeable /`
+            // (see CleaningEngine.purgePurgeableSpace), it is NOT a file that
+            // gets unlinked. Using "/" as the path made the UI render the root
+            // directory as the deletion target and triggered a bogus
+            // "couldn't remove /" error after cleaning. Use an empty path so
+            // the row shows no misleading filesystem location and the reveal-
+            // in-Finder action stays disabled for this entry. (See issue #112.)
             items.append(CleanableItem(
                 name: "APFS Purgeable Space",
-                path: "/",
+                path: "",
                 size: diskInfo.purgeableSpace,
                 category: .purgeableSpace,
                 isSelected: true,

--- a/PureMac/Views/CategoryDetailView.swift
+++ b/PureMac/Views/CategoryDetailView.swift
@@ -214,11 +214,13 @@ private struct FileRowView: View {
                         .lineLimit(1)
                         .truncationMode(.middle)
 
-                    Text(item.path)
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
+                    if !item.path.isEmpty {
+                        Text(item.path)
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
                 }
 
                 Spacer()
@@ -237,8 +239,10 @@ private struct FileRowView: View {
         }
         .toggleStyle(.checkbox)
         .contextMenu {
-            Button("Reveal in Finder") {
-                NSWorkspace.shared.selectFile(item.path, inFileViewerRootedAtPath: "")
+            if !item.path.isEmpty {
+                Button("Reveal in Finder") {
+                    NSWorkspace.shared.selectFile(item.path, inFileViewerRootedAtPath: "")
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #112.

### Problem
The "APFS Purgeable Space" entry from `ScanEngine.scanPurgeableSpace()` was created with `path: "/"`. Purgeable space is reclaimed via `diskutil apfs purgePurgeable /` (see `CleaningEngine.purgePurgeableSpace`), so it is **not** a file that gets unlinked — the path was only a label. But it leaked into the UI as the deletion target (the detail row showed `/`, "Reveal in Finder" pointed at root), which made it look like the app intended to delete the root directory.

The same entry also produced a bogus `Couldn't remove /…` alert after cleaning, because the `purgeableSpace` branch in `cleanItems` never recorded the item in `cleanedPaths`, so it was always counted as an un-removable "survivor".

The app never actually deleted `/`: purgeable items short-circuit (`continue`) before `removeItem`, and `isSafeToDelete("/")` already returns `false`. This was a display/UX bug plus a false error, not real data loss.

### Changes
- **ScanEngine**: use an empty `path` for the purgeable entry (it is not a file on disk).
- **CleaningEngine**: mark the purgeable item handled after the reclaim runs, so it is no longer reported as something that "couldn't be removed".
- **CategoryDetailView**: hide the path subtitle and the "Reveal in Finder" action when there is no real filesystem path.

### Testing
- Build succeeds (universal arm64+x86_64, macOS 13 target).
- Scan with purgeable space present → entry shows no `/` path and no Reveal action.
- Run Clean → no "Couldn't remove /" alert; `diskutil apfs purgePurgeable /` still runs.
