### PR TITLE
Fix app/file sizes showing as bytes instead of recursive total

### DIFF
--- a/PureMac.xcodeproj/project.pbxproj
+++ b/PureMac.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		A549D8A39A9E5E70D91B90A6 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A3F22FCEF534DE4A2CAD0E /* Haptics.swift */; };
 		A9C3A1F643C26930F442E729 /* OrphanSafetyPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE790496C936424EF98320A /* OrphanSafetyPolicy.swift */; };
 		ABDDD4F35102A39CC1A2C325 /* ConfettiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0599AA604B0D6BA4F957537 /* ConfettiView.swift */; };
+		B51E5A95BB49A6C0F5273E21 /* FileSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE522B406791BCE905BC55B /* FileSize.swift */; };
 		B52938BBD11842631314543D /* CategoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10B0AF194677EAC1D5568785 /* CategoryDetailView.swift */; };
 		BC6C800216343438413349A3 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4FD34378988D430A582ED0 /* OnboardingView.swift */; };
 		CDCDFEBA39A3290101F86AC6 /* MainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F510F232341EE18F11DC934 /* MainWindow.swift */; };
@@ -99,6 +100,7 @@
 		77D3D9A9BC52839E6D0A22BC /* Locations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locations.swift; sourceTree = "<group>"; };
 		798B80977D14647A5691B0A0 /* AppFilesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFilesView.swift; sourceTree = "<group>"; };
 		82BB0904726B38DEB141BECA /* AppLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLanguage.swift; sourceTree = "<group>"; };
+		8CE522B406791BCE905BC55B /* FileSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSize.swift; sourceTree = "<group>"; };
 		8D5E63D733D1A3BDEDF4DCA5 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		92259B3E9F4468865F15DEEC /* AppearancePill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearancePill.swift; sourceTree = "<group>"; };
 		9F04B811BB0012F6D2F07F91 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -266,6 +268,7 @@
 			isa = PBXGroup;
 			children = (
 				01B2C5F66B6D812572BD4F05 /* CLI.swift */,
+				8CE522B406791BCE905BC55B /* FileSize.swift */,
 				5785762276FB5E3209C6DE4D /* Logger.swift */,
 				4AE790496C936424EF98320A /* OrphanSafetyPolicy.swift */,
 			);
@@ -437,6 +440,7 @@
 				A2AE68CC75CB72D6B10CBDF5 /* DashboardView.swift in Sources */,
 				76B132F9C499225D33E0D075 /* EmptyStateView.swift in Sources */,
 				52F11962555C639F0EECADD6 /* FDADemoView.swift in Sources */,
+				B51E5A95BB49A6C0F5273E21 /* FileSize.swift in Sources */,
 				2253F11BDF561B617439C96B /* FullDiskAccessManager.swift in Sources */,
 				A549D8A39A9E5E70D91B90A6 /* Haptics.swift in Sources */,
 				E60B0A2C5D0A6CAE35BF4DFB /* Locations.swift in Sources */,

--- a/PureMac/Logic/Scanning/AppInfoFetcher.swift
+++ b/PureMac/Logic/Scanning/AppInfoFetcher.swift
@@ -133,31 +133,6 @@ final class AppInfoFetcher {
     }
 
     private func appSize(at url: URL) -> Int64 {
-        // totalFileAllocatedSizeKey on a directory URL returns only the
-        // directory inode (~4 KB on APFS), not the recursive sum - the
-        // previous fast-path returned that and exited, causing app sizes
-        // to display as ~4 KB regardless of bundle contents. Always
-        // enumerate the bundle contents and sum.
-        guard let enumerator = fileManager.enumerator(
-            at: url,
-            includingPropertiesForKeys: [.totalFileAllocatedSizeKey, .fileAllocatedSizeKey, .isRegularFileKey, .isSymbolicLinkKey],
-            options: [.skipsHiddenFiles]
-        ) else { return 0 }
-
-        var total: Int64 = 0
-        for case let fileURL as URL in enumerator {
-            guard let values = try? fileURL.resourceValues(forKeys: [.totalFileAllocatedSizeKey, .fileAllocatedSizeKey, .isRegularFileKey, .isSymbolicLinkKey]) else { continue }
-            // Skip symlinks so we don't double-count or follow links out of
-            // the bundle. Skip directories so we only count regular file
-            // payload.
-            if values.isSymbolicLink == true { continue }
-            guard values.isRegularFile == true else { continue }
-            if let allocated = values.totalFileAllocatedSize {
-                total += Int64(allocated)
-            } else if let allocated = values.fileAllocatedSize {
-                total += Int64(allocated)
-            }
-        }
-        return total
+        FileSizeCalculator.size(of: url) ?? 0
     }
 }

