### PR TITLE
l10n: restore simulator-runtimes key rename lost in #147 merge resolution

### DIFF
--- a/PureMac/ar.lproj/Localizable.strings
+++ b/PureMac/ar.lproj/Localizable.strings
@@ -242,7 +242,7 @@
 "Files in your Trash" = "الملفات الموجودة في سلة المهملات";
 "Files over 100 MB or older than 1 year" = "الملفات التي يتجاوز حجمها 100 ميغابايت أو أقدم من سنة";
 "APFS purgeable disk space" = "مساحة القرص القابلة للتحرير في APFS";
-"Derived data, archives, and simulators" = "البيانات المشتقة والأرشيفات والمحاكيات";
+"Derived data, archives, and simulator runtimes" = "البيانات المشتقة والأرشيفات والمحاكيات";
 "Homebrew download cache" = "ذاكرة تنزيلات Homebrew المؤقتة";
 "npm, yarn, and pnpm download caches" = "ذاكرات تنزيلات npm وyarn وpnpm المؤقتة";
 "Docker images, containers, and build cache" = "صور Docker والحاويات وذاكرة البناء المؤقتة";

--- a/PureMac/en.lproj/Localizable.strings
+++ b/PureMac/en.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 "Files in your Trash" = "Files in your Trash";
 "Files over 100 MB or older than 1 year" = "Files over 100 MB or older than 1 year";
 "APFS purgeable disk space" = "APFS purgeable disk space";
-"Derived data, archives, and simulators" = "Derived data, archives, and simulators";
+"Derived data, archives, and simulator runtimes" = "Derived data, archives, and simulator runtimes";
 "Homebrew download cache" = "Homebrew download cache";
 "npm, yarn, and pnpm download caches" = "npm, yarn, and pnpm download caches";
 "Docker images, containers, and build cache" = "Docker images, containers, and build cache";

--- a/PureMac/es.lproj/Localizable.strings
+++ b/PureMac/es.lproj/Localizable.strings
@@ -242,7 +242,7 @@
 "Files in your Trash" = "Archivos en la Papelera";
 "Files over 100 MB or older than 1 year" = "Archivos de más de 100 MB o con más de 1 año";
 "APFS purgeable disk space" = "Espacio liberable de disco APFS";
-"Derived data, archives, and simulators" = "Datos derivados, archivos y simuladores";
+"Derived data, archives, and simulator runtimes" = "Datos derivados, archivos y simuladores";
 "Homebrew download cache" = "Caché de descargas de Homebrew";
 "npm, yarn, and pnpm download caches" = "Cachés de descargas de npm, yarn y pnpm";
 "Docker images, containers, and build cache" = "Imágenes, contenedores y caché de compilación de Docker";

--- a/PureMac/ja.lproj/Localizable.strings
+++ b/PureMac/ja.lproj/Localizable.strings
@@ -242,7 +242,7 @@
 "Files in your Trash" = "ゴミ箱内のファイル";
 "Files over 100 MB or older than 1 year" = "100MB以上または1年以上前のファイル";
 "APFS purgeable disk space" = "APFSの削除可能ディスク領域";
-"Derived data, archives, and simulators" = "派生データ、アーカイブ、シミュレータ";
+"Derived data, archives, and simulator runtimes" = "派生データ、アーカイブ、シミュレータ";
 "Homebrew download cache" = "Homebrewのダウンロードキャッシュ";
 "npm, yarn, and pnpm download caches" = "npm、yarn、pnpm のダウンロードキャッシュ";
 "Docker images, containers, and build cache" = "Dockerイメージ、コンテナ、ビルドキャッシュ";

--- a/PureMac/pl.lproj/Localizable.strings
+++ b/PureMac/pl.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 "Files in your Trash" = "Pliki w koszu";
 "Files over 100 MB or older than 1 year" = "Pliki powyżej 100 MB lub starsze niż 1 rok";
 "APFS purgeable disk space" = "Miejsce na dysku do zwolnienia (APFS)";
-"Derived data, archives, and simulators" = "Dane pochodne, archiwa i symulatory";
+"Derived data, archives, and simulator runtimes" = "Dane pochodne, archiwa i symulatory";
 "Homebrew download cache" = "Cache pobierania Homebrew";
 "npm, yarn, and pnpm download caches" = "Cache pobierania npm, yarn i pnpm";
 "Docker images, containers, and build cache" = "Obrazy Dockera, kontenery i cache budowania";

--- a/PureMac/pt-BR.lproj/Localizable.strings
+++ b/PureMac/pt-BR.lproj/Localizable.strings
@@ -242,7 +242,7 @@
 "Files in your Trash" = "Arquivos na sua Lixeira";
 "Files over 100 MB or older than 1 year" = "Arquivos com mais de 100 MB ou mais de 1 ano";
 "APFS purgeable disk space" = "Espaço de disco liberável do APFS";
