### PR TITLE
Add VS Code–family extensions cleanup

### DIFF
--- a/PureMac.xcodeproj/project.pbxproj
+++ b/PureMac.xcodeproj/project.pbxproj
@@ -8,12 +8,15 @@
 
 /* Begin PBXBuildFile section */
 		013EF7B96BF046D4DB38FBC5 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 241E0895B09C71AB423B2F9E /* Localizable.strings */; };
+		0975846AABA6EA8B2A7FE3A8 /* AppSupportResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3409287F332A8A0F530B37FA /* AppSupportResolverTests.swift */; };
 		1B0D043102FDB245312A5147 /* AppFilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 798B80977D14647A5691B0A0 /* AppFilesView.swift */; };
 		2253F11BDF561B617439C96B /* FullDiskAccessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E866A1541D289C69144A5E62 /* FullDiskAccessManager.swift */; };
 		25E2304A3FF257F1740E304B /* FileProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7953B398E47A4C603DE287F1 /* FileProtection.swift */; };
 		27F449EDD1B082FE11FEC9DF /* SchedulerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28181F034530331A550C6A3D /* SchedulerService.swift */; };
+		2B59BFAADAE4DE50B16DE0BB /* VSCodeExtensionsIndexPruner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 643E6725E3E9C5AD9DB3BC27 /* VSCodeExtensionsIndexPruner.swift */; };
 		340E424F759ACCDE7372F99F /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5ADDC35F31E40780FB5D017 /* Theme.swift */; };
 		39BEE5E2BEC526CCADFC9DDD /* ServicesMenu.strings in Resources */ = {isa = PBXBuildFile; fileRef = 57FBBF8C7EF27C8E09126ED5 /* ServicesMenu.strings */; };
+		3FB6821BEAB6070BA1CF1088 /* CleaningEngineVSCodeExtensionsSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D1822BA5115D5C14C5016A6 /* CleaningEngineVSCodeExtensionsSafetyTests.swift */; };
 		41B27CACD7C6C7471EFD03F9 /* UpdateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022D0EAEE2B6E54069FC2CBE /* UpdateService.swift */; };
 		47C5ECD49C4DD75F271DB6CE /* StringNormalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3AC5F17D7CA94FAB1E8D7A /* StringNormalization.swift */; };
 		48D1431A7C99C19EEBDB056B /* CleaningEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A8DE5D45BA19E2670B57DC5 /* CleaningEngine.swift */; };
@@ -21,6 +24,7 @@
 		50304378D99F2E9E48B642AF /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 9CC8F66E27BE52A6639E904B /* Sparkle */; };
 		52F11962555C639F0EECADD6 /* FDADemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231FF7CBB5F621B66F2AB8A5 /* FDADemoView.swift */; };
 		535B23C0108C06475215B8E8 /* AppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB003A7751F05727DBFD1A5 /* AppTheme.swift */; };
+		5923FC5A3040EA3FDFE28449 /* ExtensionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD77AD541273D828C3C0529 /* ExtensionListView.swift */; };
 		59B3096E2AE8ED0397B16798 /* AppLanguagePreferencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491771F923C93FD61A263893 /* AppLanguagePreferencesTests.swift */; };
 		61D285E96DED76FDCD54570F /* PermissionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 069AAE87E3F9EDE5593AD8B3 /* PermissionSheet.swift */; };
 		6753946A301B2EB2FEF6998B /* SimulatorRuntimeSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74E66594478F53363BCB0F9 /* SimulatorRuntimeSupport.swift */; };
@@ -28,21 +32,28 @@
 		6D449325D54B9850FC6C119F /* UniversalBinaryScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95EC878D25C244BF94D0094C /* UniversalBinaryScanner.swift */; };
 		6E72022A661CBB41331A442C /* PermissionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9DCBD97CC88D77AE8DB01A4 /* PermissionCoordinator.swift */; };
 		75B5F0401D37F2872B1AD85A /* AppListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E6BC61614B27C065BB18C9 /* AppListView.swift */; };
+		761EDF284E391FC9D956A4C3 /* VSCodeExtensionListUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C0703391093513B93B41C2 /* VSCodeExtensionListUpdaterTests.swift */; };
 		76B132F9C499225D33E0D075 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 424F7B28624C271620E13BBC /* EmptyStateView.swift */; };
 		826A750D2D7EC14C2AE306A3 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3667D46D8E2004EB4D73835A /* Models.swift */; };
+		8514C86E91C205997AC40705 /* VSCodeExtensionScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35EEBB72EC2BC0BBE95305F9 /* VSCodeExtensionScanner.swift */; };
 		8947F0CE448791BD50EECF46 /* Conditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB94E06E145558123BB5BFB3 /* Conditions.swift */; };
 		8B541441926847072DC5B75B /* DashboardCharts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C60E04A0CA3F227816DB63 /* DashboardCharts.swift */; };
 		91751CF033E1541BFD39B12C /* MenuBarMonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A27DB5A70FA829B6C3ED0AC3 /* MenuBarMonitorView.swift */; };
 		93743B036059418560D876E6 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8D39C3C250F26302EC45AB /* SettingsView.swift */; };
 		95278ABDCF5F4D6AC60503B1 /* AppearancePill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92259B3E9F4468865F15DEEC /* AppearancePill.swift */; };
+		95720C0EF8BBB50AFA989BA3 /* VSCodeExtensionLeftoverFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3217843B3766773494CB65 /* VSCodeExtensionLeftoverFinderTests.swift */; };
 		9AA80E035DF7B33F6EE118DF /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1B71D5F9510582E869CFD /* AppState.swift */; };
 		9BB5AAA574AFED6C27A3F8E2 /* AppPathFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0FEE7141871ED5F9E36121 /* AppPathFinder.swift */; };
 		9E3639F9EFCB2A22F6747894 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 913E3064AA9BD7BE94A315CF /* MenuBarController.swift */; };
 		9E87638A3F12C12D93995DA7 /* LanguageFilesScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0899FE169D270DF95334905 /* LanguageFilesScanner.swift */; };
 		A2AE68CC75CB72D6B10CBDF5 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F661A0F64CF93E482CB1728F /* DashboardView.swift */; };
 		A549D8A39A9E5E70D91B90A6 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A3F22FCEF534DE4A2CAD0E /* Haptics.swift */; };
+		A78568618FC23BC842615701 /* VSCodeExtensionHomePathRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BB8DDDBB338006845EB46D /* VSCodeExtensionHomePathRules.swift */; };
+		A8E1A3B2F213A608682A48BC /* AppSupportResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12201F092F9880D8592EAF06 /* AppSupportResolver.swift */; };
 		A9C3A1F643C26930F442E729 /* OrphanSafetyPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE790496C936424EF98320A /* OrphanSafetyPolicy.swift */; };
+		AA42FDB0A436E24091A1ABB2 /* VSCodeExtensionHomePathRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 854B04F07E61AAE40F25464E /* VSCodeExtensionHomePathRulesTests.swift */; };
 		ABDDD4F35102A39CC1A2C325 /* ConfettiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0599AA604B0D6BA4F957537 /* ConfettiView.swift */; };
+		B266B0F8335EC5EEAA1D31D1 /* VSCodeExtensionScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6425143E7425A44834FA2730 /* VSCodeExtensionScannerTests.swift */; };
 		B51E5A95BB49A6C0F5273E21 /* FileSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE522B406791BCE905BC55B /* FileSize.swift */; };
 		B52938BBD11842631314543D /* CategoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10B0AF194677EAC1D5568785 /* CategoryDetailView.swift */; };
 		B928E4369A3FC4369F014A29 /* SmartCareCoreArtwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA389C4F50505795FB31A51 /* SmartCareCoreArtwork.swift */; };
@@ -56,6 +67,7 @@
 		DC32253D26D0E29762006DA0 /* AppBundleDragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D3F9FEDC493A8E49E910F67 /* AppBundleDragHandle.swift */; };
 		DDD6BA35DBF32E7A6B5F6F8B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B2EA41E1096FA8E3B916AD13 /* Assets.xcassets */; };
 		DDDA5879006CB97D5D7BDD87 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5785762276FB5E3209C6DE4D /* Logger.swift */; };
+		E0A0200E6253079A729C1FFC /* VSCodeExtensionLeftoverFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15ACF18E6FFF02737C738BAC /* VSCodeExtensionLeftoverFinder.swift */; };
 		E2403D82F00D749C9AD4A6D4 /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 752603285F7DBBA12BB3AA91 /* AppStateTests.swift */; };
 		E60B0A2C5D0A6CAE35BF4DFB /* Locations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D3D9A9BC52839E6D0A22BC /* Locations.swift */; };
 		E726702EABBE56155861DBA9 /* AppLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82BB0904726B38DEB141BECA /* AppLanguage.swift */; };
@@ -63,6 +75,7 @@
 		F1F506C146E17D6CEC4A12F3 /* AppInfoFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23486A54A82EE3865B784D1C /* AppInfoFetcher.swift */; };
 		F2FA881A4B2209CC2A6342FB /* CLI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B2C5F66B6D812572BD4F05 /* CLI.swift */; };
 		F4F02F966001A1504C2B4D33 /* SimulatorRuntimeSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D81BE7EA5DB17F4A0300AD /* SimulatorRuntimeSupportTests.swift */; };
+		F9F446F391AE8FD7239E8ACC /* VSCodeExtensionListUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D219E6F46B5EE8FA81D6620 /* VSCodeExtensionListUpdater.swift */; };
 		FBEE9208E222616A8DF1FE75 /* ProviderPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFB912A9A6CFDCB972E978F /* ProviderPaths.swift */; };
 		FDA30FE6349CA01C8D859F04 /* OrphanListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71E8F62DB76D85F41F9A2E9 /* OrphanListView.swift */; };
 /* End PBXBuildFile section */
@@ -85,7 +98,10 @@
 		08C60E04A0CA3F227816DB63 /* DashboardCharts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCharts.swift; sourceTree = "<group>"; };
 		0A544093C897FBCBA8E256F9 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		10B0AF194677EAC1D5568785 /* CategoryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDetailView.swift; sourceTree = "<group>"; };
+		12201F092F9880D8592EAF06 /* AppSupportResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSupportResolver.swift; sourceTree = "<group>"; };
 		155CE1B8CDCCCA6F9FD028C1 /* LocalizationFilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationFilesTests.swift; sourceTree = "<group>"; };
+		15ACF18E6FFF02737C738BAC /* VSCodeExtensionLeftoverFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VSCodeExtensionLeftoverFinder.swift; sourceTree = "<group>"; };
+		19C0703391093513B93B41C2 /* VSCodeExtensionListUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VSCodeExtensionListUpdaterTests.swift; sourceTree = "<group>"; };
 		1AB003A7751F05727DBFD1A5 /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
 		1C0D9A6F75D0B8ADDB32FC2A /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Localizable.strings; sourceTree = "<group>"; };
 		1D3AC5F17D7CA94FAB1E8D7A /* StringNormalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringNormalization.swift; sourceTree = "<group>"; };
@@ -97,7 +113,9 @@
 		2A8DE5D45BA19E2670B57DC5 /* CleaningEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleaningEngine.swift; sourceTree = "<group>"; };
 		2D3F9FEDC493A8E49E910F67 /* AppBundleDragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBundleDragHandle.swift; sourceTree = "<group>"; };
 		311078221878708524283765 /* PureMac.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PureMac.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3409287F332A8A0F530B37FA /* AppSupportResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSupportResolverTests.swift; sourceTree = "<group>"; };
 		340D303C60FF878B019056B6 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
+		35EEBB72EC2BC0BBE95305F9 /* VSCodeExtensionScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VSCodeExtensionScanner.swift; sourceTree = "<group>"; };
 		3667D46D8E2004EB4D73835A /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		374A3BE46E71E54B6927E9EF /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/ServicesMenu.strings; sourceTree = "<group>"; };
 		3A8D39C3C250F26302EC45AB /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -115,13 +133,18 @@
 		607B9A8C7B34D6A7DCF4FFE2 /* PureMacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PureMacTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		60E6BC61614B27C065BB18C9 /* AppListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppListView.swift; sourceTree = "<group>"; };
 		63581B70F9B10231964E3602 /* PureMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PureMacApp.swift; sourceTree = "<group>"; };
+		6425143E7425A44834FA2730 /* VSCodeExtensionScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VSCodeExtensionScannerTests.swift; sourceTree = "<group>"; };
+		643E6725E3E9C5AD9DB3BC27 /* VSCodeExtensionsIndexPruner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VSCodeExtensionsIndexPruner.swift; sourceTree = "<group>"; };
 		69B24B648B82186FC3B6EF2B /* BinaryThinner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryThinner.swift; sourceTree = "<group>"; };
+		6D1822BA5115D5C14C5016A6 /* CleaningEngineVSCodeExtensionsSafetyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleaningEngineVSCodeExtensionsSafetyTests.swift; sourceTree = "<group>"; };
 		6ED5C9C10C69C3143B1F5CA6 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/ServicesMenu.strings; sourceTree = "<group>"; };
 		752603285F7DBBA12BB3AA91 /* AppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
 		77D3D9A9BC52839E6D0A22BC /* Locations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locations.swift; sourceTree = "<group>"; };
 		7953B398E47A4C603DE287F1 /* FileProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProtection.swift; sourceTree = "<group>"; };
 		798B80977D14647A5691B0A0 /* AppFilesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFilesView.swift; sourceTree = "<group>"; };
+		7D219E6F46B5EE8FA81D6620 /* VSCodeExtensionListUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VSCodeExtensionListUpdater.swift; sourceTree = "<group>"; };
 		82BB0904726B38DEB141BECA /* AppLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLanguage.swift; sourceTree = "<group>"; };
+		854B04F07E61AAE40F25464E /* VSCodeExtensionHomePathRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VSCodeExtensionHomePathRulesTests.swift; sourceTree = "<group>"; };
 		8AFB912A9A6CFDCB972E978F /* ProviderPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderPaths.swift; sourceTree = "<group>"; };
 		8CE522B406791BCE905BC55B /* FileSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSize.swift; sourceTree = "<group>"; };
 		8D5E63D733D1A3BDEDF4DCA5 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -144,9 +167,11 @@
 		C7D81BE7EA5DB17F4A0300AD /* SimulatorRuntimeSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorRuntimeSupportTests.swift; sourceTree = "<group>"; };
 		CB94E06E145558123BB5BFB3 /* Conditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Conditions.swift; sourceTree = "<group>"; };
 		CED1B71D5F9510582E869CFD /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		D3BB8DDDBB338006845EB46D /* VSCodeExtensionHomePathRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VSCodeExtensionHomePathRules.swift; sourceTree = "<group>"; };
 		D74E66594478F53363BCB0F9 /* SimulatorRuntimeSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorRuntimeSupport.swift; sourceTree = "<group>"; };
 		DAA389C4F50505795FB31A51 /* SmartCareCoreArtwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartCareCoreArtwork.swift; sourceTree = "<group>"; };
 		DB798781B99987F55D77E2E3 /* SystemMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMonitor.swift; sourceTree = "<group>"; };
+		DBD77AD541273D828C3C0529 /* ExtensionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionListView.swift; sourceTree = "<group>"; };
 		DFC4A1FD7DB92C82725B4314 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		E866A1541D289C69144A5E62 /* FullDiskAccessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullDiskAccessManager.swift; sourceTree = "<group>"; };
 		ED0C4D8912DA94F81B2AEF8F /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -155,6 +180,7 @@
 		F31F91226CDCFBB8E303B7DA /* AppConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
 		F661A0F64CF93E482CB1728F /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
 		F9DCBD97CC88D77AE8DB01A4 /* PermissionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionCoordinator.swift; sourceTree = "<group>"; };
+		FA3217843B3766773494CB65 /* VSCodeExtensionLeftoverFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VSCodeExtensionLeftoverFinderTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -183,8 +209,14 @@
 			children = (
 				491771F923C93FD61A263893 /* AppLanguagePreferencesTests.swift */,
 				752603285F7DBBA12BB3AA91 /* AppStateTests.swift */,
+				3409287F332A8A0F530B37FA /* AppSupportResolverTests.swift */,
+				6D1822BA5115D5C14C5016A6 /* CleaningEngineVSCodeExtensionsSafetyTests.swift */,
 				155CE1B8CDCCCA6F9FD028C1 /* LocalizationFilesTests.swift */,
 				C7D81BE7EA5DB17F4A0300AD /* SimulatorRuntimeSupportTests.swift */,
+				854B04F07E61AAE40F25464E /* VSCodeExtensionHomePathRulesTests.swift */,
+				FA3217843B3766773494CB65 /* VSCodeExtensionLeftoverFinderTests.swift */,
+				19C0703391093513B93B41C2 /* VSCodeExtensionListUpdaterTests.swift */,
+				6425143E7425A44834FA2730 /* VSCodeExtensionScannerTests.swift */,
 			);
 			path = PureMacTests;
 			sourceTree = "<group>";