--- a/PureMac/Logic/Utilities/FileSize.swift
+++ b/PureMac/Logic/Utilities/FileSize.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Allocated-size calculation that works for both files and directories.
+///
+/// `URLResourceValues.totalFileAllocatedSize` does **not** recurse: on a
+/// directory URL it returns only the directory inode's own allocation
+/// (~96 bytes to a few KB on APFS), not the sum of the bundle's contents.
+/// Reading it directly on an `.app` bundle or a support folder is what made
+/// items display as a handful of bytes. For directories we enumerate and sum
+/// the regular files instead.
+enum FileSizeCalculator {
+    private static let fileManager = FileManager.default
+
+    /// On-disk allocated size of `url`. Recurses into directories.
+    /// Returns `nil` if the item can't be read at all.
+    static func size(of url: URL) -> Int64? {
+        let values = try? url.resourceValues(forKeys: [.isDirectoryKey])
+        if values?.isDirectory == true {
+            return directorySize(of: url)
+        }
+        return fileSize(of: url)
+    }
+
+    private static func fileSize(of url: URL) -> Int64? {
+        if let values = try? url.resourceValues(forKeys: [.totalFileAllocatedSizeKey]),
+           let size = values.totalFileAllocatedSize {
+            return Int64(size)
+        }
+        if let values = try? url.resourceValues(forKeys: [.fileAllocatedSizeKey]),
+           let size = values.fileAllocatedSize {
+            return Int64(size)
+        }
+        guard let attrs = try? fileManager.attributesOfItem(atPath: url.path),
+              let size = attrs[.size] as? Int64 else { return nil }
+        return size
+    }
+
+    private static func directorySize(of url: URL) -> Int64 {
+        guard let enumerator = fileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.totalFileAllocatedSizeKey, .fileAllocatedSizeKey, .isRegularFileKey, .isSymbolicLinkKey],
+            options: [.skipsHiddenFiles]
+        ) else { return 0 }
+
+        var total: Int64 = 0
+        for case let fileURL as URL in enumerator {
+            guard let values = try? fileURL.resourceValues(forKeys: [.totalFileAllocatedSizeKey, .fileAllocatedSizeKey, .isRegularFileKey, .isSymbolicLinkKey]) else { continue }
+            // Skip symlinks so we don't double-count or follow links that
+            // escape the directory. Only sum regular-file payload.
+            if values.isSymbolicLink == true { continue }
+            guard values.isRegularFile == true else { continue }
+            if let allocated = values.totalFileAllocatedSize {
+                total += Int64(allocated)
+            } else if let allocated = values.fileAllocatedSize {
+                total += Int64(allocated)
+            }
+        }
+        return total
+    }
+}

--- a/PureMac/Views/Apps/AppFilesView.swift
+++ b/PureMac/Views/Apps/AppFilesView.swift
@@ -372,20 +372,7 @@ struct AppFilesView: View {
     }
 
     private func fileSize(_ url: URL) -> Int64? {
-        // totalFileAllocatedSize recurses into directories; attributesOfItem
-        // returns the directory's own metadata size (≈0), which is why
-        // bundles and support folders previously displayed as 0 B.
-        if let values = try? url.resourceValues(forKeys: [.totalFileAllocatedSizeKey]),
-           let size = values.totalFileAllocatedSize, size > 0 {
-            return Int64(size)
-        }
-        if let values = try? url.resourceValues(forKeys: [.fileAllocatedSizeKey]),
-           let size = values.fileAllocatedSize {
-            return Int64(size)
-        }
-        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
-              let size = attrs[.size] as? Int64 else { return nil }
-        return size
+        FileSizeCalculator.size(of: url)
     }
 
     private func removeSingleFile(_ url: URL) {

--- a/PureMac/Views/Orphans/OrphanListView.swift
+++ b/PureMac/Views/Orphans/OrphanListView.swift
@@ -125,17 +125,7 @@ struct OrphanListView: View {
     }
 
     private func fileSize(_ url: URL) -> Int64? {
-        if let values = try? url.resourceValues(forKeys: [.totalFileAllocatedSizeKey]),
-           let size = values.totalFileAllocatedSize, size > 0 {
-            return Int64(size)
-        }
-        if let values = try? url.resourceValues(forKeys: [.fileAllocatedSizeKey]),
-           let size = values.fileAllocatedSize {
-            return Int64(size)
-        }
-        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
-              let size = attrs[.size] as? Int64 else { return nil }
-        return size
+        FileSizeCalculator.size(of: url)
     }
 
     private func removeSelectedOrphans() async {


### PR DESCRIPTION
## What does this PR do?

fileSize() in AppFilesView and OrphanListView read totalFileAllocatedSize directly on the URL, which on a directory returns only the directory inode (~bytes on APFS) rather than the sum of its contents. App bundles and support folders then were displayed as a handful of bytes (Bambu Studio showed 18 KB instead of 2.8 GB, for example).

This seems to be a recurrence of #92, but that fix only covered AppInfoFetcher.appSize.

- Extract the recursive logic into a shared FileSizeCalculator that enumerates directories and sums regular-file allocated sizes.
- Route all three call sites (AppFilesView, OrphanListView, AppInfoFetcher) through it.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] UI/UX enhancement
- [ ] Documentation
- [ ] Other (describe)

## Testing

- [ ] Tested on macOS Ventura (13.x)
- [ ] Tested on macOS Sonoma (14.x)
- [ ] Tested on macOS Sequoia (15.x)
- [X] Tested on macOS Tahoe (26.5.1)

## Screenshots

### Before
<img width="1066" height="73" alt="before" src="https://github.com/user-attachments/assets/976f367e-89d0-412e-b878-798683589407" />

### After
<img width="1076" height="68" alt="after" src="https://github.com/user-attachments/assets/2ae2ec70-cf98-4c31-882b-e0736913b4fe" />
