### PR TITLE
xcode: clean XcodeBuildMCP DerivedData

### DIFF
--- a/PureMac/Services/CleaningEngine.swift
+++ b/PureMac/Services/CleaningEngine.swift
@@ -1,8 +1,40 @@
 import Foundation
 
+enum XcodeBuildMCPStorage {
+    static func isManagedDerivedDataPath(
+        _ path: String,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> Bool {
+        let normalized = (path as NSString).standardizingPath
+        let canonicalHome = homeDirectory.resolvingSymlinksInPath().standardizedFileURL.path
+        let root = (canonicalHome as NSString)
+            .appendingPathComponent("Library/Developer/XcodeBuildMCP")
+
+        // XcodeBuildMCP before v2.5 used one shared DerivedData directory.
+        if normalized == (root as NSString).appendingPathComponent("DerivedData") {
+            return true
+        }
+
+        let workspacesRoot = (root as NSString).appendingPathComponent("workspaces")
+        let prefix = workspacesRoot + "/"
+        guard normalized.hasPrefix(prefix) else { return false }
+
+        let relative = String(normalized.dropFirst(prefix.count))
+        let components = relative.split(separator: "/", omittingEmptySubsequences: false)
+        return components.count == 2
+            && !components[0].isEmpty
+            && components[1] == "DerivedData"
+    }
+}
+
 actor CleaningEngine {
     private let fileManager = FileManager.default
+    private let homeDirectory: URL
     private let binaryThinner = BinaryThinner()
+
+    init(homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) {
+        self.homeDirectory = homeDirectory
+    }
 
     struct CleaningResult {
         var freedSpace: Int64 = 0
@@ -121,14 +153,9 @@ actor CleaningEngine {
                 // Large files surfaced by scanLargeFiles are per-file items
                 // under Downloads/Documents/Desktop; those get a narrower check
                 // instead of the whole-subtree allow-list.
-                let pathAccepted: Bool = {
-                    if item.category == .largeFiles {
-                        return isExplicitSingleFileDeletable(resolvedPath: resolved)
-                    }
-                    // languageFiles never reaches here — it is handled above
-                    // via the staged re-sign flow, not the delete path.
-                    return isSafeToDelete(resolvedPath: resolved)
-                }()
+                // languageFiles never reaches here — it is handled above via
+                // the staged re-sign flow, not the delete path.
+                let pathAccepted = isSafeToDelete(item: item, resolvedPath: resolved)
                 guard pathAccepted else {
                     let msg = "Skipped symlink or unsafe path: \(item.path) -> \(resolved)"
                     Logger.shared.log(msg, level: .warning)
@@ -160,6 +187,15 @@ actor CleaningEngine {
                     (nsError.domain == NSPOSIXErrorDomain &&
                         (nsError.code == Int(EACCES) || nsError.code == Int(EPERM)))
                 if isPermissionDenied {
+                    if XcodeBuildMCPStorage.isManagedDerivedDataPath(
+                        item.path,
+                        homeDirectory: homeDirectory
+                    ) {
+                        let detail = "Refusing administrator escalation for XcodeBuildMCP DerivedData: \(item.path)"
+                        result.errors.append(detail)
+                        Logger.shared.log(detail, level: .warning)
+                        continue
+                    }
                     // SIP-protected/immutable entries fail even as root, so
                     // escalating them just wastes an auth prompt and produces
                     // a bogus "survived admin removal" error. Record and move on.
@@ -205,16 +241,28 @@ actor CleaningEngine {
         // refuses to escalate.
         let validated: [(item: CleanableItem, resolved: String)] = items.compactMap { item in
             let resolved = URL(fileURLWithPath: item.path).resolvingSymlinksInPath().path
-            let accepted: Bool = {
-                if item.category == .largeFiles {
-                    return isExplicitSingleFileDeletable(resolvedPath: resolved)
-                }
-                // languageFiles is deliberately absent: an admin rm -rf of an
-                // .lproj would break the bundle's signature seal with no
-                // re-sign, so those items never escalate — they only go
-                // through the staged BinaryThinner flow in cleanItems.
-                return isSafeToDelete(resolvedPath: resolved) || isSafeUninstallEscalationPath(resolved)
-            }()
+            let isManaged = XcodeBuildMCPStorage.isManagedDerivedDataPath(
+                item.path,
+                homeDirectory: homeDirectory
+            ) || XcodeBuildMCPStorage.isManagedDerivedDataPath(
+                resolved,
+                homeDirectory: homeDirectory
+            )
+            guard !isManaged else {
+                Logger.shared.log(
+                    "Refusing administrator escalation for XcodeBuildMCP DerivedData: \(item.path)",
+                    level: .warning
+                )
+                return nil
+            }
+            // languageFiles is deliberately absent: an admin rm -rf of an
+            // .lproj would break the bundle's signature seal with no re-sign,
+            // so those items never escalate.
+            let accepted = isSafeToDelete(
+                item: item,
+                resolvedPath: resolved,
+                includeUninstallPaths: true
+            )
             if !accepted {
                 Logger.shared.log("Refusing admin escalation for unsafe path: \(item.path)", level: .warning)
             }
@@ -472,12 +520,49 @@ actor CleaningEngine {
 
     // MARK: - Helpers
 
+    private func isSafeToDelete(
+        item: CleanableItem,
+        resolvedPath: String,
+        includeUninstallPaths: Bool = false
+    ) -> Bool {
+        let originalIsManaged = XcodeBuildMCPStorage.isManagedDerivedDataPath(
+            item.path,
+            homeDirectory: homeDirectory
+        )
+        let resolvedIsManaged = XcodeBuildMCPStorage.isManagedDerivedDataPath(
+            resolvedPath,
+            homeDirectory: homeDirectory
+        )
+
+        // A managed path must remain managed after symlink resolution. Do not
+        // fall through to broader roots such as Application Support: that
+        // would turn a symlinked XcodeBuildMCP root into an allow-list bypass.
+        if originalIsManaged || resolvedIsManaged {
+            let original = (item.path as NSString).standardizingPath
+            let resolved = (resolvedPath as NSString).standardizingPath
+            return originalIsManaged && resolvedIsManaged && original == resolved
+        }
+        if item.category == .largeFiles {
+            return isExplicitSingleFileDeletable(resolvedPath: resolvedPath)
+        }
+        return isSafeToDelete(resolvedPath: resolvedPath)
+            || (includeUninstallPaths && isSafeUninstallEscalationPath(resolvedPath))
+    }
+
     /// Validates that a resolved path is safe to delete.
     /// Prevents symlink attacks where a link in ~/Library/Caches points to ~/.ssh.
     /// Downloads, Documents, and Desktop are intentionally NOT whole-subtree
     /// allow-listed - scanLargeFiles emits per-file items instead, so those
     /// deletions can still happen through the explicit per-item flow.
     private func isSafeToDelete(resolvedPath: String) -> Bool {
+        let home = homeDirectory.path
+        if XcodeBuildMCPStorage.isManagedDerivedDataPath(
+            resolvedPath,
+            homeDirectory: homeDirectory
+        ) {
+            return true
+        }
+
         // Cloud File Provider state is never deletable, whatever category asked
         // and whichever allowed root it happens to sit under (issue #142).
         // Checked before the allowlist because several provider directories live
@@ -491,7 +576,6 @@ actor CleaningEngine {
             return false
         }
 
-        let home = fileManager.homeDirectoryForCurrentUser.path
         let allowedRoots = [
             "\(home)/Library/Caches",
             "\(home)/Library/Logs",

--- a/PureMac/Services/ScanEngine.swift
+++ b/PureMac/Services/ScanEngine.swift
@@ -2,7 +2,11 @@ import Foundation
 
 actor ScanEngine {
     private let fileManager = FileManager.default
-    private let home = FileManager.default.homeDirectoryForCurrentUser.path
+    private let home: String
+
+    init(homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) {
+        home = homeDirectory.resolvingSymlinksInPath().path
+    }
 
     /// Live path reporter for the dashboard's scanning ticker. Throttled so
     /// a directory with thousands of entries doesn't flood the main actor.
@@ -473,6 +477,50 @@ actor ScanEngine {
             }
         }
 
+        let xcodeBuildMCPRoot = URL(
+            fileURLWithPath: "\(home)/Library/Developer/XcodeBuildMCP",
+            isDirectory: true
+        )
+        // Never traverse a replaced/symlinked managed root. Without this gate,
+        // a link into another cleanup allow-list (for example Application
+        // Support) could make unrelated data appear to be managed DerivedData.
+        if isRealDirectory(xcodeBuildMCPRoot) {
+            // XcodeBuildMCP before v2.5 used one shared DerivedData directory.
+            let legacyDerivedData = xcodeBuildMCPRoot.appendingPathComponent("DerivedData", isDirectory: true)
+            if isRealDirectory(legacyDerivedData),
+               let item = makeCleanupItem(
+                   name: "XcodeBuildMCP: Legacy DerivedData",
+                   path: legacyDerivedData.path,
+                   category: .xcodeJunk
+               ) {
+                items.append(item)
+            }
+
+            // XcodeBuildMCP v2.5+ isolates DerivedData per invocation workspace:
+            // ~/Library/Developer/XcodeBuildMCP/workspaces/<name>-<hash>/DerivedData.
+            // Only surface DerivedData here. Sibling logs, result bundles, daemon
+            // state, and locks belong to XcodeBuildMCP's own lifecycle manager.
+            let workspacesRoot = xcodeBuildMCPRoot.appendingPathComponent("workspaces", isDirectory: true)
+            if isRealDirectory(workspacesRoot),
+               let workspaces = try? fileManager.contentsOfDirectory(
+                   at: workspacesRoot,
+                   includingPropertiesForKeys: nil,
+                   options: [.skipsHiddenFiles]
+               ) {
+                for workspace in workspaces where isRealDirectory(workspace) {
+                    let derivedData = workspace.appendingPathComponent("DerivedData", isDirectory: true)
+                    guard isRealDirectory(derivedData) else { continue }
+                    if let item = makeCleanupItem(
+                        name: "XcodeBuildMCP: \(xcodeBuildMCPWorkspaceName(workspace.lastPathComponent))",
+                        path: derivedData.path,
+                        category: .xcodeJunk
+                    ) {
+                        items.append(item)
+                    }
+                }
+            }
+        }
+
         // Downloaded simulator runtimes (often multi-GB each). Listed via
         // `xcrun simctl runtime list -j` and deleted via
         // `xcrun simctl runtime delete <id>` — not a plain filesystem unlink,
@@ -483,6 +531,23 @@ actor ScanEngine {
 
         let totalSize = items.reduce(0) { $0 + $1.size }
         return CategoryResult(category: .xcodeJunk, items: items, totalSize: totalSize)
+    }
+
+    private func xcodeBuildMCPWorkspaceName(_ workspaceKey: String) -> String {
+        guard let separator = workspaceKey.lastIndex(of: "-") else { return workspaceKey }
+        let suffix = workspaceKey[workspaceKey.index(after: separator)...]
+        guard suffix.count == 12, suffix.allSatisfy(\.isHexDigit) else { return workspaceKey }
+        return String(workspaceKey[..<separator])
+    }
+
+    private func isRealDirectory(_ url: URL) -> Bool {
+        let normalized = url.standardizedFileURL.path
+        guard url.resolvingSymlinksInPath().standardizedFileURL.path == normalized,
+              let attributes = try? fileManager.attributesOfItem(atPath: normalized),
+              attributes[.type] as? FileAttributeType == .typeDirectory else {
+            return false
+        }
+        return true
     }
 
     /// Enumerate installed simulator runtime disk images via simctl.

--- a/PureMacTests/AppStateTests.swift
+++ b/PureMacTests/AppStateTests.swift
@@ -59,3 +59,275 @@ private final class StubLocations: Locations {
         appSearch = SearchCategory(name: "Apps", paths: paths)
     }
 }
+
+final class XcodeBuildMCPStorageTests: XCTestCase {
+    func testXcodeJunkIncludesManagedDerivedDataForEachWorkspace() async throws {
+        let fileManager = FileManager.default
+        let temporaryHome = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: temporaryHome) }
+
+        let workspaceRoot = temporaryHome
+            .appendingPathComponent("Library/Developer/XcodeBuildMCP/workspaces/PureMac-59316969cafe", isDirectory: true)
+        let derivedData = workspaceRoot.appendingPathComponent("DerivedData", isDirectory: true)
+        let logs = workspaceRoot.appendingPathComponent("logs", isDirectory: true)
+        let outsideDirectory = temporaryHome.appendingPathComponent("outside", isDirectory: true)
+        let symlinkedDerivedData = temporaryHome
+            .appendingPathComponent("Library/Developer/XcodeBuildMCP/workspaces/Symlinked-111111111111/DerivedData")
+        try fileManager.createDirectory(at: derivedData, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: logs, withIntermediateDirectories: true)
+        try fileManager.createDirectory(
+            at: symlinkedDerivedData.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try fileManager.createDirectory(at: outsideDirectory, withIntermediateDirectories: true)
+        try fileManager.createSymbolicLink(at: symlinkedDerivedData, withDestinationURL: outsideDirectory)
+        try Data(repeating: 0xAB, count: 4_096)
+            .write(to: derivedData.appendingPathComponent("build-product"))
+        try Data(repeating: 0xCD, count: 4_096)
+            .write(to: logs.appendingPathComponent("build.log"))
+        try Data(repeating: 0xEF, count: 4_096)
+            .write(to: outsideDirectory.appendingPathComponent("must-not-be-scanned"))
+
+        let engine = ScanEngine(homeDirectory: temporaryHome)
+        let result = await engine.scanCategory(.xcodeJunk)
+
+        let expectedPath = derivedData.resolvingSymlinksInPath().path
+        let item = try XCTUnwrap(
+            result.items.first {
+                URL(fileURLWithPath: $0.path).resolvingSymlinksInPath().path == expectedPath
+            },
+            "Expected \(expectedPath); scanned: \(result.items.map(\.path))"
+        )
+        XCTAssertEqual(item.name, "XcodeBuildMCP: PureMac")
+        XCTAssertTrue(item.isSelected)
+        XCTAssertFalse(result.items.contains { $0.path == logs.path })
+        XCTAssertFalse(result.items.contains { $0.path == symlinkedDerivedData.path })
+    }
+
+    func testSymlinkedXcodeBuildMCPRootIsNotScanned() async throws {
+        let fileManager = FileManager.default
+        let temporaryHome = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-RootLink-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: temporaryHome) }
+
+        let externalRoot = temporaryHome
+            .appendingPathComponent("Library/Application Support/FakeXcodeBuildMCP", isDirectory: true)
+        let externalDerivedData = externalRoot
+            .appendingPathComponent("workspaces/Foreign-222222222222/DerivedData", isDirectory: true)
+        let developerDirectory = temporaryHome
+            .appendingPathComponent("Library/Developer", isDirectory: true)
+        let managedRoot = developerDirectory.appendingPathComponent("XcodeBuildMCP", isDirectory: true)
+        try fileManager.createDirectory(at: externalDerivedData, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: developerDirectory, withIntermediateDirectories: true)
+        try fileManager.createSymbolicLink(at: managedRoot, withDestinationURL: externalRoot)
+        try Data(repeating: 0xAA, count: 4_096)
+            .write(to: externalDerivedData.appendingPathComponent("foreign-data"))
+
+        let result = await ScanEngine(homeDirectory: temporaryHome).scanCategory(.xcodeJunk)
+
+        XCTAssertFalse(result.items.contains { $0.name.hasPrefix("XcodeBuildMCP:") })
+    }
+
+    func testCleaningRejectsManagedPathWhoseRootResolvesOutsideManagedStorage() async throws {
+        let fileManager = FileManager.default
+        let temporaryHome = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-CleanRootLink-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: temporaryHome) }
+
+        let externalRoot = temporaryHome
+            .appendingPathComponent("Library/Application Support/FakeXcodeBuildMCP", isDirectory: true)
+        let externalDerivedData = externalRoot
+            .appendingPathComponent("workspaces/Foreign-222222222222/DerivedData", isDirectory: true)
+        let developerDirectory = temporaryHome
+            .appendingPathComponent("Library/Developer", isDirectory: true)
+        let managedRoot = developerDirectory.appendingPathComponent("XcodeBuildMCP", isDirectory: true)
+        let apparentDerivedData = managedRoot
+            .appendingPathComponent("workspaces/Foreign-222222222222/DerivedData", isDirectory: true)
+        try fileManager.createDirectory(at: externalDerivedData, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: developerDirectory, withIntermediateDirectories: true)
+        try fileManager.createSymbolicLink(at: managedRoot, withDestinationURL: externalRoot)
+        try Data(repeating: 0xBB, count: 4_096)
+            .write(to: externalDerivedData.appendingPathComponent("foreign-data"))
+
+        let item = CleanableItem(
+            name: "XcodeBuildMCP: Foreign",
+            path: apparentDerivedData.path,
+            size: 4_096,
+            category: .xcodeJunk,
+            isSelected: true,
+            lastModified: nil
+        )
+        let result = await CleaningEngine(homeDirectory: temporaryHome)
+            .cleanItems([item]) { _ in }
+
+        XCTAssertEqual(result.itemsCleaned, 0)
+        XCTAssertTrue(fileManager.fileExists(atPath: externalDerivedData.path))
+    }
+
+    func testXcodeJunkIncludesLegacySharedDerivedData() async throws {
+        let fileManager = FileManager.default
+        let temporaryHome = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-Legacy-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: temporaryHome) }
+
+        let legacyDerivedData = temporaryHome
+            .appendingPathComponent("Library/Developer/XcodeBuildMCP/DerivedData", isDirectory: true)
+        try fileManager.createDirectory(at: legacyDerivedData, withIntermediateDirectories: true)
+        try Data(repeating: 0xEF, count: 4_096)
+            .write(to: legacyDerivedData.appendingPathComponent("legacy-build-product"))
+
+        let result = await ScanEngine(homeDirectory: temporaryHome).scanCategory(.xcodeJunk)
+        let expectedPath = legacyDerivedData.resolvingSymlinksInPath().path
+        let item = try XCTUnwrap(result.items.first {
+            URL(fileURLWithPath: $0.path).resolvingSymlinksInPath().path == expectedPath
+        })
+
+        XCTAssertEqual(item.name, "XcodeBuildMCP: Legacy DerivedData")
+    }
+
+    func testCleaningManagedDerivedDataLeavesWorkspaceStateIntact() async throws {
+        let fileManager = FileManager.default
+        let temporaryHome = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-Clean-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: temporaryHome) }
+
+        let workspaceRoot = temporaryHome
+            .appendingPathComponent("Library/Developer/XcodeBuildMCP/workspaces/PureMac-59316969cafe", isDirectory: true)
+        let derivedData = workspaceRoot.appendingPathComponent("DerivedData", isDirectory: true)
+        let preservedDirectories = ["logs", "state", "locks", "result-bundles", "test-products"].map {
+            workspaceRoot.appendingPathComponent($0, isDirectory: true)
+        }
+        try fileManager.createDirectory(at: derivedData, withIntermediateDirectories: true)
+        for directory in preservedDirectories {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            try Data(repeating: 0xCD, count: 256)
+                .write(to: directory.appendingPathComponent("must-survive"))
+        }
+        try Data(repeating: 0xAB, count: 4_096)
+            .write(to: derivedData.appendingPathComponent("build-product"))
+
+        let scan = await ScanEngine(homeDirectory: temporaryHome).scanCategory(.xcodeJunk)
+        let item = try XCTUnwrap(scan.items.first { $0.name == "XcodeBuildMCP: PureMac" })
+        let result = await CleaningEngine(homeDirectory: temporaryHome)
+            .cleanItems([item]) { _ in }
+
+        XCTAssertEqual(result.itemsCleaned, 1)
+        XCTAssertFalse(fileManager.fileExists(atPath: derivedData.path))
+        for directory in preservedDirectories {
+            XCTAssertTrue(fileManager.fileExists(atPath: directory.appendingPathComponent("must-survive").path))
+        }
+    }
+
+    func testManagedDerivedDataSafetyOnlyAllowsDerivedDataDirectories() {
+        let home = URL(fileURLWithPath: "/Users/tester", isDirectory: true)
+        let managedRoot = "/Users/tester/Library/Developer/XcodeBuildMCP"
+
+        XCTAssertTrue(XcodeBuildMCPStorage.isManagedDerivedDataPath(
+            "\(managedRoot)/workspaces/PureMac-59316969cafe/DerivedData",
+            homeDirectory: home
+        ))
+        XCTAssertTrue(XcodeBuildMCPStorage.isManagedDerivedDataPath(
+            "\(managedRoot)/DerivedData",
+            homeDirectory: home
+        ))
+        XCTAssertFalse(XcodeBuildMCPStorage.isManagedDerivedDataPath(
+            "\(managedRoot)/workspaces/PureMac-59316969cafe/logs",
+            homeDirectory: home
+        ))
+        XCTAssertFalse(XcodeBuildMCPStorage.isManagedDerivedDataPath(
+            "\(managedRoot)/workspaces/PureMac-59316969cafe",
+            homeDirectory: home
+        ))
+        XCTAssertFalse(XcodeBuildMCPStorage.isManagedDerivedDataPath(
+            "\(managedRoot)-backup/workspaces/PureMac-59316969cafe/DerivedData",
+            homeDirectory: home
+        ))
+    }
+
+    func testSymlinkedHomeScanOutputCanStillBeCleaned() async throws {
+        let fileManager = FileManager.default
+        let container = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-HomeLink-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: container) }
+
+        let realHome = container.appendingPathComponent("real-home", isDirectory: true)
+        let linkedHome = container.appendingPathComponent("linked-home", isDirectory: true)
+        let derivedData = realHome
+            .appendingPathComponent("Library/Developer/XcodeBuildMCP/workspaces/PureMac-59316969cafe/DerivedData", isDirectory: true)
+        try fileManager.createDirectory(at: derivedData, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: container, withIntermediateDirectories: true)
+        try fileManager.createSymbolicLink(at: linkedHome, withDestinationURL: realHome)
+        try Data(repeating: 0xA1, count: 4_096)
+            .write(to: derivedData.appendingPathComponent("build-product"))
+
+        let scan = await ScanEngine(homeDirectory: linkedHome).scanCategory(.xcodeJunk)
+        let item = try XCTUnwrap(scan.items.first { $0.name == "XcodeBuildMCP: PureMac" })
+        let result = await CleaningEngine(homeDirectory: linkedHome).cleanItems([item]) { _ in }
+
+        XCTAssertEqual(result.itemsCleaned, 1)
+        XCTAssertTrue(result.errors.isEmpty)
+        XCTAssertFalse(fileManager.fileExists(atPath: derivedData.path))
+    }
+
+    func testCleaningRejectsDerivedDataSymlinkToAnotherManagedWorkspace() async throws {
+        let fileManager = FileManager.default
+        let temporaryHome = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-ManagedLink-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: temporaryHome) }
+
+        let workspaces = temporaryHome
+            .appendingPathComponent("Library/Developer/XcodeBuildMCP/workspaces", isDirectory: true)
+        let sourceWorkspace = workspaces.appendingPathComponent("Source-111111111111", isDirectory: true)
+        let targetDerivedData = workspaces
+            .appendingPathComponent("Target-222222222222/DerivedData", isDirectory: true)
+        let apparentDerivedData = sourceWorkspace.appendingPathComponent("DerivedData", isDirectory: true)
+        try fileManager.createDirectory(at: sourceWorkspace, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: targetDerivedData, withIntermediateDirectories: true)
+        try Data(repeating: 0xB2, count: 4_096)
+            .write(to: targetDerivedData.appendingPathComponent("must-survive"))
+        try fileManager.createSymbolicLink(at: apparentDerivedData, withDestinationURL: targetDerivedData)
+
+        let item = CleanableItem(
+            name: "XcodeBuildMCP: Source",
+            path: apparentDerivedData.path,
+            size: 4_096,
+            category: .xcodeJunk,
+            isSelected: true,
+            lastModified: nil
+        )
+        let result = await CleaningEngine(homeDirectory: temporaryHome).cleanItems([item]) { _ in }
+
+        XCTAssertEqual(result.itemsCleaned, 0)
+        XCTAssertFalse(result.errors.isEmpty)
+        XCTAssertTrue(fileManager.fileExists(atPath: targetDerivedData.appendingPathComponent("must-survive").path))
+    }
+
+    func testAdministratorCleaningNeverEscalatesManagedDerivedData() async throws {
+        let fileManager = FileManager.default
+        let temporaryHome = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-NoAdmin-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: temporaryHome) }
+
+        let derivedData = temporaryHome
+            .appendingPathComponent("Library/Developer/XcodeBuildMCP/workspaces/PureMac-59316969cafe/DerivedData", isDirectory: true)
+        let marker = derivedData.appendingPathComponent("must-survive")
+        try fileManager.createDirectory(at: derivedData, withIntermediateDirectories: true)
+        try Data(repeating: 0xC3, count: 4_096).write(to: marker)
+        let item = CleanableItem(
+            name: "XcodeBuildMCP: PureMac",
+            path: derivedData.path,
+            size: 4_096,
+            category: .xcodeJunk,
+            isSelected: true,
+            lastModified: nil
+        )
+
+        let result = await CleaningEngine(homeDirectory: temporaryHome)
+            .cleanWithAdminPrivileges(items: [item])
+
+        XCTAssertEqual(result.itemsCleaned, 0)
+        XCTAssertTrue(fileManager.fileExists(atPath: marker.path))
+    }
+
+}