@@ -217,6 +249,7 @@
 				3D4FD34378988D430A582ED0 /* OnboardingView.swift */,
 				DAD2EC78EB98016ADA27D114 /* Apps */,
 				8AE26715B5748307483A1A5E /* Components */,
+				DC0508F56E813D26C9081F6C /* Extensions */,
 				9D3C2DC382F5D4B77DFD218B /* Orphans */,
 				7BC68AB045DA6E5299FD3CB6 /* Settings */,
 			);
@@ -306,6 +339,14 @@
 			path = Apps;
 			sourceTree = "<group>";
 		};
+		DC0508F56E813D26C9081F6C /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				DBD77AD541273D828C3C0529 /* ExtensionListView.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		E05E733EFBC4EFDA12BEC43B /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
@@ -346,11 +387,17 @@
 			children = (
 				23486A54A82EE3865B784D1C /* AppInfoFetcher.swift */,
 				AC0FEE7141871ED5F9E36121 /* AppPathFinder.swift */,
+				12201F092F9880D8592EAF06 /* AppSupportResolver.swift */,
 				CB94E06E145558123BB5BFB3 /* Conditions.swift */,
 				C0899FE169D270DF95334905 /* LanguageFilesScanner.swift */,
 				77D3D9A9BC52839E6D0A22BC /* Locations.swift */,
 				1D3AC5F17D7CA94FAB1E8D7A /* StringNormalization.swift */,
 				95EC878D25C244BF94D0094C /* UniversalBinaryScanner.swift */,
+				D3BB8DDDBB338006845EB46D /* VSCodeExtensionHomePathRules.swift */,
+				15ACF18E6FFF02737C738BAC /* VSCodeExtensionLeftoverFinder.swift */,
+				7D219E6F46B5EE8FA81D6620 /* VSCodeExtensionListUpdater.swift */,
+				35EEBB72EC2BC0BBE95305F9 /* VSCodeExtensionScanner.swift */,
+				643E6725E3E9C5AD9DB3BC27 /* VSCodeExtensionsIndexPruner.swift */,
 			);
 			path = Scanning;
 			sourceTree = "<group>";
@@ -484,6 +531,7 @@
 				75B5F0401D37F2872B1AD85A /* AppListView.swift in Sources */,
 				9BB5AAA574AFED6C27A3F8E2 /* AppPathFinder.swift in Sources */,
 				9AA80E035DF7B33F6EE118DF /* AppState.swift in Sources */,
+				A8E1A3B2F213A608682A48BC /* AppSupportResolver.swift in Sources */,
 				535B23C0108C06475215B8E8 /* AppTheme.swift in Sources */,
 				95278ABDCF5F4D6AC60503B1 /* AppearancePill.swift in Sources */,
 				68F9CE5ED4908F674D673FB2 /* BinaryThinner.swift in Sources */,
@@ -495,6 +543,7 @@
 				8B541441926847072DC5B75B /* DashboardCharts.swift in Sources */,
 				A2AE68CC75CB72D6B10CBDF5 /* DashboardView.swift in Sources */,
 				76B132F9C499225D33E0D075 /* EmptyStateView.swift in Sources */,
+				5923FC5A3040EA3FDFE28449 /* ExtensionListView.swift in Sources */,
 				52F11962555C639F0EECADD6 /* FDADemoView.swift in Sources */,
 				25E2304A3FF257F1740E304B /* FileProtection.swift in Sources */,
 				B51E5A95BB49A6C0F5273E21 /* FileSize.swift in Sources */,
@@ -525,6 +574,11 @@
 				340E424F759ACCDE7372F99F /* Theme.swift in Sources */,
 				6D449325D54B9850FC6C119F /* UniversalBinaryScanner.swift in Sources */,
 				41B27CACD7C6C7471EFD03F9 /* UpdateService.swift in Sources */,
+				A78568618FC23BC842615701 /* VSCodeExtensionHomePathRules.swift in Sources */,
+				E0A0200E6253079A729C1FFC /* VSCodeExtensionLeftoverFinder.swift in Sources */,
+				F9F446F391AE8FD7239E8ACC /* VSCodeExtensionListUpdater.swift in Sources */,
+				8514C86E91C205997AC40705 /* VSCodeExtensionScanner.swift in Sources */,
+				2B59BFAADAE4DE50B16DE0BB /* VSCodeExtensionsIndexPruner.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -534,8 +588,14 @@
 			files = (
 				59B3096E2AE8ED0397B16798 /* AppLanguagePreferencesTests.swift in Sources */,
 				E2403D82F00D749C9AD4A6D4 /* AppStateTests.swift in Sources */,
+				0975846AABA6EA8B2A7FE3A8 /* AppSupportResolverTests.swift in Sources */,
+				3FB6821BEAB6070BA1CF1088 /* CleaningEngineVSCodeExtensionsSafetyTests.swift in Sources */,
 				CFA64F54CDBF8A4765E0068D /* LocalizationFilesTests.swift in Sources */,
 				F4F02F966001A1504C2B4D33 /* SimulatorRuntimeSupportTests.swift in Sources */,