-"Derived data, archives, and simulators" = "Derived data, arquivos e simuladores";
+"Derived data, archives, and simulator runtimes" = "Derived data, arquivos e simuladores";
 "Homebrew download cache" = "Cache de downloads do Homebrew";
 "npm, yarn, and pnpm download caches" = "Caches de download do npm, yarn e pnpm";
 "Docker images, containers, and build cache" = "Imagens, containers e cache de build do Docker";

--- a/PureMac/ru.lproj/Localizable.strings
+++ b/PureMac/ru.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 "Files in your Trash" = "Файлы в Корзине";
 "Files over 100 MB or older than 1 year" = "Файлы размером более 100 МБ или старше 1 года";
 "APFS purgeable disk space" = "Очищаемое пространство на диске APFS";
-"Derived data, archives, and simulators" = "Производные данные, архивы и симуляторы";
+"Derived data, archives, and simulator runtimes" = "Производные данные, архивы и среды выполнения симуляторов";
 "Homebrew download cache" = "Кэш загрузок Homebrew";
 "npm, yarn, and pnpm download caches" = "Кэши загрузок npm, yarn и pnpm";
 "Docker images, containers, and build cache" = "Образы и контейнеры Docker, а также кэш сборки";

--- a/PureMac/uk.lproj/Localizable.strings
+++ b/PureMac/uk.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 "Files in your Trash" = "Файли у Смітнику";
 "Files over 100 MB or older than 1 year" = "Файли розміром понад 100 МБ або старші за 1 рік";
 "APFS purgeable disk space" = "Місце APFS, яке можна звільнити";
-"Derived data, archives, and simulators" = "Похідні дані, архіви та симулятори";
+"Derived data, archives, and simulator runtimes" = "Похідні дані, архіви та середовища виконання симуляторів";
 "Homebrew download cache" = "Кеш завантажень Homebrew";
 "npm, yarn, and pnpm download caches" = "Кеші завантажень npm, yarn і pnpm";
 "Docker images, containers, and build cache" = "Образи й контейнери Docker, а також кеш збірок";

--- a/PureMac/zh-Hans.lproj/Localizable.strings
+++ b/PureMac/zh-Hans.lproj/Localizable.strings
@@ -242,7 +242,7 @@
 "Files in your Trash" = "废纸篓中的文件";
 "Files over 100 MB or older than 1 year" = "大于 100 MB 或超过 1 年的文件";
 "APFS purgeable disk space" = "APFS 可清理磁盘空间";
-"Derived data, archives, and simulators" = "派生数据、归档和模拟器";
+"Derived data, archives, and simulator runtimes" = "派生数据、归档和模拟器";
 "Homebrew download cache" = "Homebrew 下载缓存";
 "npm, yarn, and pnpm download caches" = "npm、yarn 和 pnpm 下载缓存";
 "Docker images, containers, and build cache" = "Docker 镜像、容器和构建缓存";

--- a/PureMac/zh-Hant.lproj/Localizable.strings
+++ b/PureMac/zh-Hant.lproj/Localizable.strings
@@ -242,7 +242,7 @@
 "Files in your Trash" = "垃圾桶中的檔案";
 "Files over 100 MB or older than 1 year" = "超過 100 MB 或一年以上的檔案";
 "APFS purgeable disk space" = "APFS 可清除的磁碟空間";
-"Derived data, archives, and simulators" = "衍生資料、封存與模擬器";
+"Derived data, archives, and simulator runtimes" = "衍生資料、封存與模擬器";
 "Homebrew download cache" = "Homebrew 下載快取";
 "npm, yarn, and pnpm download caches" = "npm、yarn 與 pnpm 下載快取";
 "Docker images, containers, and build cache" = "Docker 映像檔、容器與建置快取";


### PR DESCRIPTION
## Summary

While resolving `Localizable.strings` conflicts between #145 and #147, the union resolution kept main's side of each catalog and re-appended only the end-of-file `"Simulator runtime"` block — which silently dropped #147's mid-file key rename (`"Derived data, archives, and simulators"` → `"Derived data, archives, and simulator runtimes"`).

Since `Models.swift` merged with the new string, `CategoryDetailView` (`Text(LocalizedStringKey(category.description))`) and `DashboardView` (`String(localized:)`) were looking up a key no catalog carried: English users saw the identical fallback, but every other locale regressed to English for the Xcode Junk description. `LocalizationFilesTests` could not catch it because all 10 catalogs were consistently wrong together — the suite checks catalogs against each other, not against code literals.

This restores the rename in all 10 catalogs, preserving each locale's translated value and #147's improved ru/uk values.

## Verification

- Key-parity, duplicate-key, and format-specifier checks pass (396 keys × 10 catalogs)
- `plutil -lint` clean on all files
- Old key no longer appears anywhere in the tree; `Models.swift` string now resolves in every catalog

— automated maintainer pass on behalf of @momenbasel

Made with [Cursor](https://cursor.com)