### PR DESCRIPTION
## What does this PR do?

Adds XcodeBuildMCP-managed DerivedData to the existing **Xcode Junk** cleanup category.

- Discovers both the legacy shared `~/Library/Developer/XcodeBuildMCP/DerivedData` directory and current workspace-scoped `workspaces/<workspace-key>/DerivedData` directories.
- Cleans only DerivedData while preserving workspace logs, state, locks, result bundles, and test products.
- Rejects symlinked managed storage, managed-to-managed retargeting, and administrator escalation specifically for XcodeBuildMCP DerivedData.
- Keeps the existing category title, description, and localizations unchanged.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] UI/UX enhancement
- [ ] Documentation
- [ ] Other (describe)

## Testing

- [ ] Tested on macOS Ventura (13.x)
- [ ] Tested on macOS Sonoma (14.x)
- [ ] Tested on macOS Sequoia (15.x)

Automated verification:

- `xcodebuildmcp macos test --project-path ./PureMac.xcodeproj --scheme PureMac --configuration Debug --output json`
- 28 tests passed, 0 failed, 0 warnings, 0 errors.
- `git diff --check` passed.

## Screenshots

<img width="2998" height="2544" alt="CleanShot 2026-08-14 at 12 45 29@2x" src="https://github.com/user-attachments/assets/843d2292-0b2f-4958-85f3-ef1058c37eae" />