+				AA42FDB0A436E24091A1ABB2 /* VSCodeExtensionHomePathRulesTests.swift in Sources */,
+				95720C0EF8BBB50AFA989BA3 /* VSCodeExtensionLeftoverFinderTests.swift in Sources */,
+				761EDF284E391FC9D956A4C3 /* VSCodeExtensionListUpdaterTests.swift in Sources */,
+				B266B0F8335EC5EEAA1D31D1 /* VSCodeExtensionScannerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PureMac/Logic/Scanning/AppSupportResolver.swift
+++ b/PureMac/Logic/Scanning/AppSupportResolver.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Maps `~/.{editor}` dot-directories to one or more
+/// `~/Library/Application Support/...` data directories used by VS Code forks.
+enum AppSupportResolver {
+    private static let aliases: [String: [String]] = [
+        "vscode": ["Code"],
+        "vscode-insiders": ["Code - Insiders"],
+        "vscode-oss": ["VSCodium"],
+    ]
+
+    static func resolve(
+        editorDotDirectory: String,
+        homeDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> [URL] {
+        let supportRoot = homeDirectory
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+        var isDir: ObjCBool = false
+        guard fileManager.fileExists(atPath: supportRoot.path, isDirectory: &isDir), isDir.boolValue else {
+            return []
+        }
+        guard let children = try? fileManager.contentsOfDirectory(
+            at: supportRoot,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+
+        let key = normalizeKey(editorDotDirectory)
+        var wantedNames = Set(aliases[key] ?? [])
+        wantedNames.insert(editorDotDirectory.hasPrefix(".")
+            ? String(editorDotDirectory.dropFirst())
+            : editorDotDirectory)
+
+        var matches: [URL] = []
+        for child in children {
+            let values = try? child.resourceValues(forKeys: [.isDirectoryKey])
+            guard values?.isDirectory == true else { continue }
+            let name = child.lastPathComponent
+            if namesMatch(candidate: name, wanted: wantedNames, normalizedKey: key) {
+                matches.append(child)
+            }
+        }
+        return matches.sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    private static func normalizeKey(_ editorDotDirectory: String) -> String {
+        let trimmed = editorDotDirectory.hasPrefix(".")
+            ? String(editorDotDirectory.dropFirst())
+            : editorDotDirectory
+        return trimmed.lowercased()
+    }
+
+    private static func namesMatch(candidate: String, wanted: Set<String>, normalizedKey: String) -> Bool {
+        let candidateFolded = fold(candidate)
+        if wanted.contains(where: { fold($0) == candidateFolded }) {
+            return true
+        }
+        // Hyphen / space insensitive: trae-cn ↔ Trae CN
+        return fold(normalizedKey) == candidateFolded
+    }
+
+    private static func fold(_ value: String) -> String {
+        value
+            .lowercased()
+            .replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: "-", with: "")
+            .replacingOccurrences(of: "_", with: "")
+    }
+}

--- a/PureMac/Logic/Scanning/VSCodeExtensionHomePathRules.swift
+++ b/PureMac/Logic/Scanning/VSCodeExtensionHomePathRules.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+/// Deterministic `~` / `~/.config` association rules for VS Code–family extensions.
+///
+/// Personalization data under home is high-confidence when the directory name
+/// equals the extension `name`, `publisher`, `publisher-name`, or dashed
+/// `extensionId` — never via fuzzy whole-home search. Ultra-generic tokens
+/// (python, docker, github, …) are denied so CLI/tool dirs are not claimed.
+enum VSCodeExtensionHomePathRules {
+    private static let minTokenLength = 5
+
+    private static let deniedNames: Set<String> = [
+        "python", "java", "rust", "ruby", "php", "yaml", "xml", "json",
+        "markdown", "docker", "git", "node", "npm", "ssh", "remote",
+        "theme", "icons", "debug", "test", "html", "css", "sql", "shell",
+        "bash", "zsh", "vim", "code", "editor", "go", "cpp", "c",
+    ]
+
+    private static let deniedPublishers: Set<String> = [
+        "microsoft", "google", "amazon", "apple", "docker", "meta",
+        "oracle", "ibm", "github",
+    ]
+
+    /// Relative paths under the home directory (POSIX, leading `.` for home dots).
+    static func candidateRelativePaths(extensionId: String) -> [String] {
+        guard let (publisher, name) = splitExtensionId(extensionId) else { return [] }
+        let pub = publisher.lowercased()
+        let nam = name.lowercased()
+        let dashedId = extensionId.lowercased().replacingOccurrences(of: ".", with: "-")
+
+        var out: [String] = []
+        func add(_ relative: String) {
+            if !out.contains(relative) { out.append(relative) }
+        }
+
+        if isAllowedName(nam) {
+            add(".\(nam)")
+            add(".config/\(nam)")
+        }
+        if isAllowedPublisher(pub) {
+            add(".\(pub)")
+            add(".config/\(pub)")
+        }
+        add(".\(pub)-\(nam)")
+        add(".\(pub)_\(nam)")
+        add(".\(extensionId.lowercased())")
+        add(".config/\(pub)-\(nam)")
+        add(".config/\(pub)_\(nam)")
+        add(".config/\(dashedId)")
+
+        return out
+    }
+
+    static func isAssociated(
+        path: String,
+        extensionId: String,
+        homeDirectoryPath: String
+    ) -> Bool {
+        let normalized = (path as NSString).standardizingPath
+        let home = (homeDirectoryPath as NSString).standardizingPath
+        let prefix = home.hasSuffix("/") ? home : home + "/"
+        guard normalized.hasPrefix(prefix) else { return false }
+        // Never allow entire ~/.config (or other blocked roots as exact path).
+        if isBlockedExactHomePath(normalized, home: home) { return false }
+
+        let relative = String(normalized.dropFirst(prefix.count))
+        let candidates = Set(candidateRelativePaths(extensionId: extensionId).map { $0.lowercased() })
+        return candidates.contains(relative.lowercased())
+    }
+
+    /// Home personalization leftovers: `~/.token` or `~/.config/token` only.
+    static func isHomePersonalizationPath(_ url: URL, homeDirectory: URL) -> Bool {
+        let normalized = (url.path as NSString).standardizingPath
+        let home = (homeDirectory.path as NSString).standardizingPath
+        let prefix = home.hasSuffix("/") ? home : home + "/"
+        guard normalized.hasPrefix(prefix) else { return false }
+        let relative = String(normalized.dropFirst(prefix.count))
+        let parts = relative.split(separator: "/").map(String.init)
+        if parts.count == 1, parts[0].hasPrefix("."), parts[0] != ".config" {
+            return true
+        }
+        if parts.count == 2, parts[0] == ".config", !parts[1].isEmpty {
+            return true
+        }
+        return false
+    }
+
+    static func defaultSelectedPaths(from urls: [URL], homeDirectory: URL) -> Set<URL> {
+        Set(urls.filter { !isHomePersonalizationPath($0, homeDirectory: homeDirectory) })
+    }
+
+    /// Existing home leftovers for an extensionId (existence-checked).
+    static func existingPaths(
+        extensionId: String,
+        homeDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> [URL] {
+        var urls: [URL] = []
+        for relative in candidateRelativePaths(extensionId: extensionId) {
+            let url = homeDirectory.appendingPathComponent(relative, isDirectory: true)
+            var isDir: ObjCBool = false
+            // Also accept files (rare) at the same relative path.
+            if fileManager.fileExists(atPath: url.path, isDirectory: &isDir) {
+                if isBlockedExactHomePath(
+                    (url.path as NSString).standardizingPath,
+                    home: (homeDirectory.path as NSString).standardizingPath
+                ) {
+                    continue
+                }
+                urls.append(url)
+            }
+        }
+        return urls
+    }
+
+    private static func splitExtensionId(_ extensionId: String) -> (String, String)? {
+        let parts = extensionId.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: false)
+        guard parts.count == 2 else { return nil }
+        let publisher = String(parts[0])
+        let name = String(parts[1])
+        guard !publisher.isEmpty, !name.isEmpty else { return nil }
+        return (publisher, name)
+    }
+
+    private static func isAllowedName(_ name: String) -> Bool {
+        name.count >= minTokenLength && !deniedNames.contains(name)
+    }
+
+    private static func isAllowedPublisher(_ publisher: String) -> Bool {
+        publisher.count >= minTokenLength && !deniedPublishers.contains(publisher)
+    }
+
+    private static func isBlockedExactHomePath(_ normalized: String, home: String) -> Bool {
+        let blockedExact: Set<String> = [
+            "\(home)/.config",
+            "\(home)/.ssh",
+            "\(home)/.aws",
+            "\(home)/.gnupg",
+            "\(home)/.docker",
+            "\(home)/.git",
+            "\(home)/.claude",
+            "\(home)/.vscode",
+            "\(home)/.local",
+            "\(home)/.npm",
+            "\(home)/.cache",
+        ]
+        return blockedExact.contains(normalized)
+    }
+}

--- a/PureMac/Logic/Scanning/VSCodeExtensionLeftoverFinder.swift
+++ b/PureMac/Logic/Scanning/VSCodeExtensionLeftoverFinder.swift
@@ -1,0 +1,210 @@
+import Foundation
+
+/// Finds leftover paths for a VS Code–family extension (install + storage/cache).
+enum VSCodeExtensionLeftoverFinder {
+    static func findRelatedPaths(
+        for item: VSCodeExtensionItem,
+        homeDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> [URL] {
+        var urls: [URL] = []
+        let install = URL(fileURLWithPath: item.path)
+        if fileManager.fileExists(atPath: install.path) {
+            urls.append(install)
+        }
+
+        let supports = AppSupportResolver.resolve(
+            editorDotDirectory: item.editorDotDirectory,
+            homeDirectory: homeDirectory,
+            fileManager: fileManager
+        )
+        let id = item.extensionId
+        let idLower = id.lowercased()
+
+        for support in supports {
+            let globalRoot = support
+                .appendingPathComponent("User", isDirectory: true)
+                .appendingPathComponent("globalStorage", isDirectory: true)
+            if let match = childDirectory(namedLike: id, under: globalRoot, fileManager: fileManager) {
+                urls.append(match)
+            }
+
+            let workspaceRoot = support
+                .appendingPathComponent("User", isDirectory: true)
+                .appendingPathComponent("workspaceStorage", isDirectory: true)
+            if let hashes = try? fileManager.contentsOfDirectory(
+                at: workspaceRoot,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            ) {
+                for hashDir in hashes {
+                    let values = try? hashDir.resourceValues(forKeys: [.isDirectoryKey])
+                    guard values?.isDirectory == true else { continue }
+                    if let match = childDirectory(namedLike: id, under: hashDir, fileManager: fileManager) {
+                        urls.append(match)
+                    }
+                }
+            }
+
+            let vsixRoot = support.appendingPathComponent("CachedExtensionVSIXs", isDirectory: true)
+            if let vsixChildren = try? fileManager.contentsOfDirectory(
+                at: vsixRoot,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            ) {
+                for child in vsixChildren {
+                    let name = child.lastPathComponent
+                    if name.lowercased().hasPrefix(idLower + "-") || name.lowercased() == idLower {
+                        urls.append(child)
+                    }
+                }
+            }
+        }
+
+        urls.append(contentsOf: VSCodeExtensionHomePathRules.existingPaths(
+            extensionId: id,
+            homeDirectory: homeDirectory,
+            fileManager: fileManager
+        ))
+
+        // Deduplicate by standardized path.
+        var seen = Set<String>()
+        return urls.filter { url in
+            let key = (url.path as NSString).standardizingPath
+            return seen.insert(key).inserted
+        }
+    }
+
+    /// Infers extensionId from a related-path shape, then applies the typed check.
+    static func isSafeRelatedPath(_ path: String, homeDirectoryPath: String) -> Bool {
+        let normalized = (path as NSString).standardizingPath
+        let home = (homeDirectoryPath as NSString).standardizingPath
+        let prefix = home.hasSuffix("/") ? home : home + "/"
+        guard normalized.hasPrefix(prefix) else { return false }
+        let relative = String(normalized.dropFirst(prefix.count))
+        let parts = relative.split(separator: "/").map(String.init)
+
+        // Home personalization: require a concrete extensionId association.
+        // Path-only CleaningEngine checks cannot safely infer id from `~/.foo`,
+        // so those deletions go through the typed API / UI selection only —
+        // except we still accept App Support shapes below.
+        if VSCodeExtensionHomePathRules.isHomePersonalizationPath(
+            URL(fileURLWithPath: normalized),
+            homeDirectory: URL(fileURLWithPath: home, isDirectory: true)
+        ) {
+            return false
+        }
+
+        guard parts.count >= 4,
+              parts[0] == "Library",
+              parts[1] == "Application Support"
+        else {
+            return false
+        }
+        let extensionId: String?
+        if parts.count >= 6, parts[3] == "User", parts[4] == "globalStorage" {
+            extensionId = parts[5]
+        } else if parts.count >= 7, parts[3] == "User", parts[4] == "workspaceStorage" {
+            extensionId = parts[6]
+        } else if parts.count >= 5, parts[3] == "CachedExtensionVSIXs" {
+            extensionId = vsixExtensionId(fromFileName: parts[4])
+        } else {
+            extensionId = nil
+        }
+        guard let extensionId, !extensionId.isEmpty else { return false }
+        return isSafeRelatedPath(normalized, extensionId: extensionId, homeDirectoryPath: home)
+    }
+
+    private static func vsixExtensionId(fromFileName name: String) -> String? {
+        // publisher.name-1.2.3[-platform] → publisher.name
+        guard let match = name.range(
+            of: #"^[A-Za-z0-9][A-Za-z0-9\-]*\.[A-Za-z0-9][A-Za-z0-9\-_.]*"#,
+            options: .regularExpression
+        ) else {
+            return nil
+        }
+        return String(name[match])
+    }
+
+    /// Safety gate for related leftovers (not the install dir — that uses
+    /// `VSCodeExtensionScanner.isSafeDeletePath`).
+    static func isSafeRelatedPath(
+        _ path: String,
+        extensionId: String,
+        homeDirectoryPath: String
+    ) -> Bool {
+        let normalized = (path as NSString).standardizingPath
+        let home = (homeDirectoryPath as NSString).standardizingPath
+        let prefix = home.hasSuffix("/") ? home : home + "/"
+        guard normalized.hasPrefix(prefix) else { return false }
+
+        if VSCodeExtensionHomePathRules.isAssociated(
+            path: normalized,
+            extensionId: extensionId,
+            homeDirectoryPath: home
+        ) {
+            return true
+        }
+
+        let relative = String(normalized.dropFirst(prefix.count))
+        let parts = relative.split(separator: "/").map(String.init)
+        // Library/Application Support/<Editor>/...
+        guard parts.count >= 4,
+              parts[0] == "Library",
+              parts[1] == "Application Support"
+        else {
+            return false
+        }
+
+        let idLower = extensionId.lowercased()
+        // .../User/globalStorage/<id>
+        if parts.count >= 5,
+           parts[3] == "User",
+           parts[4] == "globalStorage",
+           parts.count >= 6,
+           parts[5].lowercased() == idLower
+        {
+            return true
+        }
+        // .../User/workspaceStorage/<hash>/<id>
+        if parts.count >= 7,
+           parts[3] == "User",
+           parts[4] == "workspaceStorage",
+           parts[6].lowercased() == idLower
+        {
+            return true
+        }
+        // .../CachedExtensionVSIXs/<id>-*
+        if parts.count >= 4,
+           parts[3] == "CachedExtensionVSIXs",
+           parts.count >= 5
+        {
+            let name = parts[4].lowercased()
+            return name == idLower || name.hasPrefix(idLower + "-")
+        }
+        return false
+    }
+
+    private static func childDirectory(
+        namedLike extensionId: String,
+        under parent: URL,
+        fileManager: FileManager
+    ) -> URL? {
+        var isDir: ObjCBool = false
+        guard fileManager.fileExists(atPath: parent.path, isDirectory: &isDir), isDir.boolValue else {
+            return nil
+        }
+        let wanted = extensionId.lowercased()
+        guard let children = try? fileManager.contentsOfDirectory(
+            at: parent,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return nil
+        }
+        return children.first { child in
+            let values = try? child.resourceValues(forKeys: [.isDirectoryKey])
+            return values?.isDirectory == true && child.lastPathComponent.lowercased() == wanted
+        }
+    }
+}

--- a/PureMac/Logic/Scanning/VSCodeExtensionListUpdater.swift
+++ b/PureMac/Logic/Scanning/VSCodeExtensionListUpdater.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Incremental list updates after deleting extension-related paths — avoids a
+/// full `~/.*/extensions` rescan (which can take many seconds with hundreds of installs).
+enum VSCodeExtensionListUpdater {
+    struct Result: Equatable {
+        var extensions: [VSCodeExtensionItem]
+        /// Selection after removal: kept item, neighbor when install dir gone, or nil.
+        var selected: VSCodeExtensionItem?
+    }
+
+    static func applyingRemoval(
+        extensions: [VSCodeExtensionItem],
+        selected: VSCodeExtensionItem?,
+        removedPaths: [URL],
+        neighborOrder: [VSCodeExtensionItem]? = nil
+    ) -> Result {
+        let removed = Set(removedPaths.map { ($0.path as NSString).standardizingPath })
+        let remaining = extensions.filter { item in
+            !removed.contains((item.path as NSString).standardizingPath)
+        }
+        let remainingById = Dictionary(uniqueKeysWithValues: remaining.map { ($0.id, $0) })
+
+        guard let selected else {
+            return Result(extensions: remaining, selected: nil)
+        }
+
+        let selectedPath = (selected.path as NSString).standardizingPath
+        if !removed.contains(selectedPath) {
+            return Result(extensions: remaining, selected: remainingById[selected.id] ?? selected)
+        }
+
+        let order = neighborOrder ?? extensions
+        let next = neighbor(
+            of: selected.id,
+            in: order,
+            remainingIds: Set(remainingById.keys)
+        ).flatMap { remainingById[$0] }
+
+        return Result(extensions: remaining, selected: next)
+    }
+
+    /// Prefer the next row in display order; if none, the previous row.
+    private static func neighbor(
+        of selectedId: VSCodeExtensionItem.ID,
+        in order: [VSCodeExtensionItem],
+        remainingIds: Set<VSCodeExtensionItem.ID>
+    ) -> VSCodeExtensionItem.ID? {
+        guard let idx = order.firstIndex(where: { $0.id == selectedId }) else {
+            return order.first(where: { remainingIds.contains($0.id) })?.id
+        }
+        if let after = order[(idx + 1)...].first(where: { remainingIds.contains($0.id) }) {
+            return after.id
+        }
+        return order[..<idx].last(where: { remainingIds.contains($0.id) })?.id
+    }
+}

--- a/PureMac/Logic/Scanning/VSCodeExtensionScanner.swift
+++ b/PureMac/Logic/Scanning/VSCodeExtensionScanner.swift
@@ -1,0 +1,186 @@
+import Foundation
+
+/// Discovered VS Code–family extension folder (one marketplace install).
+struct VSCodeExtensionItem: Equatable, Identifiable {
+    var id: String { path }
+    let editorLabel: String
+    let displayName: String
+    let path: String
+    let size: Int64
+    let lastModified: Date?
+    let extensionId: String
+    let editorDotDirectory: String
+
+    var listName: String { "\(editorLabel) · \(displayName)" }
+}
+
+/// Discovers VS Code–compatible extensions under `~/.*/extensions` without a
+/// hardcoded editor allow-list.
+///
+/// Unified rule:
+/// - Editor root shape: `~/.{name}/extensions/{extensionFolder}`
+/// - Extension folder is included only when its `package.json` declares
+///   `engines.vscode` (the VS Code compatibility marker used by forks).
+enum VSCodeExtensionScanner {
+    static func scan(
+        homeDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> [VSCodeExtensionItem] {
+        scanDotDirectories(homeDirectory: homeDirectory, fileManager: fileManager)
+    }
+
+    /// True when `path` is inside `~/.{editor}/extensions/{ext}/…` and that
+    /// extension folder's `package.json` declares `engines.vscode`.
+    static func isSafeDeletePath(_ path: String, homeDirectoryPath: String) -> Bool {
+        let normalized = (path as NSString).standardizingPath
+        let home = (homeDirectoryPath as NSString).standardizingPath
+        let homePrefix = home.hasSuffix("/") ? home : home + "/"
+        guard normalized.hasPrefix(homePrefix) else { return false }
+
+        let relative = String(normalized.dropFirst(homePrefix.count))
+        let parts = relative.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+        guard parts.count >= 3,
+              parts[0].hasPrefix("."),
+              parts[0] != ".",
+              parts[0] != "..",
+              !parts[0].contains(".."),
+              parts[1] == "extensions",
+              !parts[2].isEmpty,
+              !parts[2].hasPrefix(".")
+        else {
+            return false
+        }
+
+        let extensionDir = [parts[0], "extensions", parts[2]].reduce(home) { partial, component in
+            (partial as NSString).appendingPathComponent(component)
+        }
+        return hasVSCodeEngine(packageJSONAt: URL(fileURLWithPath: extensionDir).appendingPathComponent("package.json"))
+    }
+
+    // MARK: - Private
+
+    private static func scanDotDirectories(
+        homeDirectory: URL,
+        fileManager: FileManager
+    ) -> [VSCodeExtensionItem] {
+        guard let homeContents = try? fileManager.contentsOfDirectory(
+            at: homeDirectory,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: []
+        ) else {
+            return []
+        }
+
+        var items: [VSCodeExtensionItem] = []
+        for entry in homeContents {
+            let name = entry.lastPathComponent
+            guard name.hasPrefix("."), name != ".", name != ".." else { continue }
+            let values = try? entry.resourceValues(forKeys: [.isDirectoryKey])
+            guard values?.isDirectory == true else { continue }
+
+            let extensionsRoot = entry.appendingPathComponent("extensions", isDirectory: true)
+            var isDir: ObjCBool = false
+            guard fileManager.fileExists(atPath: extensionsRoot.path, isDirectory: &isDir),
+                  isDir.boolValue
+            else {
+                continue
+            }
+
+            let editorLabel = editorLabel(fromDotDirectory: name)
+            guard let children = try? fileManager.contentsOfDirectory(
+                at: extensionsRoot,
+                includingPropertiesForKeys: [.isDirectoryKey, .contentModificationDateKey],
+                options: [.skipsHiddenFiles]
+            ) else {
+                continue
+            }
+
+            for child in children {
+                let childValues = try? child.resourceValues(forKeys: [.isDirectoryKey, .contentModificationDateKey])
+                guard childValues?.isDirectory == true else { continue }
+                if child.lastPathComponent.hasPrefix(".") { continue }
+                let packageURL = child.appendingPathComponent("package.json")
+                guard let meta = readExtensionMetadata(from: packageURL), meta.hasVSCodeEngine else {
+                    continue
+                }
+                let size = FileSizeCalculator.size(of: child) ?? 0
+                items.append(
+                    VSCodeExtensionItem(
+                        editorLabel: editorLabel,
+                        displayName: meta.displayName,
+                        path: (child.path as NSString).standardizingPath,
+                        size: size,
+                        lastModified: childValues?.contentModificationDate,
+                        extensionId: meta.extensionId,
+                        editorDotDirectory: name
+                    )
+                )
+            }
+        }
+        return items.sorted { $0.size > $1.size }
+    }
+
+    static func editorLabel(fromDotDirectory name: String) -> String {
+        let trimmed = name.hasPrefix(".") ? String(name.dropFirst()) : name
+        return trimmed
+            .split(separator: "-")
+            .map { part -> String in
+                guard let first = part.first else { return "" }
+                return String(first).uppercased() + part.dropFirst()
+            }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    private struct ExtensionMetadata {
+        let displayName: String
+        let extensionId: String
+        let hasVSCodeEngine: Bool
+    }
+
+    private static func readExtensionMetadata(from packageURL: URL) -> ExtensionMetadata? {
+        guard let data = try? Data(contentsOf: packageURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+        let displayName: String
+        if let name = json["displayName"] as? String, !name.isEmpty {
+            displayName = name
+        } else if let name = json["name"] as? String, !name.isEmpty {
+            displayName = name
+        } else {
+            displayName = packageURL.deletingLastPathComponent().lastPathComponent
+        }
+        let publisher = (json["publisher"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let name = (json["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let extensionId: String
+        if !publisher.isEmpty, !name.isEmpty {
+            extensionId = "\(publisher).\(name)"
+        } else {
+            // Fallback: strip version suffix from folder name best-effort.
+            extensionId = packageURL.deletingLastPathComponent().lastPathComponent
+        }
+        return ExtensionMetadata(
+            displayName: displayName,
+            extensionId: extensionId,
+            hasVSCodeEngine: hasVSCodeEngine(in: json)
+        )
+    }
+
+    private static func hasVSCodeEngine(packageJSONAt url: URL) -> Bool {
+        guard let data = try? Data(contentsOf: url),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return false
+        }
+        return hasVSCodeEngine(in: json)
+    }
+
+    private static func hasVSCodeEngine(in json: [String: Any]) -> Bool {
+        guard let engines = json["engines"] as? [String: Any] else { return false }
+        if let value = engines["vscode"] as? String, !value.isEmpty { return true }
+        // Some manifests use a non-string placeholder; presence is enough.
+        return engines["vscode"] != nil
+    }
+}

--- a/PureMac/Logic/Scanning/VSCodeExtensionsIndexPruner.swift
+++ b/PureMac/Logic/Scanning/VSCodeExtensionsIndexPruner.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+enum VSCodeExtensionsIndexPruner {
+    /// Best-effort: drop entries from `extensions.json` whose install folder was removed.
+    static func pruneIndexes(afterRemoving paths: [URL], fileManager: FileManager = .default) {
+        let removedFolders = Set(paths.map { ($0.path as NSString).standardizingPath })
+        guard !removedFolders.isEmpty else { return }
+
+        var indexDirs = Set<URL>()
+        for path in removedFolders {
+            let url = URL(fileURLWithPath: path)
+            // .../extensions/<folder> → .../extensions
+            let parent = url.deletingLastPathComponent()
+            if parent.lastPathComponent == "extensions" {
+                indexDirs.insert(parent)
+            }
+        }
+
+        for dir in indexDirs {
+            let indexURL = dir.appendingPathComponent("extensions.json")
+            guard fileManager.fileExists(atPath: indexURL.path),
+                  let data = try? Data(contentsOf: indexURL),
+                  var list = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+            else {
+                continue
+            }
+            let before = list.count
+            list.removeAll { entry in
+                let relative = (entry["relativeLocation"] as? String)
+                    ?? (entry["location"] as? [String: Any])?["path"] as? String
+                guard let relative, !relative.isEmpty else { return false }
+                let absolute = (dir.appendingPathComponent(relative).path as NSString).standardizingPath
+                return removedFolders.contains(absolute)
+            }
+            guard list.count != before,
+                  let out = try? JSONSerialization.data(withJSONObject: list, options: [.prettyPrinted])
+            else {
+                continue
+            }
+            try? out.write(to: indexURL, options: .atomic)
+        }
+    }
+}

--- a/PureMac/Models/Models.swift
+++ b/PureMac/Models/Models.swift
@@ -15,6 +15,7 @@ enum CleaningCategory: String, CaseIterable, Identifiable, Codable {
     case brewCache = "Brew Cache"
     case nodeCache = "Node Cache"
     case dockerCache = "Docker Cache"
+    case vsCodeExtensions = "VS Code Extensions"
     case universalBinaries = "Universal Binaries"
     case languageFiles = "Language Files"
 
@@ -34,6 +35,7 @@ enum CleaningCategory: String, CaseIterable, Identifiable, Codable {
         case .brewCache: return "mug.fill"
         case .nodeCache: return "leaf.fill"
         case .dockerCache: return "shippingbox.fill"
+        case .vsCodeExtensions: return "puzzlepiece.extension"
         case .universalBinaries: return "cpu"
         case .languageFiles: return "globe"
         }
@@ -53,6 +55,7 @@ enum CleaningCategory: String, CaseIterable, Identifiable, Codable {
         case .brewCache: return "Homebrew download cache"
         case .nodeCache: return "npm, yarn, and pnpm download caches"
         case .dockerCache: return "Docker images, containers, and build cache"
+        case .vsCodeExtensions: return "Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)"
         case .universalBinaries: return "Unused CPU architecture slices in app binaries"
         case .languageFiles: return "Unused app localizations"
         }
@@ -72,6 +75,7 @@ enum CleaningCategory: String, CaseIterable, Identifiable, Codable {
         case .brewCache: return .mint
         case .nodeCache: return .pink
         case .dockerCache: return .indigo
+        case .vsCodeExtensions: return .brown
         case .universalBinaries: return .brown
         case .languageFiles: return .gray
         }

--- a/PureMac/Services/CleaningEngine.swift
+++ b/PureMac/Services/CleaningEngine.swift
@@ -472,6 +472,13 @@ actor CleaningEngine {
 
     // MARK: - Helpers
 
+    /// Same allow-list gate used by `cleanItems` (after symlink resolution).
+    /// Exposed for unit tests covering category-specific roots (e.g. VS Code extensions).
+    func isAllowedCleanupPath(_ path: String) -> Bool {
+        let resolved = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
+        return isSafeToDelete(resolvedPath: resolved)
+    }
+
     /// Validates that a resolved path is safe to delete.
     /// Prevents symlink attacks where a link in ~/Library/Caches points to ~/.ssh.
     /// Downloads, Documents, and Desktop are intentionally NOT whole-subtree
@@ -541,6 +548,11 @@ actor CleaningEngine {
         // sits strictly inside one. The trailing "/" on the prefix match
         // prevents siblings like "/tmpfoo" from sneaking past "/tmp".
         let normalized = (resolvedPath as NSString).standardizingPath
+        if VSCodeExtensionScanner.isSafeDeletePath(normalized, homeDirectoryPath: home)
+            || VSCodeExtensionLeftoverFinder.isSafeRelatedPath(normalized, homeDirectoryPath: home)
+        {
+            return true
+        }
         return allowedRoots.contains { root in
             if normalized == root { return true }
             let rootWithSeparator = root.hasSuffix("/") ? root : root + "/"

--- a/PureMac/Services/ScanEngine.swift
+++ b/PureMac/Services/ScanEngine.swift
@@ -67,6 +67,8 @@ actor ScanEngine {
             return scanNodeCache()
         case .dockerCache:
             return scanDockerCache()
+        case .vsCodeExtensions:
+            return scanVSCodeExtensions()
         case .universalBinaries:
             return scanUniversalBinaries()
         case .languageFiles:
@@ -791,6 +793,24 @@ actor ScanEngine {
 
         let totalSize = items.reduce(0) { $0 + $1.size }
         return CategoryResult(category: .dockerCache, items: items, totalSize: totalSize)
+    }
+
+    private func scanVSCodeExtensions() -> CategoryResult {
+        let home = fileManager.homeDirectoryForCurrentUser
+        let discovered = VSCodeExtensionScanner.scan(homeDirectory: home, fileManager: fileManager)
+        let items = discovered.map { ext in
+            report(ext.path)
+            return CleanableItem(
+                name: ext.listName,
+                path: ext.path,
+                size: ext.size,
+                category: .vsCodeExtensions,
+                isSelected: false,
+                lastModified: ext.lastModified
+            )
+        }
+        let totalSize = items.reduce(0) { $0 + $1.size }
+        return CategoryResult(category: .vsCodeExtensions, items: items, totalSize: totalSize)
     }
 
     private func scanUniversalBinaries() -> CategoryResult {

--- a/PureMac/ViewModels/AppState.swift
+++ b/PureMac/ViewModels/AppState.swift
@@ -103,6 +103,15 @@ final class AppState: ObservableObject {
     /// still showing) is still surfaced — a one-shot token would be missed.
     @Published var pendingExternalApp: InstalledApp?
 
+    // MARK: - VS Code Extension Uninstaller State
+
+    @Published var vscodeExtensions: [VSCodeExtensionItem] = []
+    @Published var selectedVSCodeExtension: VSCodeExtensionItem?
+    @Published var extensionRelatedFiles: [URL] = []
+    @Published var selectedExtensionRelatedFiles: Set<URL> = []
+    @Published var isLoadingVSCodeExtensions = false
+    @Published var isScanningExtensionRelatedFiles = false
+
     private var externalUninstallObserver: AnyCancellable?
 
     // MARK: - Services
@@ -143,10 +152,12 @@ final class AppState: ObservableObject {
     init(
         performStartupTasks: Bool = true,
         locationsProvider: @escaping () -> Locations = Locations.init,
-        appFileScanner: @escaping AppFileScanner = AppState.defaultAppFileScanner
+        // Default arg evaluation is nonisolated on Xcode 16.1; resolve MainActor
+        // scanner in the body instead of `= AppState.defaultAppFileScanner`.
+        appFileScanner: AppFileScanner? = nil
     ) {
         self.locationsProvider = locationsProvider
-        self.appFileScanner = appFileScanner
+        self.appFileScanner = appFileScanner ?? AppState.defaultAppFileScanner
 
         // Listen for right-click "Uninstall with PureMac" hand-offs from the
         // Finder Services handler in AppDelegate.
@@ -241,6 +252,106 @@ final class AppState: ObservableObject {
             self.selectedFiles = urls
             self.isScanningAppFiles = false
             self.appFileScanLocationCount = 0
+        }
+    }
+
+    func loadVSCodeExtensions() {
+        isLoadingVSCodeExtensions = true
+        selectedVSCodeExtension = nil
+        extensionRelatedFiles = []
+        selectedExtensionRelatedFiles = []
+        Task {
+            let items = await Task.detached(priority: .userInitiated) {
+                VSCodeExtensionScanner.scan(
+                    homeDirectory: FileManager.default.homeDirectoryForCurrentUser
+                )
+            }.value
+            vscodeExtensions = items
+            isLoadingVSCodeExtensions = false
+        }
+    }
+
+    func scanExtensionRelatedFiles(_ item: VSCodeExtensionItem) {
+        selectedVSCodeExtension = item
+        extensionRelatedFiles = []
+        selectedExtensionRelatedFiles = []
+        isScanningExtensionRelatedFiles = true
+        Task {
+            let home = FileManager.default.homeDirectoryForCurrentUser
+            let urls = await Task.detached(priority: .userInitiated) {
+                VSCodeExtensionLeftoverFinder.findRelatedPaths(
+                    for: item,
+                    homeDirectory: home
+                )
+                .sorted { $0.path < $1.path }
+            }.value
+            extensionRelatedFiles = urls
+            // Home personalization (~/.continue, ~/.config/github-copilot, …)
+            // is listed but default-unchecked — user must opt in.
+            selectedExtensionRelatedFiles = VSCodeExtensionHomePathRules.defaultSelectedPaths(
+                from: urls,
+                homeDirectory: home
+            )
+            isScanningExtensionRelatedFiles = false
+        }
+    }
+
+    func removeSelectedExtensionRelatedFiles(
+        displayOrder: [VSCodeExtensionItem]? = nil
+    ) {
+        guard let item = selectedVSCodeExtension else { return }
+        let homePath = FileManager.default.homeDirectoryForCurrentUser.path
+        let urls = Array(selectedExtensionRelatedFiles).filter { url in
+            let path = (url.path as NSString).standardizingPath
+            return VSCodeExtensionScanner.isSafeDeletePath(path, homeDirectoryPath: homePath)
+                || VSCodeExtensionLeftoverFinder.isSafeRelatedPath(
+                    path,
+                    extensionId: item.extensionId,
+                    homeDirectoryPath: homePath
+                )
+        }
+        guard !urls.isEmpty else { return }
+        let neighborOrder = displayOrder
+        trashDirectly(urls: urls) { [weak self] removed, needsFullDiskAccess, needsAdmin, failed in
+            Task { @MainActor in
+                guard let self else { return }
+                if !removed.isEmpty {
+                    if NSWorkspace.shared.accessibilityDisplayShouldReduceMotion {
+                        self.extensionRelatedFiles.removeAll { removed.contains($0) }
+                    } else {
+                        withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+                            self.extensionRelatedFiles.removeAll { removed.contains($0) }
+                        }
+                    }
+                    self.selectedExtensionRelatedFiles.subtract(removed)
+                    VSCodeExtensionsIndexPruner.pruneIndexes(afterRemoving: removed)
+                    // Incremental list update — do not full-rescan ~/.*/extensions.
+                    let previousId = self.selectedVSCodeExtension?.id
+                    let update = VSCodeExtensionListUpdater.applyingRemoval(
+                        extensions: self.vscodeExtensions,
+                        selected: self.selectedVSCodeExtension,
+                        removedPaths: removed,
+                        neighborOrder: neighborOrder
+                    )
+                    self.vscodeExtensions = update.extensions
+                    if let next = update.selected {
+                        if next.id != previousId {
+                            // Install dir gone — advance to next/previous in display order.
+                            self.scanExtensionRelatedFiles(next)
+                        }
+                    } else {
+                        self.selectedVSCodeExtension = nil
+                        self.extensionRelatedFiles = []
+                        self.selectedExtensionRelatedFiles = []
+                    }
+                }
+                if needsFullDiskAccess || !needsAdmin.isEmpty || !failed.isEmpty {
+                    self.removalError = needsFullDiskAccess
+                        ? String(localized: "Full Disk Access is required to remove some extension files.")
+                        : String(localized: "Some extension files could not be removed.")
+                    self.removalNeedsFullDiskAccess = needsFullDiskAccess
+                }
+            }
         }
     }
 

--- a/PureMac/Views/DashboardView.swift
+++ b/PureMac/Views/DashboardView.swift
@@ -444,7 +444,7 @@ struct DashboardView: View {
     }
 
     private var developerCleanupCategories: [CleaningCategory] {
-        [.aiApps, .xcodeJunk, .brewCache, .nodeCache, .dockerCache]
+        [.aiApps, .xcodeJunk, .brewCache, .nodeCache, .dockerCache, .vsCodeExtensions]
             .filter(CleaningCategory.scannable.contains)
     }
 

--- a/PureMac/Views/Extensions/ExtensionListView.swift
+++ b/PureMac/Views/Extensions/ExtensionListView.swift
@@ -1,0 +1,329 @@
+import SwiftUI
+
+private enum ExtensionLeftoverGroup: String, CaseIterable, Identifiable {
+    case extensionInstall = "Extension"
+    case globalStorage = "Global Storage"
+    case workspaceStorage = "Workspace Storage"
+    case vsixCache = "VSIX Cache"
+    case homePersonalization = "Home Personalization"
+    case other = "Other Files"
+
+    var id: String { rawValue }
+
+    var icon: String {
+        switch self {
+        case .extensionInstall: return "puzzlepiece.extension"
+        case .globalStorage: return "externaldrive.fill"
+        case .workspaceStorage: return "folder.fill"
+        case .vsixCache: return "shippingbox.fill"
+        case .homePersonalization: return "house.fill"
+        case .other: return "doc.fill"
+        }
+    }
+
+    static func categorize(_ url: URL) -> ExtensionLeftoverGroup {
+        let path = url.path
+        if path.contains("/CachedExtensionVSIXs/") { return .vsixCache }
+        if path.contains("/globalStorage/") { return .globalStorage }
+        if path.contains("/workspaceStorage/") { return .workspaceStorage }
+        if path.contains("/extensions/") { return .extensionInstall }
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        if VSCodeExtensionHomePathRules.isHomePersonalizationPath(url, homeDirectory: home) {
+            return .homePersonalization
+        }
+        return .other
+    }
+}
+
+struct ExtensionListView: View {
+    @EnvironmentObject var appState: AppState
+    @State private var searchText = ""
+    @State private var selection: VSCodeExtensionItem.ID?
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var sortOrder: [KeyPathComparator<VSCodeExtensionItem>] = [
+        .init(\.size, order: .reverse)
+    ]
+
+    private var filtered: [VSCodeExtensionItem] {
+        let base: [VSCodeExtensionItem]
+        if searchText.isEmpty {
+            base = appState.vscodeExtensions
+        } else {
+            let q = searchText.lowercased()
+            base = appState.vscodeExtensions.filter {
+                $0.displayName.lowercased().contains(q)
+                    || $0.extensionId.lowercased().contains(q)
+                    || $0.editorLabel.lowercased().contains(q)
+            }
+        }
+        return base.sorted(using: sortOrder)
+    }
+
+    var body: some View {
+        HSplitView {
+            extensionTable
+                .frame(minWidth: 320, idealWidth: 420, maxWidth: 640)
+            fileDetail
+                .frame(minWidth: 300)
+        }
+        .searchable(text: $searchText, prompt: Text(LocalizedStringKey("Search extensions")))
+        .navigationTitle(title)
+        .toolbar {
+            ToolbarItemGroup {
+                Button {
+                    appState.loadVSCodeExtensions()
+                } label: {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                }
+                Button(removeLabel, role: .destructive) {
+                    // Pass current table order so "next" matches what the user sees.
+                    appState.removeSelectedExtensionRelatedFiles(displayOrder: filtered)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.red)
+                .opacity(appState.selectedExtensionRelatedFiles.isEmpty ? 0 : 1)
+                .disabled(appState.selectedExtensionRelatedFiles.isEmpty)
+                .animation(
+                    reduceMotion ? nil : .spring(response: 0.35, dampingFraction: 0.8),
+                    value: appState.selectedExtensionRelatedFiles.isEmpty
+                )
+            }
+        }
+        .onAppear {
+            if appState.vscodeExtensions.isEmpty && !appState.isLoadingVSCodeExtensions {
+                appState.loadVSCodeExtensions()
+            }
+        }
+    }
+
+    private var title: String {
+        String(
+            format: String(localized: "VS Code Extensions (%lld)"),
+            Int64(appState.vscodeExtensions.count)
+        )
+    }
+
+    private var removeLabel: String {
+        String(
+            format: String(localized: "Remove (%lld files)"),
+            Int64(appState.selectedExtensionRelatedFiles.count)
+        )
+    }
+
+    private var extensionTable: some View {
+        Group {
+            if appState.isLoadingVSCodeExtensions {
+                ProgressView(LocalizedStringKey("Loading extensions..."))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if appState.vscodeExtensions.isEmpty {
+                EmptyStateView(
+                    "No Extensions Found",
+                    systemImage: "puzzlepiece.extension",
+                    description: "No VS Code–family extensions with engines.vscode were found under ~/.*/extensions.",
+                    action: { appState.loadVSCodeExtensions() },
+                    actionLabel: "Retry"
+                )
+            } else {
+                Table(filtered, selection: $selection, sortOrder: $sortOrder) {
+                    TableColumn("Extension", value: \.displayName) { item in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(item.displayName)
+                            Text(item.extensionId)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .width(min: 160)
+                    TableColumn("Editor", value: \.editorLabel) { item in
+                        Text(item.editorLabel)
+                            .foregroundStyle(.secondary)
+                    }
+                    .width(ideal: 100)
+                    TableColumn("Size", value: \.size) { item in
+                        Text(ByteCountFormatter.string(fromByteCount: item.size, countStyle: .file))
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                    }
+                    .width(ideal: 80)
+                }
+                .onChange(of: selection) { newValue in
+                    guard let id = newValue,
+                          let item = appState.vscodeExtensions.first(where: { $0.id == id })
+                    else { return }
+                    guard appState.selectedVSCodeExtension?.id != item.id else { return }
+                    appState.scanExtensionRelatedFiles(item)
+                }
+                .onChange(of: appState.selectedVSCodeExtension) { item in
+                    if selection != item?.id { selection = item?.id }
+                }
+                .onChange(of: appState.vscodeExtensions) { items in
+                    if let id = selection, !items.contains(where: { $0.id == id }) {
+                        // Prefer AppState's advanced selection (next/previous) over clearing.
+                        selection = appState.selectedVSCodeExtension?.id
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var fileDetail: some View {
+        if let item = appState.selectedVSCodeExtension {
+            ExtensionFilesView(item: item)
+        } else {
+            EmptyStateView(
+                "Select an Extension",
+                systemImage: "cursorarrow.click.2",
+                description: "Select an extension to review its install folder and related storage/cache files.",
+                tint: Tint.purple
+            )
+        }
+    }
+}
+
+struct ExtensionFilesView: View {
+    @EnvironmentObject var appState: AppState
+    let item: VSCodeExtensionItem
+    @State private var collapsed: Set<ExtensionLeftoverGroup> = []
+    @State private var sizeCache: [URL: Int64] = [:]
+
+    private var grouped: [(ExtensionLeftoverGroup, [URL])] {
+        let buckets = Dictionary(grouping: appState.extensionRelatedFiles, by: ExtensionLeftoverGroup.categorize)
+        return ExtensionLeftoverGroup.allCases.compactMap { group in
+            guard let urls = buckets[group], !urls.isEmpty else { return nil }
+            return (group, urls)
+        }
+    }
+
+    private var selectedTotalSize: Int64 {
+        appState.selectedExtensionRelatedFiles.reduce(Int64(0)) { total, url in
+            total + (sizeCache[url] ?? FileSizeCalculator.size(of: url) ?? 0)
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider()
+            if appState.isScanningExtensionRelatedFiles {
+                ProgressView(LocalizedStringKey("Scanning related files..."))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if appState.extensionRelatedFiles.isEmpty {
+                EmptyStateView(
+                    "No Related Files",
+                    systemImage: "checkmark.circle",
+                    description: "Only the install directory was expected; nothing else matched for this extension."
+                )
+            } else {
+                List {
+                    ForEach(grouped, id: \.0.id) { group, urls in
+                        Section {
+                            if !collapsed.contains(group) {
+                                ForEach(urls, id: \.path) { url in
+                                    row(url)
+                                }
+                            }
+                        } header: {
+                            HStack {
+                                Label(LocalizedStringKey(group.rawValue), systemImage: group.icon)
+                                Spacer()
+                                Text(groupSizeText(urls))
+                                    .foregroundStyle(.secondary)
+                                    .monospacedDigit()
+                                Text("\(urls.count)")
+                                    .foregroundStyle(.secondary)
+                                Button {
+                                    if collapsed.contains(group) {
+                                        collapsed.remove(group)
+                                    } else {
+                                        collapsed.insert(group)
+                                    }
+                                } label: {
+                                    Image(systemName: collapsed.contains(group) ? "chevron.right" : "chevron.down")
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+                }
+                .listStyle(.inset)
+            }
+        }
+        .onAppear { rebuildSizeCache() }
+        .onChange(of: appState.extensionRelatedFiles) { _ in rebuildSizeCache() }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(item.displayName)
+                .font(.title2.weight(.semibold))
+            Text("\(item.editorLabel) · \(item.extensionId)")
+                .foregroundStyle(.secondary)
+            HStack {
+                Button(String(localized: "Select All")) {
+                    appState.selectedExtensionRelatedFiles = Set(appState.extensionRelatedFiles)
+                }
+                Button(String(localized: "Select None")) {
+                    appState.selectedExtensionRelatedFiles = []
+                }
+                Spacer()
+                Text(selectedSummaryText)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            .buttonStyle(.borderless)
+        }
+        .padding()
+    }
+
+    private var selectedSummaryText: String {
+        let count = "\(appState.selectedExtensionRelatedFiles.count)/\(appState.extensionRelatedFiles.count)"
+        let size = ByteCountFormatter.string(fromByteCount: selectedTotalSize, countStyle: .file)
+        return "\(count) · \(size)"
+    }
+
+    private func groupSizeText(_ urls: [URL]) -> String {
+        let total = urls.reduce(Int64(0)) { partial, url in
+            partial + (sizeCache[url] ?? 0)
+        }
+        return ByteCountFormatter.string(fromByteCount: total, countStyle: .file)
+    }
+
+    private func row(_ url: URL) -> some View {
+        let selected = appState.selectedExtensionRelatedFiles.contains(url)
+        let size = sizeCache[url] ?? 0
+        return Toggle(isOn: Binding(
+            get: { selected },
+            set: { on in
+                if on {
+                    appState.selectedExtensionRelatedFiles.insert(url)
+                } else {
+                    appState.selectedExtensionRelatedFiles.remove(url)
+                }
+            }
+        )) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(url.lastPathComponent)
+                    Text(url.path)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                Spacer(minLength: 8)
+                Text(ByteCountFormatter.string(fromByteCount: size, countStyle: .file))
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .toggleStyle(.checkbox)
+    }
+
+    private func rebuildSizeCache() {
+        var cache: [URL: Int64] = [:]
+        for url in appState.extensionRelatedFiles {
+            cache[url] = FileSizeCalculator.size(of: url) ?? 0
+        }
+        sizeCache = cache
+    }
+}

--- a/PureMac/Views/MainWindow.swift
+++ b/PureMac/Views/MainWindow.swift
@@ -27,6 +27,7 @@ struct MainWindow: View {
         .brewCache,
         .nodeCache,
         .dockerCache,
+        .vsCodeExtensions,
     ].filter(CleaningCategory.scannable.contains)
 
     var body: some View {
@@ -436,6 +437,8 @@ struct MainWindow: View {
         case .cleaning(let category):
             if category == .smartScan {
                 DashboardView { selectSection($0) }
+            } else if category == .vsCodeExtensions {
+                ExtensionListView()
             } else {
                 CategoryDetailView(category: category)
             }

--- a/PureMac/ar.lproj/Localizable.strings
+++ b/PureMac/ar.lproj/Localizable.strings
@@ -231,6 +231,7 @@
 "Brew Cache" = "ذاكرة Brew المؤقتة";
 "Node Cache" = "ذاكرة Node المؤقتة";
 "Docker Cache" = "ذاكرة Docker المؤقتة";
+"VS Code Extensions" = "VS Code Extensions";
 "Universal Binaries" = "الملفات الثنائية المتعددة البنى";
 "Language Files" = "ملفات اللغات";
 
@@ -247,6 +248,7 @@
 "Homebrew download cache" = "ذاكرة تنزيلات Homebrew المؤقتة";
 "npm, yarn, and pnpm download caches" = "ذاكرات تنزيلات npm وyarn وpnpm المؤقتة";
 "Docker images, containers, and build cache" = "صور Docker والحاويات وذاكرة البناء المؤقتة";
+"Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)" = "Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)";
 "Unused CPU architecture slices in app binaries" = "شرائح بنى معالج غير مستخدمة في الملفات الثنائية للتطبيقات";
 "Unused app localizations" = "ترجمات التطبيقات غير المستخدمة";
 
@@ -460,3 +462,18 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "وقت تشغيل المحاكي";
+
+"Search extensions" = "Search extensions";
+"VS Code Extensions (%lld)" = "VS Code Extensions (%lld)";
+"Remove (%lld files)" = "Remove (%lld files)";
+"Loading extensions..." = "Loading extensions...";
+"No Extensions Found" = "No Extensions Found";
+"Select an Extension" = "Select an Extension";
+"Scanning related files..." = "Scanning related files...";
+"Extension" = "Extension";
+"Global Storage" = "Global Storage";
+"Workspace Storage" = "Workspace Storage";
+"VSIX Cache" = "VSIX Cache";
+"Home Personalization" = "بيانات التخصيص في المجلد الرئيسي";
+"Full Disk Access is required to remove some extension files." = "يلزم الوصول الكامل إلى القرص لإزالة بعض ملفات الإضافة.";
+"Some extension files could not be removed." = "تعذّر إزالة بعض ملفات الإضافة.";

--- a/PureMac/en.lproj/Localizable.strings
+++ b/PureMac/en.lproj/Localizable.strings
@@ -272,6 +272,7 @@
 "Brew Cache" = "Brew Cache";
 "Node Cache" = "Node Cache";
 "Docker Cache" = "Docker Cache";
+"VS Code Extensions" = "VS Code Extensions";
 "Universal Binaries" = "Universal Binaries";
 "Language Files" = "Language Files";
 
@@ -288,6 +289,7 @@
 "Homebrew download cache" = "Homebrew download cache";
 "npm, yarn, and pnpm download caches" = "npm, yarn, and pnpm download caches";
 "Docker images, containers, and build cache" = "Docker images, containers, and build cache";
+"Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)" = "Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)";
 "Unused CPU architecture slices in app binaries" = "Unused CPU architecture slices in app binaries";
 "Unused app localizations" = "Unused app localizations";
 
@@ -460,3 +462,18 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "Simulator runtime";
+
+"Search extensions" = "Search extensions";
+"VS Code Extensions (%lld)" = "VS Code Extensions (%lld)";
+"Remove (%lld files)" = "Remove (%lld files)";
+"Loading extensions..." = "Loading extensions...";
+"No Extensions Found" = "No Extensions Found";
+"Select an Extension" = "Select an Extension";
+"Scanning related files..." = "Scanning related files...";
+"Extension" = "Extension";
+"Global Storage" = "Global Storage";
+"Workspace Storage" = "Workspace Storage";
+"VSIX Cache" = "VSIX Cache";
+"Home Personalization" = "Home Personalization";
+"Full Disk Access is required to remove some extension files." = "Full Disk Access is required to remove some extension files.";
+"Some extension files could not be removed." = "Some extension files could not be removed.";

--- a/PureMac/es.lproj/Localizable.strings
+++ b/PureMac/es.lproj/Localizable.strings
@@ -231,6 +231,7 @@
 "Brew Cache" = "Caché de Brew";
 "Node Cache" = "Caché de Node";
 "Docker Cache" = "Caché de Docker";
+"VS Code Extensions" = "VS Code Extensions";
 "Universal Binaries" = "Binarios universales";
 "Language Files" = "Archivos de idioma";
 
@@ -247,6 +248,7 @@
 "Homebrew download cache" = "Caché de descargas de Homebrew";
 "npm, yarn, and pnpm download caches" = "Cachés de descargas de npm, yarn y pnpm";
 "Docker images, containers, and build cache" = "Imágenes, contenedores y caché de compilación de Docker";
+"Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)" = "Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)";
 "Unused CPU architecture slices in app binaries" = "Arquitecturas de CPU sin usar en los binarios de las apps";
 "Unused app localizations" = "Localizaciones de apps sin usar";
 
@@ -460,3 +462,18 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "Runtime del simulador";
+
+"Search extensions" = "Search extensions";
+"VS Code Extensions (%lld)" = "VS Code Extensions (%lld)";
+"Remove (%lld files)" = "Remove (%lld files)";
+"Loading extensions..." = "Loading extensions...";
+"No Extensions Found" = "No Extensions Found";
+"Select an Extension" = "Select an Extension";
+"Scanning related files..." = "Scanning related files...";
+"Extension" = "Extension";
+"Global Storage" = "Global Storage";
+"Workspace Storage" = "Workspace Storage";
+"VSIX Cache" = "VSIX Cache";
+"Home Personalization" = "Personalización del hogar";
+"Full Disk Access is required to remove some extension files." = "Se requiere Acceso completo al disco para eliminar algunos archivos de extensión.";
+"Some extension files could not be removed." = "No se pudieron eliminar algunos archivos de extensión.";

--- a/PureMac/fr.lproj/Localizable.strings
+++ b/PureMac/fr.lproj/Localizable.strings
@@ -456,3 +456,21 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "Runtime de simulateur";
+
+/* VS Code–family extensions cleanup */
+"VS Code Extensions" = "Extensions VS Code";
+"Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)" = "Extensions de la famille VS Code sous ~/.*/extensions (vérifiez avant de supprimer ; quittez l’éditeur d’abord)";
+"Search extensions" = "Rechercher des extensions";
+"VS Code Extensions (%lld)" = "Extensions VS Code (%lld)";
+"Remove (%lld files)" = "Supprimer (%lld fichiers)";
+"Loading extensions..." = "Chargement des extensions…";
+"No Extensions Found" = "Aucune extension trouvée";
+"Select an Extension" = "Sélectionnez une extension";
+"Scanning related files..." = "Analyse des fichiers associés…";
+"Extension" = "Extension";
+"Global Storage" = "Stockage global";
+"Workspace Storage" = "Stockage d’espace de travail";
+"VSIX Cache" = "Cache VSIX";
+"Home Personalization" = "Personnalisation du dossier personnel";
+"Full Disk Access is required to remove some extension files." = "L’accès complet au disque est requis pour supprimer certains fichiers d’extension.";
+"Some extension files could not be removed." = "Certains fichiers d’extension n’ont pas pu être supprimés.";

--- a/PureMac/ja.lproj/Localizable.strings
+++ b/PureMac/ja.lproj/Localizable.strings
@@ -231,6 +231,7 @@
 "Brew Cache" = "Brewキャッシュ";
 "Node Cache" = "Nodeキャッシュ";
 "Docker Cache" = "Dockerキャッシュ";
+"VS Code Extensions" = "VS Code Extensions";
 "Universal Binaries" = "ユニバーサルバイナリ";
 "Language Files" = "言語ファイル";
 
@@ -247,6 +248,7 @@
 "Homebrew download cache" = "Homebrewのダウンロードキャッシュ";
 "npm, yarn, and pnpm download caches" = "npm、yarn、pnpm のダウンロードキャッシュ";
 "Docker images, containers, and build cache" = "Dockerイメージ、コンテナ、ビルドキャッシュ";
+"Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)" = "Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)";
 "Unused CPU architecture slices in app binaries" = "アプリバイナリ内の未使用CPUアーキテクチャコード";
 "Unused app localizations" = "使用されていないアプリのローカライゼーション";
 
@@ -460,3 +462,18 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "シミュレータランタイム";
+
+"Search extensions" = "Search extensions";
+"VS Code Extensions (%lld)" = "VS Code Extensions (%lld)";
+"Remove (%lld files)" = "Remove (%lld files)";
+"Loading extensions..." = "Loading extensions...";
+"No Extensions Found" = "No Extensions Found";
+"Select an Extension" = "Select an Extension";
+"Scanning related files..." = "Scanning related files...";
+"Extension" = "Extension";
+"Global Storage" = "Global Storage";
+"Workspace Storage" = "Workspace Storage";
+"VSIX Cache" = "VSIX Cache";
+"Home Personalization" = "ホームの個人設定";
+"Full Disk Access is required to remove some extension files." = "一部の拡張機能ファイルを削除するにはフルディスクアクセスが必要です。";
+"Some extension files could not be removed." = "一部の拡張機能ファイルを削除できませんでした。";

--- a/PureMac/pl.lproj/Localizable.strings
+++ b/PureMac/pl.lproj/Localizable.strings
@@ -272,6 +272,7 @@
 "Brew Cache" = "Cache Homebrew";
 "Node Cache" = "Cache Node";
 "Docker Cache" = "Cache Dockera";
+"VS Code Extensions" = "VS Code Extensions";
 "Universal Binaries" = "Uniwersalne pliki binarne";
 "Language Files" = "Pliki językowe";
 
@@ -288,6 +289,7 @@
 "Homebrew download cache" = "Cache pobierania Homebrew";
 "npm, yarn, and pnpm download caches" = "Cache pobierania npm, yarn i pnpm";
 "Docker images, containers, and build cache" = "Obrazy Dockera, kontenery i cache budowania";
+"Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)" = "Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)";
 "Unused CPU architecture slices in app binaries" = "Nieużywane architektury CPU w plikach binarnych aplikacji";
 "Unused app localizations" = "Nieużywane lokalizacje aplikacji";
 
@@ -460,3 +462,18 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "Środowisko uruchomieniowe symulatora";
+
+"Search extensions" = "Search extensions";
+"VS Code Extensions (%lld)" = "VS Code Extensions (%lld)";
+"Remove (%lld files)" = "Remove (%lld files)";
+"Loading extensions..." = "Loading extensions...";
+"No Extensions Found" = "No Extensions Found";
+"Select an Extension" = "Select an Extension";
+"Scanning related files..." = "Scanning related files...";
+"Extension" = "Extension";
+"Global Storage" = "Global Storage";
+"Workspace Storage" = "Workspace Storage";
+"VSIX Cache" = "VSIX Cache";
+"Home Personalization" = "Dane personalizacji w katalogu domowym";
+"Full Disk Access is required to remove some extension files." = "Do usunięcia niektórych plików rozszerzeń wymagany jest pełny dostęp do dysku.";
+"Some extension files could not be removed." = "Nie udało się usunąć niektórych plików rozszerzeń.";

--- a/PureMac/pt-BR.lproj/Localizable.strings
+++ b/PureMac/pt-BR.lproj/Localizable.strings
@@ -231,6 +231,7 @@
 "Brew Cache" = "Cache do Brew";
 "Node Cache" = "Cache do Node";
 "Docker Cache" = "Cache do Docker";
+"VS Code Extensions" = "VS Code Extensions";
 "Universal Binaries" = "Binários universais";
 "Language Files" = "Arquivos de idioma";
 
@@ -247,6 +248,7 @@
 "Homebrew download cache" = "Cache de downloads do Homebrew";
 "npm, yarn, and pnpm download caches" = "Caches de download do npm, yarn e pnpm";
 "Docker images, containers, and build cache" = "Imagens, containers e cache de build do Docker";
+"Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)" = "Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)";
 "Unused CPU architecture slices in app binaries" = "Arquiteturas de CPU não usadas nos binários dos apps";
 "Unused app localizations" = "Localizações de apps não usadas";
 
@@ -460,3 +462,18 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "Runtime do simulador";
+
+"Search extensions" = "Search extensions";
+"VS Code Extensions (%lld)" = "VS Code Extensions (%lld)";
+"Remove (%lld files)" = "Remove (%lld files)";
+"Loading extensions..." = "Loading extensions...";
+"No Extensions Found" = "No Extensions Found";
+"Select an Extension" = "Select an Extension";
+"Scanning related files..." = "Scanning related files...";
+"Extension" = "Extension";
+"Global Storage" = "Global Storage";
+"Workspace Storage" = "Workspace Storage";
+"VSIX Cache" = "VSIX Cache";
+"Home Personalization" = "Personalização do diretório home";
+"Full Disk Access is required to remove some extension files." = "É necessário Acesso Total ao Disco para remover alguns arquivos de extensão.";
+"Some extension files could not be removed." = "Alguns arquivos de extensão não puderam ser removidos.";

--- a/PureMac/ru.lproj/Localizable.strings
+++ b/PureMac/ru.lproj/Localizable.strings
@@ -272,6 +272,7 @@
 "Brew Cache" = "Кэш Homebrew";
 "Node Cache" = "Кэш Node.js";
 "Docker Cache" = "Кэш Docker";
+"VS Code Extensions" = "VS Code Extensions";
 "Universal Binaries" = "Универсальные бинарные файлы";
 "Language Files" = "Языковые файлы";
 
@@ -288,6 +289,7 @@
 "Homebrew download cache" = "Кэш загрузок Homebrew";
 "npm, yarn, and pnpm download caches" = "Кэши загрузок npm, yarn и pnpm";
 "Docker images, containers, and build cache" = "Образы и контейнеры Docker, а также кэш сборки";
+"Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)" = "Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)";
 "Unused CPU architecture slices in app binaries" = "Неиспользуемые архитектуры процессора в бинарных файлах приложений";
 "Unused app localizations" = "Неиспользуемые локализации приложений";
 
@@ -460,3 +462,18 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "Среда выполнения симулятора";
+
+"Search extensions" = "Search extensions";
+"VS Code Extensions (%lld)" = "VS Code Extensions (%lld)";
+"Remove (%lld files)" = "Remove (%lld files)";
+"Loading extensions..." = "Loading extensions...";
+"No Extensions Found" = "No Extensions Found";
+"Select an Extension" = "Select an Extension";
+"Scanning related files..." = "Scanning related files...";
+"Extension" = "Extension";
+"Global Storage" = "Global Storage";
+"Workspace Storage" = "Workspace Storage";
+"VSIX Cache" = "VSIX Cache";
+"Home Personalization" = "Персональные данные в домашней папке";
+"Full Disk Access is required to remove some extension files." = "Для удаления некоторых файлов расширений требуется полный доступ к диску.";
+"Some extension files could not be removed." = "Не удалось удалить некоторые файлы расширений.";

--- a/PureMac/uk.lproj/Localizable.strings
+++ b/PureMac/uk.lproj/Localizable.strings
@@ -272,6 +272,7 @@
 "Brew Cache" = "Кеш Brew";
 "Node Cache" = "Кеш Node";
 "Docker Cache" = "Кеш Docker";
+"VS Code Extensions" = "VS Code Extensions";
 "Universal Binaries" = "Універсальні бінарні файли";
 "Language Files" = "Мовні файли";
 
@@ -288,6 +289,7 @@
 "Homebrew download cache" = "Кеш завантажень Homebrew";
 "npm, yarn, and pnpm download caches" = "Кеші завантажень npm, yarn і pnpm";
 "Docker images, containers, and build cache" = "Образи й контейнери Docker, а також кеш збірок";
+"Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)" = "Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)";
 "Unused CPU architecture slices in app binaries" = "Невикористовувані архітектури процесора в бінарних файлах програм";
 "Unused app localizations" = "Невикористовувані локалізації програм";
 
@@ -460,3 +462,18 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "Середовище виконання симулятора";
+
+"Search extensions" = "Search extensions";
+"VS Code Extensions (%lld)" = "VS Code Extensions (%lld)";
+"Remove (%lld files)" = "Remove (%lld files)";
+"Loading extensions..." = "Loading extensions...";
+"No Extensions Found" = "No Extensions Found";
+"Select an Extension" = "Select an Extension";
+"Scanning related files..." = "Scanning related files...";
+"Extension" = "Extension";
+"Global Storage" = "Global Storage";
+"Workspace Storage" = "Workspace Storage";
+"VSIX Cache" = "VSIX Cache";
+"Home Personalization" = "Персональні дані в домашній теці";
+"Full Disk Access is required to remove some extension files." = "Щоб видалити деякі файли розширень, потрібен повний доступ до диска.";
+"Some extension files could not be removed." = "Не вдалося видалити деякі файли розширень.";

--- a/PureMac/zh-Hans.lproj/Localizable.strings
+++ b/PureMac/zh-Hans.lproj/Localizable.strings
@@ -231,6 +231,7 @@
 "Brew Cache" = "Brew 缓存";
 "Node Cache" = "Node 缓存";
 "Docker Cache" = "Docker 缓存";
+"VS Code Extensions" = "VS Code 扩展";
 "Universal Binaries" = "通用二进制文件";
 "Language Files" = "语言文件";
 
@@ -247,6 +248,7 @@
 "Homebrew download cache" = "Homebrew 下载缓存";
 "npm, yarn, and pnpm download caches" = "npm、yarn 和 pnpm 下载缓存";
 "Docker images, containers, and build cache" = "Docker 镜像、容器和构建缓存";
+"Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)" = "扫描 ~/.*/extensions 下声明 engines.vscode 的扩展（删除前请确认，建议先退出对应编辑器）";
 "Unused CPU architecture slices in app binaries" = "应用二进制文件中未使用的 CPU 架构代码";
 "Unused app localizations" = "未使用的应用本地化文件";
 
@@ -460,3 +462,18 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "模拟器运行时";
+
+"Search extensions" = "搜索扩展";
+"VS Code Extensions (%lld)" = "VS Code 扩展（%lld）";
+"Remove (%lld files)" = "删除（%lld 个文件）";
+"Loading extensions..." = "正在加载扩展…";
+"No Extensions Found" = "未找到扩展";
+"Select an Extension" = "选择一个扩展";
+"Scanning related files..." = "正在扫描关联文件…";
+"Extension" = "扩展安装目录";
+"Global Storage" = "全局存储";
+"Workspace Storage" = "工作区存储";
+"VSIX Cache" = "VSIX 缓存";
+"Home Personalization" = "主目录个性化数据";
+"Full Disk Access is required to remove some extension files." = "删除部分扩展文件需要“完全磁盘访问权限”。";
+"Some extension files could not be removed." = "部分扩展文件无法删除。";

--- a/PureMac/zh-Hant.lproj/Localizable.strings
+++ b/PureMac/zh-Hant.lproj/Localizable.strings
@@ -231,6 +231,7 @@
 "Brew Cache" = "Brew 快取";
 "Node Cache" = "Node 快取";
 "Docker Cache" = "Docker 快取";
+"VS Code Extensions" = "VS Code 擴充功能";
 "Universal Binaries" = "通用二進位檔案";
 "Language Files" = "語言檔案";
 
@@ -247,6 +248,7 @@
 "Homebrew download cache" = "Homebrew 下載快取";
 "npm, yarn, and pnpm download caches" = "npm、yarn 與 pnpm 下載快取";
 "Docker images, containers, and build cache" = "Docker 映像檔、容器與建置快取";
+"Installed VS Code–family extensions under ~/.*/extensions (review before removing; quit the editor first)" = "掃描 ~/.*/extensions 下宣告 engines.vscode 的擴充功能（刪除前請確認，建議先退出對應編輯器）";
 "Unused CPU architecture slices in app binaries" = "應用程式二進位檔中未使用的 CPU 架構程式碼";
 "Unused app localizations" = "未使用的應用程式本地化檔案";
 
@@ -460,3 +462,18 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "模擬器執行環境";
+
+"Search extensions" = "Search extensions";
+"VS Code Extensions (%lld)" = "VS Code Extensions (%lld)";
+"Remove (%lld files)" = "Remove (%lld files)";
+"Loading extensions..." = "Loading extensions...";
+"No Extensions Found" = "No Extensions Found";
+"Select an Extension" = "Select an Extension";
+"Scanning related files..." = "Scanning related files...";
+"Extension" = "Extension";
+"Global Storage" = "Global Storage";
+"Workspace Storage" = "Workspace Storage";
+"VSIX Cache" = "VSIX Cache";
+"Home Personalization" = "主目錄個人化資料";
+"Full Disk Access is required to remove some extension files." = "刪除部分擴充功能檔案需要「完整磁碟取用權限」。";
+"Some extension files could not be removed." = "部分擴充功能檔案無法刪除。";

--- a/PureMacTests/AppStateTests.swift
+++ b/PureMacTests/AppStateTests.swift
@@ -4,6 +4,12 @@ import XCTest
 
 @MainActor
 final class AppStateTests: XCTestCase {
+    func testInitWithDefaultAppFileScannerDoesNotCrash() {
+        let appState = AppState(performStartupTasks: false)
+        XCTAssertTrue(appState.discoveredFiles.isEmpty)
+        XCTAssertFalse(appState.isScanningAppFiles)
+    }
+
     func testScanForAppFilesTracksLocationsWhileResultsArePending() throws {
         var completion: ((Set<URL>) -> Void)?
         let expectedLocations = ["/one", "/two", "/three"]

--- a/PureMacTests/AppSupportResolverTests.swift
+++ b/PureMacTests/AppSupportResolverTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import PureMac
+
+final class AppSupportResolverTests: XCTestCase {
+    private var tempHome: URL!
+
+    override func setUpWithError() throws {
+        tempHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMacAS-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempHome, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempHome { try? FileManager.default.removeItem(at: tempHome) }
+        tempHome = nil
+    }
+
+    func testResolvesCursorAndHyphenatedTraeCN() throws {
+        let support = tempHome.appendingPathComponent("Library/Application Support", isDirectory: true)
+        for name in ["Cursor", "Trae CN", "Code", "Qoder"] {
+            try FileManager.default.createDirectory(
+                at: support.appendingPathComponent(name, isDirectory: true),
+                withIntermediateDirectories: true
+            )
+        }
+
+        let cursor = AppSupportResolver.resolve(
+            editorDotDirectory: ".cursor",
+            homeDirectory: tempHome
+        ).map(\.lastPathComponent)
+        let traeCN = AppSupportResolver.resolve(
+            editorDotDirectory: ".trae-cn",
+            homeDirectory: tempHome
+        ).map(\.lastPathComponent)
+        let vscode = AppSupportResolver.resolve(
+            editorDotDirectory: ".vscode",
+            homeDirectory: tempHome
+        ).map(\.lastPathComponent)
+
+        XCTAssertEqual(cursor, ["Cursor"])
+        XCTAssertTrue(traeCN.contains("Trae CN"))
+        XCTAssertEqual(vscode, ["Code"])
+    }
+}

--- a/PureMacTests/CleaningEngineVSCodeExtensionsSafetyTests.swift
+++ b/PureMacTests/CleaningEngineVSCodeExtensionsSafetyTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import PureMac
+
+final class CleaningEngineVSCodeExtensionsSafetyTests: XCTestCase {
+    func testCleaningEngineAllowListAcceptsVSCodeEngineExtensionOnly() async throws {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let extensionsRoot = home.appendingPathComponent(".cursor/extensions", isDirectory: true)
+        try FileManager.default.createDirectory(at: extensionsRoot, withIntermediateDirectories: true)
+
+        let probe = extensionsRoot.appendingPathComponent(
+            "puremac.safety-probe-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: probe, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: probe) }
+
+        let pkg: [String: Any] = [
+            "name": "puremac-safety-probe",
+            "displayName": "PureMac Safety Probe",
+            "engines": ["vscode": "^1.60.0"],
+        ]
+        try JSONSerialization.data(withJSONObject: pkg)
+            .write(to: probe.appendingPathComponent("package.json"))
+
+        let engine = CleaningEngine()
+        let allowed = await engine.isAllowedCleanupPath(probe.path)
+        let rootAllowed = await engine.isAllowedCleanupPath(extensionsRoot.path)
+        let editorHomeBlocked = await engine.isAllowedCleanupPath(home.appendingPathComponent(".cursor").path)
+        let settingsBlocked = await engine.isAllowedCleanupPath(
+            home.appendingPathComponent(".cursor/argv.json").path
+        )
+        let siblingBlocked = await engine.isAllowedCleanupPath(
+            home.appendingPathComponent(".cursor/extensions_backup/x").path
+        )
+
+        XCTAssertTrue(allowed, "VS Code engine extension under ~/.*/extensions must be allow-listed")
+        XCTAssertFalse(rootAllowed, "entire extensions root must not be deletable")
+        XCTAssertFalse(editorHomeBlocked, "~/.cursor must not be deletable")
+        XCTAssertFalse(settingsBlocked, "editor settings must not be deletable")
+        XCTAssertFalse(siblingBlocked, "sibling of extensions/ must not sneak past prefix match")
+    }
+
+    func testScanEngineEmitsUnselectedVSCodeExtensionItems() async throws {
+        let engine = ScanEngine()
+        let result = await engine.scanCategory(.vsCodeExtensions)
+        XCTAssertEqual(result.category, .vsCodeExtensions)
+        if !result.items.isEmpty {
+            XCTAssertTrue(result.items.allSatisfy { !$0.isSelected })
+            XCTAssertTrue(result.items.allSatisfy { !$0.path.isEmpty })
+            XCTAssertGreaterThan(result.totalSize, 0)
+            XCTAssertTrue(result.items.contains { $0.name.contains(" · ") })
+        }
+    }
+}

--- a/PureMacTests/LocalizationFilesTests.swift
+++ b/PureMacTests/LocalizationFilesTests.swift
@@ -104,6 +104,20 @@ final class LocalizationFilesTests: XCTestCase {
         }
     }
 
+    func testLocalizableStringsEntriesDoNotHaveLeadingWhitespace() throws {
+        let pattern = try NSRegularExpression(pattern: #"(?m)^[ \t]+""#)
+        for (language, fileURL) in try localizableStringsFiles() {
+            let contents = try String(contentsOf: fileURL, encoding: .utf8)
+            let range = NSRange(contents.startIndex..., in: contents)
+            let matches = pattern.numberOfMatches(in: contents, range: range)
+            XCTAssertEqual(
+                matches,
+                0,
+                "\(language).lproj/Localizable.strings has \(matches) entry line(s) with leading whitespace"
+            )
+        }
+    }
+
     private func localizableStringsFiles() throws -> [String: URL] {
         let sourceRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()

--- a/PureMacTests/VSCodeExtensionHomePathRulesTests.swift
+++ b/PureMacTests/VSCodeExtensionHomePathRulesTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import PureMac
+
+final class VSCodeExtensionHomePathRulesTests: XCTestCase {
+    func testCandidatePathsForContinueIncludeDotContinue() {
+        let rel = VSCodeExtensionHomePathRules.candidateRelativePaths(
+            extensionId: "Continue.continue"
+        )
+        XCTAssertTrue(rel.contains(".continue"))
+        XCTAssertTrue(rel.contains(".config/continue"))
+        XCTAssertTrue(rel.contains(".config/Continue-continue") || rel.contains(".config/continue-continue"))
+    }
+
+    func testCandidatePathsForGitHubCopilotIncludeDotCopilotAndConfigDashId() {
+        let rel = VSCodeExtensionHomePathRules.candidateRelativePaths(
+            extensionId: "GitHub.copilot"
+        )
+        XCTAssertTrue(rel.contains(".copilot"))
+        XCTAssertTrue(rel.contains(".config/github-copilot"))
+        // `.github` is too generic (gh CLI); publisher-only must be denied.
+        XCTAssertFalse(rel.contains(".github"))
+    }
+
+    func testDeniedGenericNamePythonDoesNotEmitDotPython() {
+        let rel = VSCodeExtensionHomePathRules.candidateRelativePaths(
+            extensionId: "ms-python.python"
+        )
+        XCTAssertFalse(rel.contains(".python"))
+        XCTAssertFalse(rel.contains(".config/python"))
+    }
+
+    func testDeniedDockerPublisherDoesNotEmitDotDocker() {
+        let rel = VSCodeExtensionHomePathRules.candidateRelativePaths(
+            extensionId: "ms-azuretools.vscode-docker"
+        )
+        // name vscode-docker is long enough → may emit .vscode-docker
+        XCTAssertTrue(rel.contains(".vscode-docker") || rel.contains(".ms-azuretools-vscode-docker"))
+        XCTAssertFalse(rel.contains(".docker"))
+    }
+
+    func testIsAssociatedMatchesCaseInsensitiveHomeDotDir() {
+        let home = "/Users/demo"
+        XCTAssertTrue(
+            VSCodeExtensionHomePathRules.isAssociated(
+                path: "\(home)/.Continue",
+                extensionId: "Continue.continue",
+                homeDirectoryPath: home
+            )
+        )
+        XCTAssertFalse(
+            VSCodeExtensionHomePathRules.isAssociated(
+                path: "\(home)/.ssh",
+                extensionId: "Continue.continue",
+                homeDirectoryPath: home
+            )
+        )
+        XCTAssertFalse(
+            VSCodeExtensionHomePathRules.isAssociated(
+                path: "\(home)/.config",
+                extensionId: "GitHub.copilot",
+                homeDirectoryPath: home
+            )
+        )
+        XCTAssertTrue(
+            VSCodeExtensionHomePathRules.isAssociated(
+                path: "\(home)/.config/github-copilot",
+                extensionId: "GitHub.copilot",
+                homeDirectoryPath: home
+            )
+        )
+    }
+
+    func testIsHomePersonalizationPath() {
+        let home = URL(fileURLWithPath: "/Users/demo", isDirectory: true)
+        XCTAssertTrue(
+            VSCodeExtensionHomePathRules.isHomePersonalizationPath(
+                URL(fileURLWithPath: "/Users/demo/.continue"),
+                homeDirectory: home
+            )
+        )
+        XCTAssertTrue(
+            VSCodeExtensionHomePathRules.isHomePersonalizationPath(
+                URL(fileURLWithPath: "/Users/demo/.config/github-copilot"),
+                homeDirectory: home
+            )
+        )
+        XCTAssertFalse(
+            VSCodeExtensionHomePathRules.isHomePersonalizationPath(
+                URL(fileURLWithPath: "/Users/demo/Library/Application Support/Cursor/User/globalStorage/x"),
+                homeDirectory: home
+            )
+        )
+    }
+
+    func testDefaultSelectionExcludesPersonalization() {
+        let home = URL(fileURLWithPath: "/tmp/home", isDirectory: true)
+        let install = URL(fileURLWithPath: "/tmp/home/.cursor/extensions/Continue.continue-1.0.0")
+        let global = URL(fileURLWithPath: "/tmp/home/Library/Application Support/Cursor/User/globalStorage/Continue.continue")
+        let personal = URL(fileURLWithPath: "/tmp/home/.continue")
+        let selected = VSCodeExtensionHomePathRules.defaultSelectedPaths(
+            from: [install, global, personal],
+            homeDirectory: home
+        )
+        XCTAssertTrue(selected.contains(install))
+        XCTAssertTrue(selected.contains(global))
+        XCTAssertFalse(selected.contains(personal))
+    }
+}

--- a/PureMacTests/VSCodeExtensionLeftoverFinderTests.swift
+++ b/PureMacTests/VSCodeExtensionLeftoverFinderTests.swift
@@ -1,0 +1,160 @@
+import XCTest
+@testable import PureMac
+
+final class VSCodeExtensionLeftoverFinderTests: XCTestCase {
+    private var tempHome: URL!
+
+    override func setUpWithError() throws {
+        tempHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMacExtLeft-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempHome, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempHome { try? FileManager.default.removeItem(at: tempHome) }
+        tempHome = nil
+    }
+
+    func testFindsInstallGlobalWorkspaceAndVsixCache() throws {
+        let install = try makeInstall(
+            dot: ".cursor",
+            folder: "ms-python.python-2025.1.0",
+            extensionId: "ms-python.python",
+            displayName: "Python"
+        )
+        let support = tempHome.appendingPathComponent("Library/Application Support/Cursor", isDirectory: true)
+        let global = support.appendingPathComponent("User/globalStorage/ms-python.python", isDirectory: true)
+        let workspaceChild = support.appendingPathComponent(
+            "User/workspaceStorage/abc123/ms-python.python",
+            isDirectory: true
+        )
+        let vsix = support.appendingPathComponent(
+            "CachedExtensionVSIXs/ms-python.python-2025.1.0-darwin-arm64",
+            isDirectory: true
+        )
+        let other = support.appendingPathComponent("User/globalStorage/redhat.java", isDirectory: true)
+        for url in [global, workspaceChild, vsix, other] {
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        }
+
+        let item = VSCodeExtensionItem(
+            editorLabel: "Cursor",
+            displayName: "Python",
+            path: install.path,
+            size: 1,
+            lastModified: nil,
+            extensionId: "ms-python.python",
+            editorDotDirectory: ".cursor"
+        )
+        let urls = VSCodeExtensionLeftoverFinder.findRelatedPaths(for: item, homeDirectory: tempHome)
+        let paths = Set(urls.map { ($0.path as NSString).standardizingPath })
+
+        XCTAssertTrue(paths.contains((install.path as NSString).standardizingPath))
+        XCTAssertTrue(paths.contains((global.path as NSString).standardizingPath))
+        XCTAssertTrue(paths.contains((workspaceChild.path as NSString).standardizingPath))
+        XCTAssertTrue(paths.contains((vsix.path as NSString).standardizingPath))
+        XCTAssertFalse(paths.contains((other.path as NSString).standardizingPath))
+    }
+
+    func testSafetyAllowsIdChildButNotWorkspaceHashRoot() throws {
+        let home = tempHome.path
+        let hashRoot = "\(home)/Library/Application Support/Cursor/User/workspaceStorage/abc123"
+        let idChild = "\(hashRoot)/ms-python.python"
+        let global = "\(home)/Library/Application Support/Cursor/User/globalStorage/ms-python.python"
+
+        XCTAssertTrue(
+            VSCodeExtensionLeftoverFinder.isSafeRelatedPath(
+                idChild,
+                extensionId: "ms-python.python",
+                homeDirectoryPath: home
+            )
+        )
+        XCTAssertTrue(
+            VSCodeExtensionLeftoverFinder.isSafeRelatedPath(
+                global,
+                extensionId: "ms-python.python",
+                homeDirectoryPath: home
+            )
+        )
+        XCTAssertFalse(
+            VSCodeExtensionLeftoverFinder.isSafeRelatedPath(
+                hashRoot,
+                extensionId: "ms-python.python",
+                homeDirectoryPath: home
+            )
+        )
+    }
+
+    func testFindsHomePersonalizationDotDir() throws {
+        let install = try makeInstall(
+            dot: ".cursor",
+            folder: "Continue.continue-1.0.0",
+            extensionId: "Continue.continue",
+            displayName: "Continue"
+        )
+        let personal = tempHome.appendingPathComponent(".continue", isDirectory: true)
+        try FileManager.default.createDirectory(at: personal, withIntermediateDirectories: true)
+        let unrelated = tempHome.appendingPathComponent(".ssh", isDirectory: true)
+        try FileManager.default.createDirectory(at: unrelated, withIntermediateDirectories: true)
+
+        let item = VSCodeExtensionItem(
+            editorLabel: "Cursor",
+            displayName: "Continue",
+            path: install.path,
+            size: 1,
+            lastModified: nil,
+            extensionId: "Continue.continue",
+            editorDotDirectory: ".cursor"
+        )
+        let urls = VSCodeExtensionLeftoverFinder.findRelatedPaths(for: item, homeDirectory: tempHome)
+        let paths = Set(urls.map { ($0.path as NSString).standardizingPath })
+        XCTAssertTrue(paths.contains((personal.path as NSString).standardizingPath))
+        XCTAssertFalse(paths.contains((unrelated.path as NSString).standardizingPath))
+
+        XCTAssertTrue(
+            VSCodeExtensionLeftoverFinder.isSafeRelatedPath(
+                personal.path,
+                extensionId: "Continue.continue",
+                homeDirectoryPath: tempHome.path
+            )
+        )
+        let selected = VSCodeExtensionHomePathRules.defaultSelectedPaths(from: urls, homeDirectory: tempHome)
+        XCTAssertFalse(selected.contains(where: {
+            ($0.path as NSString).standardizingPath == (personal.path as NSString).standardizingPath
+        }))
+
+        // Path-only CleaningEngine entry must not allow bare ~/.continue.
+        XCTAssertFalse(
+            VSCodeExtensionLeftoverFinder.isSafeRelatedPath(
+                personal.path,
+                homeDirectoryPath: tempHome.path
+            )
+        )
+    }
+
+    private func makeInstall(
+        dot: String,
+        folder: String,
+        extensionId: String,
+        displayName: String
+    ) throws -> URL {
+        let parts = extensionId.split(separator: ".")
+        let publisher = String(parts[0])
+        let name = String(parts[1])
+        let ext = tempHome
+            .appendingPathComponent(dot, isDirectory: true)
+            .appendingPathComponent("extensions", isDirectory: true)
+            .appendingPathComponent(folder, isDirectory: true)
+        try FileManager.default.createDirectory(at: ext, withIntermediateDirectories: true)
+        let pkg: [String: Any] = [
+            "name": name,
+            "publisher": publisher,
+            "displayName": displayName,
+            "version": "1.0.0",
+            "engines": ["vscode": "^1.60.0"],
+        ]
+        try JSONSerialization.data(withJSONObject: pkg)
+            .write(to: ext.appendingPathComponent("package.json"))
+        return ext
+    }
+}

--- a/PureMacTests/VSCodeExtensionListUpdaterTests.swift
+++ b/PureMacTests/VSCodeExtensionListUpdaterTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import PureMac
+
+final class VSCodeExtensionListUpdaterTests: XCTestCase {
+    func testRemovingInstallDirectoryDropsThatExtensionOnly() {
+        let keep = makeItem(path: "/tmp/home/.cursor/extensions/keep.ext-1.0.0", id: "keep.ext")
+        let gone = makeItem(path: "/tmp/home/.cursor/extensions/gone.ext-1.0.0", id: "gone.ext")
+        let result = VSCodeExtensionListUpdater.applyingRemoval(
+            extensions: [keep, gone],
+            selected: gone,
+            removedPaths: [URL(fileURLWithPath: gone.path)]
+        )
+        XCTAssertEqual(result.extensions.map(\.extensionId), ["keep.ext"])
+        XCTAssertEqual(result.selected?.extensionId, "keep.ext")
+    }
+
+    func testRemovingInstallSelectsNextThenPrevious() {
+        let a = makeItem(path: "/tmp/a", id: "a.ext")
+        let b = makeItem(path: "/tmp/b", id: "b.ext")
+        let c = makeItem(path: "/tmp/c", id: "c.ext")
+
+        let mid = VSCodeExtensionListUpdater.applyingRemoval(
+            extensions: [a, b, c],
+            selected: b,
+            removedPaths: [URL(fileURLWithPath: b.path)]
+        )
+        XCTAssertEqual(mid.extensions.map(\.extensionId), ["a.ext", "c.ext"])
+        XCTAssertEqual(mid.selected?.extensionId, "c.ext")
+
+        let last = VSCodeExtensionListUpdater.applyingRemoval(
+            extensions: [a, b, c],
+            selected: c,
+            removedPaths: [URL(fileURLWithPath: c.path)]
+        )
+        XCTAssertEqual(last.selected?.extensionId, "b.ext")
+
+        let only = VSCodeExtensionListUpdater.applyingRemoval(
+            extensions: [a],
+            selected: a,
+            removedPaths: [URL(fileURLWithPath: a.path)]
+        )
+        XCTAssertTrue(only.extensions.isEmpty)
+        XCTAssertNil(only.selected)
+    }
+
+    func testNeighborOrderUsesDisplayOrderNotStorageOrder() {
+        let a = makeItem(path: "/tmp/a", id: "a.ext")
+        let b = makeItem(path: "/tmp/b", id: "b.ext")
+        let c = makeItem(path: "/tmp/c", id: "c.ext")
+        // Storage order a,b,c — display order c,b,a (e.g. size sort).
+        let result = VSCodeExtensionListUpdater.applyingRemoval(
+            extensions: [a, b, c],
+            selected: b,
+            removedPaths: [URL(fileURLWithPath: b.path)],
+            neighborOrder: [c, b, a]
+        )
+        XCTAssertEqual(result.selected?.extensionId, "a.ext")
+    }
+
+    func testRemovingOnlyRelatedStorageKeepsExtensionRow() {
+        let item = makeItem(path: "/tmp/home/.cursor/extensions/keep.ext-1.0.0", id: "keep.ext")
+        let storage = URL(fileURLWithPath: "/tmp/home/Library/Application Support/Cursor/User/globalStorage/keep.ext")
+        let result = VSCodeExtensionListUpdater.applyingRemoval(
+            extensions: [item],
+            selected: item,
+            removedPaths: [storage]
+        )
+        XCTAssertEqual(result.extensions.map(\.extensionId), ["keep.ext"])
+        XCTAssertEqual(result.selected?.extensionId, "keep.ext")
+    }
+
+    private func makeItem(path: String, id: String) -> VSCodeExtensionItem {
+        VSCodeExtensionItem(
+            editorLabel: "Cursor",
+            displayName: id,
+            path: path,
+            size: 1,
+            lastModified: nil,
+            extensionId: id,
+            editorDotDirectory: ".cursor"
+        )
+    }
+}

--- a/PureMacTests/VSCodeExtensionScannerTests.swift
+++ b/PureMacTests/VSCodeExtensionScannerTests.swift
@@ -1,0 +1,214 @@
+import XCTest
+@testable import PureMac
+
+final class VSCodeExtensionScannerTests: XCTestCase {
+    private var tempHome: URL!
+
+    override func setUpWithError() throws {
+        tempHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMacVSExt-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempHome, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempHome {
+            try? FileManager.default.removeItem(at: tempHome)
+        }
+        tempHome = nil
+    }
+
+    func testDiscoversUnknownEditorRootWithoutHardcodedList() throws {
+        let ext = try makeExtension(
+            under: ".totally-new-fork/extensions",
+            folder: "pub.sample-1.0.0",
+            displayName: "Sample",
+            fileBytes: 8,
+            enginesVSCode: "^1.80.0"
+        )
+
+        let items = VSCodeExtensionScanner.scan(homeDirectory: tempHome)
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].editorLabel, "Totally New Fork")
+        XCTAssertEqual(items[0].displayName, "Sample")
+        XCTAssertEqual(items[0].path, (ext.path as NSString).standardizingPath)
+    }
+
+    func testSkipsExtensionFoldersWithoutEnginesVSCode() throws {
+        try makeExtension(
+            under: ".openclaw/extensions",
+            folder: "agent.plugin-1.0.0",
+            displayName: "Agent Plugin",
+            fileBytes: 8,
+            enginesVSCode: nil
+        )
+        try makeExtension(
+            under: ".cursor/extensions",
+            folder: "pub.real-1.0.0",
+            displayName: "Real",
+            fileBytes: 8,
+            enginesVSCode: "^1.70.0"
+        )
+
+        let items = VSCodeExtensionScanner.scan(homeDirectory: tempHome)
+
+        XCTAssertEqual(items.map(\.displayName), ["Real"])
+        XCTAssertEqual(items.map(\.editorLabel), ["Cursor"])
+    }
+
+    func testScanFindsExtensionWithPackageJSON() throws {
+        let extDir = try makeExtension(
+            under: ".cursor/extensions",
+            folder: "aaron-bond.better-comments-3.0.2-universal",
+            displayName: "Better Comments",
+            fileBytes: 64,
+            enginesVSCode: "^1.60.0"
+        )
+
+        let items = VSCodeExtensionScanner.scan(homeDirectory: tempHome)
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].editorLabel, "Cursor")
+        XCTAssertEqual(items[0].displayName, "Better Comments")
+        XCTAssertEqual(items[0].path, (extDir.path as NSString).standardizingPath)
+        XCTAssertGreaterThan(items[0].size, 0)
+        XCTAssertEqual(items[0].listName, "Cursor · Better Comments")
+    }
+
+    func testScanSkipsHiddenAndMissingPackageJSON() throws {
+        try makeExtension(
+            under: ".vscode/extensions",
+            folder: "pub.good-1.0.0",
+            displayName: "Good",
+            fileBytes: 8,
+            enginesVSCode: "^1.60.0"
+        )
+        let hidden = tempHome.appendingPathComponent(".vscode/extensions/.obsolete", isDirectory: true)
+        try FileManager.default.createDirectory(at: hidden, withIntermediateDirectories: true)
+        let noPkg = tempHome.appendingPathComponent(".vscode/extensions/broken-folder", isDirectory: true)
+        try FileManager.default.createDirectory(at: noPkg, withIntermediateDirectories: true)
+
+        let items = VSCodeExtensionScanner.scan(homeDirectory: tempHome)
+
+        XCTAssertEqual(items.map(\.displayName), ["Good"])
+    }
+
+    func testScanMissingRootIsEmpty() {
+        let items = VSCodeExtensionScanner.scan(homeDirectory: tempHome)
+        XCTAssertTrue(items.isEmpty)
+    }
+
+    func testItemsSortedBySizeDescending() throws {
+        try makeExtension(
+            under: ".vscode/extensions",
+            folder: "a.small-1.0.0",
+            displayName: "Small",
+            fileBytes: 16,
+            enginesVSCode: "^1.60.0"
+        )
+        try makeExtension(
+            under: ".vscode/extensions",
+            folder: "b.large-1.0.0",
+            displayName: "Large",
+            fileBytes: 4096,
+            enginesVSCode: "^1.60.0"
+        )
+
+        let items = VSCodeExtensionScanner.scan(homeDirectory: tempHome)
+
+        XCTAssertEqual(items.map(\.displayName), ["Large", "Small"])
+    }
+
+    func testScanCategoryMapsExtensionsAsUnselectedCleanableItems() throws {
+        let ext = try makeExtension(
+            under: ".vscode/extensions",
+            folder: "pub.demo-1.0.0",
+            displayName: "Demo Ext",
+            fileBytes: 32,
+            enginesVSCode: "^1.60.0"
+        )
+        let discovered = VSCodeExtensionScanner.scan(homeDirectory: tempHome)
+        XCTAssertEqual(discovered.count, 1)
+        let item = CleanableItem(
+            name: discovered[0].listName,
+            path: discovered[0].path,
+            size: discovered[0].size,
+            category: .vsCodeExtensions,
+            isSelected: false,
+            lastModified: discovered[0].lastModified
+        )
+        XCTAssertFalse(item.isSelected)
+        XCTAssertEqual(item.name, "Vscode · Demo Ext")
+        XCTAssertEqual(item.path, (ext.path as NSString).standardizingPath)
+        XCTAssertEqual(item.category, .vsCodeExtensions)
+    }
+
+    func testIsSafeDeletePathRequiresVSCodeEngineManifest() throws {
+        let home = tempHome.path
+        let ok = try makeExtension(
+            under: ".cursor/extensions",
+            folder: "pub.name-1.0.0",
+            displayName: "Name",
+            fileBytes: 4,
+            enginesVSCode: "^1.60.0"
+        )
+        let noEngine = try makeExtension(
+            under: ".openclaw/extensions",
+            folder: "agent.plug-1.0.0",
+            displayName: "Plug",
+            fileBytes: 4,
+            enginesVSCode: nil
+        )
+
+        XCTAssertTrue(VSCodeExtensionScanner.isSafeDeletePath(ok.path, homeDirectoryPath: home))
+        XCTAssertFalse(VSCodeExtensionScanner.isSafeDeletePath(noEngine.path, homeDirectoryPath: home))
+        XCTAssertFalse(
+            VSCodeExtensionScanner.isSafeDeletePath(
+                "\(home)/.cursor/extensions",
+                homeDirectoryPath: home
+            )
+        )
+        XCTAssertFalse(
+            VSCodeExtensionScanner.isSafeDeletePath("\(home)/.cursor", homeDirectoryPath: home)
+        )
+        XCTAssertFalse(
+            VSCodeExtensionScanner.isSafeDeletePath(
+                "\(home)/.cursor/argv.json",
+                homeDirectoryPath: home
+            )
+        )
+        XCTAssertFalse(
+            VSCodeExtensionScanner.isSafeDeletePath(
+                "\(home)/.cursor/extensions_backup/x",
+                homeDirectoryPath: home
+            )
+        )
+    }
+
+    @discardableResult
+    private func makeExtension(
+        under relativeRoot: String,
+        folder: String,
+        displayName: String,
+        fileBytes: Int,
+        enginesVSCode: String?
+    ) throws -> URL {
+        let root = tempHome.appendingPathComponent(relativeRoot, isDirectory: true)
+        let ext = root.appendingPathComponent(folder, isDirectory: true)
+        try FileManager.default.createDirectory(at: ext, withIntermediateDirectories: true)
+        var pkg: [String: Any] = [
+            "name": "ext",
+            "displayName": displayName,
+            "publisher": "pub",
+            "version": "1.0.0",
+        ]
+        if let enginesVSCode {
+            pkg["engines"] = ["vscode": enginesVSCode]
+        }
+        let data = try JSONSerialization.data(withJSONObject: pkg)
+        try data.write(to: ext.appendingPathComponent("package.json"))
+        let blob = Data(repeating: 0x61, count: fileBytes)
+        try blob.write(to: ext.appendingPathComponent("payload.bin"))
+        return ext
+    }
+}

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Smart Scan runs every category in parallel. Each category is its own deliberate 
 - **Brew Cache** - respects custom `HOMEBREW_CACHE`
 - **Node Cache** - npm, yarn classic, pnpm content-addressable store
 - **Docker Cache** - images, containers, build cache
+- **VS Code Extensions** - Apps-like browser for `~/.*/extensions` installs (`engines.vscode`); drill in to review related `globalStorage` / workspace storage / VSIX cache / home personalization (`~/.continue`, etc., default unchecked) before removal
 
 > **On "purgeable space":** PureMac shows your APFS purgeable space in the storage breakdown for transparency, but it deliberately does **not** list it as junk to delete. Purgeable space is reserved and reclaimed by macOS itself - no third-party app can reliably free it, and even the Finder's purgeable figure is known to be inaccurate. Cleaners that claim to "reclaim purgeable space" are overpromising. We'd rather be honest than impressive.
 

--- a/docs/README.zh-Hans.md
+++ b/docs/README.zh-Hans.md
@@ -90,6 +90,7 @@ open build/Build/Products/Release/PureMac.app
 - **可清除空间** — 检测 APFS 可清除磁盘空间
 - **Xcode 垃圾** — DerivedData、Archives、模拟器缓存与已下载的 simulator runtimes（通过 `simctl runtime delete` 删除，不会自动勾选）
 - **Brew 缓存** — Homebrew 下载缓存(可识别自定义 HOMEBREW_CACHE)
+- **VS Code 扩展** — 类似应用卸载：浏览 `~/.*/extensions`（需 `engines.vscode`），进入详情勾选关联的 globalStorage / 工作区存储 / VSIX 缓存 / 主目录个性化数据（`~/.continue` 等，默认不勾选）后再删除
 - **定时清理** — 按可配置的间隔自动扫描
 
 ### 原生 macOS 体验

--- a/docs/superpowers/specs/2026-08-12-vscode-extension-related-files-design.md
+++ b/docs/superpowers/specs/2026-08-12-vscode-extension-related-files-design.md
@@ -1,0 +1,110 @@
+# VS Code Extension Related-Files Cleanup — Design
+
+**Date:** 2026-08-12  
+**Status:** Approved  
+**Parent:** `2026-08-12-vscode-extensions-cleanup-design.md`  
+**Approach:** A — Apps-like list → related-files detail
+
+## Goal
+
+Change VS Code Extensions from a flat cleanable-item list into an Apps-style flow: pick an extension, review related leftovers (install dir + storage/cache), then delete selected paths.
+
+## UX
+
+1. **Extension list** (like `AppListView`): editor label, display name, install size; search; select row.
+2. **Related files detail** (like `AppFilesView`): grouped paths, per-item selection, delete selected.
+3. Smart Scan / category tile remains an **entry** showing install-dir total size only; related-file deletion requires the detail flow (no one-click wipe of storage).
+
+### Groups
+
+- Extension (install directory)
+- Global Storage
+- Workspace Storage
+- VSIX Cache
+- Home Personalization (`~/.{name|publisher|…}`, `~/.config/…`) — listed, **default unchecked**
+- Other (only whitelist hits)
+
+### Defaults
+
+- Install / globalStorage / workspaceStorage id folder / CachedExtensionVSIXs: default selected when shown.
+- Home personalization leftovers: **default not selected** (opt-in only).
+- Do not list `extensions.json` / `.obsolete` as rows; after successful install-dir delete, best-effort rewrite those indexes.
+
+## Discovery rules
+
+### Installed extensions
+
+Unchanged: `~/.*/extensions/{folder}` whose `package.json` has `engines.vscode`.
+
+Identity: `publisher.name` → `extensionId`. Keep `editorDotDir` (e.g. `.cursor`) and install path.
+
+### App Support mapping (`AppSupportResolver`)
+
+From `~/.{dot}` under home, resolve zero or more directories under `~/Library/Application Support/`:
+
+1. Case-insensitive exact match on `{dot}` without leading `.`
+2. Hyphen/space insensitive match (`trae-cn` ↔ `Trae CN`)
+3. Fixed aliases only: `vscode`→`Code`, `vscode-insiders`→`Code - Insiders`, `vscode-oss`→`VSCodium`
+4. Multiple matches allowed (e.g. `.trae` → `Trae` + `Trae CN`); union and dedupe paths
+
+### Leftovers (`VSCodeExtensionLeftoverFinder`)
+
+For each resolved App Support root + extensionId:
+
+| Group | Path rule |
+|---|---|
+| Extension | install directory itself |
+| Global Storage | `{AS}/User/globalStorage/{extensionId}` (case-insensitive dir name) |
+| Workspace Storage | `{AS}/User/workspaceStorage/*/{extensionId}` (child only) |
+| VSIX Cache | `{AS}/CachedExtensionVSIXs/{extensionId}-*` |
+| Home Personalization | Deterministic home hits only (see below) |
+
+No fuzzy whole-disk search. No deleting entire `workspaceStorage/<hash>`.
+
+### Home personalization (`VSCodeExtensionHomePathRules`)
+
+For `publisher.name`, check existence of (case-insensitive on APFS):
+
+- `~/.{name}`, `~/.config/{name}` — if `name` length ≥ 5 and not denylisted (python, docker, git, …)
+- `~/.{publisher}`, `~/.config/{publisher}` — if `publisher` length ≥ 5 and not denylisted (microsoft, github, docker, …)
+- `~/.{publisher}-{name}`, `~/.{publisher}_{name}`, `~/.{extensionId}`
+- `~/.config/{publisher}-{name}`, `~/.config/{publisher}_{name}`, `~/.config/{extensionId with . → -}` (e.g. `github.copilot` → `github-copilot`)
+
+Never list exact high-risk roots (`.ssh`, `.config`, `.docker`, `.vscode`, …).
+
+## Safety
+
+`CleaningEngine` accepts a path if:
+
+- existing VS Code install-dir rule (`engines.vscode`), OR
+- under `~/Library/Application Support/<Editor>/User/globalStorage/<extensionId>` (exact folder), OR
+- under `.../workspaceStorage/<hash>/<extensionId>` (exact folder or inside it), OR
+- under `.../CachedExtensionVSIXs/<extensionId>-*`, OR
+- home personalization path associated via `VSCodeExtensionHomePathRules` for that `extensionId` (typed check; path-only CleaningEngine inference does not allow bare `~/.foo`)
+
+Prefer validating via `VSCodeExtensionLeftoverFinder.isSafeRelatedPath` shared helper.
+
+## Implementation touchpoints
+
+- `Logic/Scanning/AppSupportResolver.swift`
+- `Logic/Scanning/VSCodeExtensionLeftoverFinder.swift`
+- Enrich `VSCodeExtensionItem` with `extensionId`, `editorDotDirectory`, optional version
+- `Views/Extensions/ExtensionListView.swift` (+ files detail, can mirror AppFiles grouping)
+- `AppState`: load extensions, select, scan leftovers, remove selected
+- `MainWindow`: `.cleaning(.vsCodeExtensions)` → `ExtensionListView`
+- `ScanEngine.scanVSCodeExtensions`: keep install-only totals for Smart Scan card
+- Localizations + README note
+
+## Tests
+
+- Resolver aliases and hyphen matching
+- LeftoverFinder fixture finds all four kinds; ignores other extensionIds
+- Safety rejects workspace hash root; accepts id child
+- Scanner still skips non-`engines.vscode` folders
+
+## Non-goals (v1)
+
+- Extension-specific external caches (cpptools ipch, etc.)
+- Editing `settings.json` / sync state
+- Calling `code --uninstall-extension`
+EOF

--- a/docs/superpowers/specs/2026-08-12-vscode-extensions-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-12-vscode-extensions-cleanup-design.md
@@ -1,0 +1,135 @@
+# VS Code–Family Extensions Cleanup — Design
+
+**Date:** 2026-08-12  
+**Status:** Approved for implementation planning  
+**Approach:** New `CleaningCategory` (Developer section), list installed extensions for user review
+
+## Goal
+
+Add a PureMac Smart Scan / Developer cleanup category that lists installed VS Code–family editor extensions so the user can selectively move chosen extension folders to Trash.
+
+## Non-goals (v1)
+
+- JetBrains / Sublime / other non–VS Code–family plugins
+- Auto-discovery of unknown VS Code forks under Application Support
+- Legacy `~/Library/Application Support/<Editor>/extensions` paths
+- Detecting disabled extensions or calling `code --uninstall-extension`
+- Collapsing multiple versions of the same extension into one row
+- Blocking delete while the editor is running
+
+## Product decisions
+
+| Decision | Choice |
+|---|---|
+| Scope | VS Code, VS Code Insiders, Cursor, VSCodium, Windsurf only |
+| Behavior | List installed extensions; user selects; default **unselected** |
+| Placement | New category in Developer cleanup + Smart Scan |
+| Delete | `FileManager.trashItem` via existing `CleaningEngine` |
+| Paths | Home-dir `~/.{vscode,vscode-insiders,vscode-oss,cursor,windsurf}/extensions` |
+
+## Architecture
+
+Follow the existing cleaning-category pattern (same shape as Xcode / Docker):
+
+1. `CleaningCategory.vsCodeExtensions` in `Models.swift`
+2. `ScanEngine.scanVSCodeExtensions()` (optionally extract helpers into `Logic/Scanning/VSCodeExtensionScanner.swift`)
+3. Extend `CleaningEngine.isSafeToDelete` allow-list with the five `…/extensions` roots
+4. Wire UI lists: `DashboardView.developerCleanupCategories`, `MainWindow.advancedCategories`
+5. Localize display name / description (at least `en` + `zh-Hans`)
+6. Document in README / Chinese README sibling if present
+
+```text
+Smart Scan / category tap
+        │
+        ▼
+ScanEngine.scanVSCodeExtensions()
+        │  enumerate roots → child dirs → package.json + size
+        ▼
+CategoryResult / CleanableItem[]  (isSelected = false)
+        │
+        ▼
+CategoryDetailView (reuse) → user selects
+        │
+        ▼
+CleaningEngine.cleanItems → trashItem (allow-listed paths only)
+```
+
+## Scan roots
+
+**No hardcoded editor list.** At scan time, PureMac enumerates `~/.*` directories and looks for an `extensions/` child. An extension folder is included only when its `package.json` declares `engines.vscode`.
+
+Delete safety uses the same rule: path must be `~/.{editor}/extensions/{ext}/…` and that `{ext}/package.json` must declare `engines.vscode`. The entire `extensions/` directory itself is not deletable.
+
+Editor label is derived from the dot-directory name (e.g. `.trae-cn` → `Trae Cn`).
+
+## Item rules
+
+For each **immediate child directory** under a root:
+
+1. Skip any immediate child whose name starts with `.` (e.g. `.obsolete`)
+2. Require a readable `package.json`; if missing or unreadable, **skip** the directory (no Unknown rows in v1)
+3. Parse `displayName` (fallback: folder name), optional `publisher` / `version`
+4. `CleanableItem.name`: `"{Editor} · {displayName}"` (e.g. `Cursor · Better Comments`)
+5. `path`: absolute path to that extension directory
+6. `size`: recursive directory size (same helper style as other scanners)
+7. `isSelected`: `false`
+8. Sort items by size descending within the category result
+
+Do not emit the extensions root itself as a single wipe item.
+
+## Safety
+
+`CleaningEngine.isSafeToDelete` must allow only paths that are **equal to or strictly inside** one of:
+
+- `~/…/.vscode/extensions`
+- `~/…/.vscode-insiders/extensions`
+- `~/…/.vscode-oss/extensions`
+- `~/…/.cursor/extensions`
+- `~/…/.windsurf/extensions`
+
+Must **refuse**:
+
+- `~/.vscode`, `~/.cursor`, etc. (editor home roots)
+- Settings, argv, CLI shims, anything outside the five extensions roots
+- Existing provider-owned / cloud paths (reuse current checks)
+
+Trailing-`/` prefix matching must follow the same sibling-safe pattern already used for `/tmp` vs `/tmpfoo`.
+
+Copy in category description / README: suggest quitting the matching editor before cleaning.
+
+## UI / copy
+
+- English raw value / title: `VS Code Extensions`
+- Description: installed VS Code–family extensions; review before removing
+- Icon: `puzzlepiece.extension` (macOS 13+)
+- Color: `.brown` (unused by active Developer categories)
+- Sidebar: include in `MainWindow.advancedCategories`
+- Dashboard: include in `developerCleanupCategories`
+- Localizations: `en.lproj` + `zh-Hans.lproj` minimum; other locales can fall back or get a short string in the same PR if cheap
+
+## Testing
+
+TDD with temp-directory fixtures (no user home absolute paths in tests):
+
+1. Scanner finds extensions under a fake root with `package.json` → correct name/path/size; `isSelected == false`
+2. Skips directories without `package.json` and hidden dirs
+3. Missing root → empty contribution (no crash)
+4. `isSafeToDelete`: child under allow-listed extensions root → true; editor home root / settings path → false
+
+## README
+
+Add one bullet under System Cleaner / Smart Scan developer categories documenting VS Code–family extension review cleanup.
+
+## Implementation notes
+
+- Prefer a small `VSCodeExtensionScanner` type for path table + `package.json` parsing so unit tests do not need the full `ScanEngine` graph.
+- CLI (`CleaningCategory.scannable`) picks up the new case automatically once it is not in `appModifying`.
+- No change to orphan finder or uninstall `AppCondition` paths in v1.
+
+## Approval record
+
+- Scope: VS Code family only (option 1)
+- Behavior: list + user select (option 2)
+- Editors: fixed set of five (option 1)
+- Approach: new cleaning category A
+- Design sections 1–3: approved 2026-08-12


### PR DESCRIPTION
## Summary
- Add Apps-like cleanup for VS Code–family extensions discovered under `~/.*/extensions` (`engines.vscode`), with related-file drill-in (install dir, globalStorage, workspaceStorage id folders, VSIX cache).
- Include deterministic home personalization leftovers (`~/.{name|publisher|…}`, `~/.config/…`) that stay **unchecked by default**.
- After deleting an install directory, auto-select the next (or previous) extension in the current table order; incremental list update without a full rescan.

## Test plan
- [ ] Open PureMac → Developer / VS Code Extensions; confirm list loads from `~/.*/extensions`
- [ ] Select Continue / Copilot; confirm related files include App Support leftovers and Home Personalization (unchecked by default)
- [ ] Delete an extension install; confirm it leaves the list and the next row is selected
- [ ] `xcodebuild test -scheme PureMac -destination 'platform=macOS'` (PureMacTests)


Made with [Cursor](https://cursor.com)