### PR TITLE
fix(l10n): apply appearance name localization in MainWindow

### DIFF
--- a/PureMac/Views/MainWindow.swift
+++ b/PureMac/Views/MainWindow.swift
@@ -350,7 +350,7 @@ struct MainWindow: View {
                 Button {
                     theme.appearance = appearance
                 } label: {
-                    Label(appearance.label, systemImage: appearance.icon)
+                    Label(LocalizedStringKey(appearance.label), systemImage: appearance.icon)
                 }
             }
         } label: {
@@ -366,7 +366,7 @@ struct MainWindow: View {
 
                 Spacer(minLength: 6)
 
-                Text(theme.appearance.label)
+                Text(LocalizedStringKey(theme.appearance.label))
                     .font(.system(size: 10.5, weight: .medium))
                     .foregroundStyle(.secondary)
 
@@ -382,7 +382,7 @@ struct MainWindow: View {
         .menuStyle(.borderlessButton)
         .help("Change appearance")
         .accessibilityLabel("Appearance")
-        .accessibilityValue(theme.appearance.label)
+        .accessibilityValue(Text(LocalizedStringKey(theme.appearance.label)))
     }
 
     private var sidebarLabelColor: Color {


### PR DESCRIPTION
The appearance name (System/Light/Dark) was rendered via Text(String) and Label(String, systemImage:), which use the non-localizing initializers. As a result the existing "System"/"Light"/"Dark" translations were never applied and the labels always showed English.

Wrap the values in LocalizedStringKey (matching AppearancePill) at the menu item, the sidebar value, and the accessibility value so they localize correctly.