### PR TITLE
Add a shared sort control to every file list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,202 @@
+# AGENTS.md
+
+Contract for any coding agent working in this repository. PureMac is a native SwiftUI
+macOS cleaner app, MIT licensed. It removes files from a real person's Mac. Work
+accordingly.
+
+## Before you touch anything
+
+- [ ] Read this file to the end. Then read `CONTRIBUTING.md`.
+- [ ] Know that `PureMac.xcodeproj` is **generated**. `project.yml` is the source of truth.
+- [ ] Have XcodeGen installed: `brew install xcodegen`.
+- [ ] Run `xcodegen generate` once, and again after every `git pull` or `project.yml` edit.
+- [ ] If `xcode-select` points at CommandLineTools, export the full Xcode path before any
+      `xcodebuild` call:
+      `export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer`
+- [ ] Know the localization rule: 11 `Localizable.strings` files must hold exactly the
+      same keys. One new English string means 11 file edits.
+- [ ] Know that CI runs the build only. It does **not** run the tests. Green CI does not
+      mean the change is correct.
+- [ ] Scope your change to one thing. This project takes one focused change per PR.
+
+## Build and verify loop
+
+Setup:
+
+```bash
+brew install xcodegen
+xcodegen generate
+```
+
+Build exactly as CI does. This build is the only required check for merge:
+
+```bash
+xcodebuild -project PureMac.xcodeproj -scheme PureMac -configuration Release -derivedDataPath build build ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+```
+
+Test, because CI will not:
+
+```bash
+xcodebuild test -project PureMac.xcodeproj -scheme PureMac
+```
+
+Tests are XCTest, not Swift Testing. 4 files, 19 test functions, in `PureMacTests/`:
+`AppLanguagePreferencesTests.swift`, `AppStateTests.swift`, `LocalizationFilesTests.swift`,
+`SimulatorRuntimeSupportTests.swift`.
+
+There is no linter and no formatter in this repo. No SwiftLint, no SwiftFormat. Match the
+surrounding code by reading it.
+
+Facts you may need:
+
+| Item | Value |
+| --- | --- |
+| Deployment target | macOS 13.0 |
+| Swift | 5.9 |
+| xcodeVersion | 16.4 |
+| Architectures | arm64 + x86_64 |
+| Bundle id | `com.puremac.app` |
+| Targets | `PureMac`, `PureMacTests` |
+| Scheme | `PureMac` |
+| Dependency | Sparkle (SPM, from 2.0.0). First build needs network. |
+| CI | `.github/workflows/build.yml`, macos-15, push to main and PRs to main |
+
+`DEVELOPMENT_TEAM` is hardcoded to `H3WXHVTP97` in `project.yml`. Do not commit a change
+to it. Local builds should rely on the Debug config, which sets `CODE_SIGNING_ALLOWED`
+to `NO`.
+
+## Hard rules
+
+### 1. Never edit `PureMac.xcodeproj`
+
+It is generated from `project.yml` by XcodeGen. Any hand edit is lost on the next
+`xcodegen generate` and will confuse everyone. Change `project.yml`, then regenerate.
+New source files need no project edit at all. XcodeGen picks them up.
+
+### 2. Never break localization parity
+
+11 languages, classic `Localizable.strings` (not `.xcstrings`):
+`ar`, `en`, `es`, `fr`, `ja`, `pl`, `pt-BR`, `ru`, `uk`, `zh-Hans`, `zh-Hant`.
+
+`PureMacTests/LocalizationFilesTests.swift` fails on:
+
+- a key missing from any of the 11 files
+- an **extra** key present in one file and not the others
+- a format-specifier mismatch between languages
+- a duplicate key inside one file
+
+Add a string, add it to all 11. Remove a string, remove it from all 11. Use `%lld` with
+an explicit `Int64` cast, never `%d`.
+
+Three lookup patterns are in use:
+
+- bare string literal passed to `Text` / `Button` / `Label` / `.help` / `.searchable`
+- `Text(LocalizedStringKey(runtimeString))` for enum `rawValue` and other runtime strings
+- `String(format: String(localized: "...%lld..."), Int64(n))` for interpolation
+
+CI does not run tests, so broken localization can pass CI. Run the test target yourself.
+
+### 3. Never bypass `CleaningEngine`
+
+All destructive work goes through `Services/CleaningEngine.swift`. It is
+symlink-resistant, does TOCTOU-safe re-resolution, and is gated by an allow-list.
+Orphan removal is additionally gated by `OrphanSafetyPolicy.allowedRoots` in
+`Logic/Utilities/OrphanSafetyPolicy.swift`. Do not create a second delete path anywhere.
+
+### 4. Never add `rm`, and never add ad hoc removal
+
+Files move to the Trash with `FileManager.trashItem`. No `rm`. No shell-out deletes.
+No new `FileManager.removeItem` calls.
+
+### 5. Other safety constraints
+
+- The app is **not sandboxed**. `PureMac.entitlements` sets
+  `com.apple.security.app-sandbox` to `false`. It needs this to work. Do not enable the
+  sandbox.
+- Full Disk Access is load-bearing. Without it the app misses most of what it should
+  find. `FullDiskAccessManager` probes with real reads (`FileHandle` / `Data`), not
+  `FileManager.isReadableFile` or `fileExists`. Metadata-only calls do not trigger TCC,
+  and macOS then never lists the app in the Full Disk Access pane. Do not convert that
+  probe to a metadata check.
+- Every destructive UI action sits behind `.confirmationDialog` or `.alert`. Keep it that
+  way.
+- `Info.plist` declares an `NSServices` entry (`NSMessage` `uninstallApp`) that powers the
+  Finder right-click "Uninstall with PureMac". Do not drop it.
+
+## Where code goes
+
+| Directory | Role |
+| --- | --- |
+| `Core/` | App-wide constants. `AppConstants.swift`. |
+| `Models/` | Pure value types, no logic. `Models.swift`, `ScanError.swift`, `AppLanguage.swift`. |
+| `Logic/Scanning/` | Stateless discovery. `AppPathFinder.swift` (10-level leftover matching), `Locations.swift` (120+ search paths), `Conditions.swift` (25 per-app rules), `AppInfoFetcher.swift`, `UniversalBinaryScanner.swift`, `LanguageFilesScanner.swift`. |
+| `Logic/Utilities/` | `Logger.swift`, `FileSize.swift`, `OrphanSafetyPolicy.swift`, `FileProtection.swift`, `CLI.swift`, `SimulatorRuntimeSupport.swift`. |
+| `Services/` | Engines. `ScanEngine`, `CleaningEngine`, `BinaryThinner` are actors. `PermissionCoordinator`, `SchedulerService`, `SystemMonitor`, `MenuBarController`, `UpdateService`, `FullDiskAccessManager` are `@MainActor` ObservableObjects. |
+| `ViewModels/` | `AppState.swift` only. `@MainActor final class AppState: ObservableObject`, about 1128 lines, 15 MARK sections. The single store for the app. |
+| `Views/` | SwiftUI screens, with `Apps/`, `Components/`, `Orphans/`, `Settings/`. `Views/Components/AppTheme.swift` is the design system. |
+| `Extensions/` | `Theme.swift`, one View modifier. |
+
+## Style to match
+
+- 4 spaces, no tabs.
+- Types default to `internal` with no explicit modifier. Everything else is `private`
+  (573 `private` against 5 explicit `internal`).
+- `// MARK: - Title` with the dash, in files over roughly 60 lines.
+- **No header comment block on new files.** Start with `import SwiftUI` or
+  `import Foundation`. Some older files carry an Xcode template header. Do not copy it.
+- Comments explain why, and often cite an issue number such as `(#114)`.
+- State is classic Combine: `ObservableObject`, `@Published`, `@EnvironmentObject`,
+  `@ObservedObject`. The `@Observable` macro is used nowhere (47 `@Published`,
+  0 `@Observable`). Do not introduce it.
+- Concurrency: the three engine actors expose plain synchronous methods. Actor isolation
+  is the safety, so no `async func` declarations. Call sites use `Task { }` and `await`.
+  Heavy work uses `Task.detached(priority:)` and comes back through
+  `await MainActor.run { [weak self] in }`. Two legacy completion-handler APIs remain, in
+  `AppPathFinder.swift` and `AppState.swift`.
+- Errors: typed `enum: LocalizedError` with `errorDescription`. Most failure paths return
+  an optional or append to an `errors: [String]` array instead of throwing. Only 3
+  `throws` sites exist.
+- Logging: `Logger.shared.log(_:level:)` over `os.Logger`. 16 stray `print()` calls exist.
+  Add none.
+- Motion: gate every animation on `@Environment(\.accessibilityReduceMotion)`, written
+  `.animation(reduceMotion ? nil : MotionTokens.snappy, value: x)`.
+
+## Definition of done
+
+Do not report a change as finished until all of these are true.
+
+- [ ] `xcodegen generate` runs clean, and `PureMac.xcodeproj` was not hand-edited.
+- [ ] The CI build command above completes with no errors and no new warnings.
+- [ ] `xcodebuild test -project PureMac.xcodeproj -scheme PureMac` passes locally.
+- [ ] Every added or removed string key is present in, or absent from, **all 11**
+      `Localizable.strings` files, with matching format specifiers.
+- [ ] No new `print()` calls. Logging goes through `Logger.shared.log(_:level:)`.
+- [ ] Every new animation respects `@Environment(\.accessibilityReduceMotion)`.
+- [ ] No new delete path. Nothing bypasses `CleaningEngine` or
+      `OrphanSafetyPolicy.allowedRoots`. No `rm`, no new `FileManager.removeItem`.
+- [ ] Every new destructive action is behind `.confirmationDialog` or `.alert`.
+- [ ] **No em-dashes** in code, comments, strings, commit messages or PR text. Use a plain
+      hyphen or restructure the sentence.
+- [ ] `README.md` is updated if user-facing behaviour changed.
+- [ ] The change is one focused thing, and it builds on macOS 13.0 at minimum.
+
+## PRs, issues, releases
+
+- Fork, clone, `brew install xcodegen`, `xcodegen generate`, `open PureMac.xcodeproj`.
+- One focused change per PR. Test on macOS 13.0 at minimum.
+- Issue titles use the prefix `[Bug]` (label `bug`) or `[Feature]` (label `enhancement`).
+- The PR template asks for: what the PR does, type of change, tested-on checkboxes for
+  Ventura 13.x / Sonoma 14.x / Sequoia 15.x, and screenshots.
+- No documented commit message convention. Observed style in automation is a lowercase
+  scope prefix and a colon, for example `homebrew: bump to 2.9.7`.
+
+Release is tag-driven. Bump `MARKETING_VERSION` in `project.yml`, then push a matching
+`v*.*.*` tag. `.github/workflows/release.yml` archives, signs with Developer ID, builds
+the DMG, notarizes, staples, writes checksums, publishes the GitHub release, and bumps
+both `homebrew/puremac.rb` and the external `momenbasel/homebrew-tap`. It needs 6 secrets,
+listed in `scripts/SECRETS.md`. A fork cannot run it without its own Apple Developer ID.
+Local fallback:
+
+```bash
+scripts/release-local.sh <version> [notary_profile]
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,229 @@
+# CLAUDE.md
+
+Guidance for Claude Code working in this repository.
+
+## 1. What this app is, and why care is needed
+
+PureMac is a native SwiftUI macOS cleaner app (MIT licensed). It finds junk files,
+app leftovers, orphaned data, unused languages and fat universal binaries, then
+removes them.
+
+**This app deletes user data.** A wrong path, a bad allow-list edit or a skipped
+confirmation can destroy files a person cannot get back. Treat every change under
+`Logic/`, `Services/CleaningEngine.swift` and `Logic/Utilities/OrphanSafetyPolicy.swift`
+as high risk. Read section 6 before you touch any of them.
+
+## 2. Build and test
+
+The project uses **XcodeGen**. `project.yml` is the source of truth.
+`PureMac.xcodeproj` is generated output. **Never hand-edit `PureMac.xcodeproj`.**
+
+First-time setup:
+
+```bash
+brew install xcodegen
+xcodegen generate
+open PureMac.xcodeproj
+```
+
+Re-run `xcodegen generate` after any change to `project.yml`, and after every `git pull`.
+
+If `xcode-select` points at CommandLineTools, `xcodebuild` will fail. Export the full
+Xcode path first:
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+```
+
+Build the way CI builds (this is the only required check for merge):
+
+```bash
+xcodegen generate
+xcodebuild -project PureMac.xcodeproj -scheme PureMac -configuration Release -derivedDataPath build build ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+```
+
+Run the tests:
+
+```bash
+xcodebuild test -project PureMac.xcodeproj -scheme PureMac
+```
+
+In Xcode, tests run with Cmd+U.
+
+| Item | Value |
+| --- | --- |
+| Deployment target | macOS 13.0 |
+| Swift | 5.9 |
+| xcodeVersion | 16.4 |
+| Architectures | arm64 + x86_64 |
+| Bundle id | `com.puremac.app` |
+| Targets | `PureMac` (app), `PureMacTests` (unit tests) |
+| Scheme | `PureMac` |
+| Dependency | Sparkle (SPM, from 2.0.0) for auto-update |
+| Test framework | XCTest (not Swift Testing) |
+| Lint / format | None. No SwiftLint, no SwiftFormat. |
+| CI | `.github/workflows/build.yml`, macos-15, on push to main and PRs to main |
+
+The first build needs network access to resolve Sparkle.
+
+`DEVELOPMENT_TEAM` is hardcoded to `H3WXHVTP97` in `project.yml`. Do not commit a
+change to it. For local builds rely on the Debug config, which sets
+`CODE_SIGNING_ALLOWED` to `NO`.
+
+**CI does not run tests.** Only the build runs. See section 3 for why that matters.
+
+## 3. The localization parity trap (read this first)
+
+This is the most common way to break the repo.
+
+The app ships 11 languages using classic `Localizable.strings` files (not `.xcstrings`):
+
+`ar`, `en`, `es`, `fr`, `ja`, `pl`, `pt-BR`, `ru`, `uk`, `zh-Hans`, `zh-Hant`
+
+`PureMacTests/LocalizationFilesTests.swift` enforces:
+
+- key parity across all 11 files, failing on **missing keys and on extra keys**
+- format-specifier parity between languages
+- no duplicate keys inside a file
+
+So:
+
+- Adding one English string means adding that key to **all 11** `Localizable.strings` files.
+- Removing one string means deleting that key from **all 11**.
+
+**CI does not run tests, so you can get a green CI with broken localization.**
+Run `xcodebuild test -project PureMac.xcodeproj -scheme PureMac` yourself before you
+call any string change done.
+
+Three lookup patterns are in use:
+
+| Pattern | Use it for |
+| --- | --- |
+| Bare string literal passed to `Text` / `Button` / `Label` / `.help` / `.searchable` | Static UI text. SwiftUI resolves the key. |
+| `Text(LocalizedStringKey(runtimeString))` | Runtime strings, such as enum `rawValue`. |
+| `String(format: String(localized: "...%lld..."), Int64(n))` | Interpolated numbers. |
+
+Always use `%lld` with an explicit `Int64` cast. Never `%d`.
+
+## 4. Architecture map
+
+| Directory | Role |
+| --- | --- |
+| `Core/` | App-wide constants. `AppConstants.swift`. |
+| `Models/` | Pure value types, no logic. `Models.swift` (CleaningCategory, CleanableItem, CategoryResult, ScanState, DiskInfo, ScheduleConfig), `ScanError.swift` (LocalizedError enum), `AppLanguage.swift`. |
+| `Logic/Scanning/` | Stateless discovery helpers. `AppPathFinder.swift` (10-level app-leftover matching engine), `Locations.swift` (120+ macOS search paths), `Conditions.swift` (25 per-app edge-case rules), `AppInfoFetcher.swift`, `UniversalBinaryScanner.swift`, `LanguageFilesScanner.swift`. |
+| `Logic/Utilities/` | `Logger.swift`, `FileSize.swift` (allocated-size math), `OrphanSafetyPolicy.swift` (allowedRoots allow-list), `FileProtection.swift`, `CLI.swift`, `SimulatorRuntimeSupport.swift`. |
+| `Services/` | The engines. `ScanEngine`, `CleaningEngine`, `BinaryThinner` are `actor` types. `PermissionCoordinator`, `SchedulerService`, `SystemMonitor`, `MenuBarController`, `UpdateService`, `FullDiskAccessManager` are `@MainActor` ObservableObjects. |
+| `ViewModels/` | One file: `AppState.swift`, about 1128 lines, `@MainActor final class AppState: ObservableObject`. The single store for the whole app, split into 15 MARK sections. |
+| `Views/` | SwiftUI screens. Subfolders `Apps/`, `Components/`, `Orphans/`, `Settings/`. `Views/Components/AppTheme.swift` holds the design system: CardSurface, IconTile, Tint, MotionTokens, AnimatedCheckboxStyle, EmptyStateView. |
+| `Extensions/` | `Theme.swift`, one View modifier. |
+
+## 5. Code style (observed, not aspirational)
+
+- 4 spaces. No tabs.
+- Types default to `internal` with no explicit modifier. Everything else is `private`.
+  The tree has 573 uses of `private` against 5 explicit `internal`.
+- `// MARK: - Title`, with the dash, in files over roughly 60 lines.
+- Most files have **no header comment block**. They start with `import SwiftUI` or
+  `import Foundation`. A few older files still carry an Xcode template header.
+  New files get no header block.
+- Comments explain **why**, and often cite an issue number such as `(#114)`.
+- State is classic Combine: `ObservableObject` + `@Published` + `@EnvironmentObject` +
+  `@ObservedObject`. The `@Observable` macro is **not used anywhere**
+  (47 `@Published`, 0 `@Observable`). Do not introduce it.
+- Concurrency: `ScanEngine`, `CleaningEngine` and `BinaryThinner` are actors with plain
+  synchronous methods. Actor isolation is the safety, so there are no `async func`
+  declarations on them. Call sites use `Task { }` and `await`. Heavy work uses
+  `Task.detached(priority:)` and returns through
+  `await MainActor.run { [weak self] in }`. Two legacy completion-handler APIs remain,
+  in `AppPathFinder.swift` and `AppState.swift`.
+- Errors: typed `enum: LocalizedError` with `errorDescription`. Most failure paths
+  return an optional or collect messages into an `errors: [String]` array instead of
+  throwing. Only 3 `throws` sites exist in the tree.
+- Logging: `Logger.shared.log(_:level:)`, which wraps `os.Logger`. 16 stray `print()`
+  calls exist. Do not add more.
+- Motion: every animation is gated on `@Environment(\.accessibilityReduceMotion)` and
+  written as `.animation(reduceMotion ? nil : MotionTokens.snappy, value: x)`.
+  New animations must follow this.
+
+## 6. Safety rules
+
+These are not style preferences. Breaking one can destroy user data.
+
+1. **Trash, never delete.** Removal goes through `FileManager.trashItem`. Never `rm`.
+   Do not add ad hoc `FileManager.removeItem` calls.
+2. **Route destructive work through `CleaningEngine`.** It is symlink-resistant, does
+   TOCTOU-safe re-resolution, and is allow-list gated. Do not build a second delete path.
+3. **Respect `OrphanSafetyPolicy.allowedRoots`.** Every orphan removal is gated by this
+   allow-list. Widening it needs a strong, stated reason.
+4. **The app is not sandboxed.** `PureMac.entitlements` sets
+   `com.apple.security.app-sandbox` to `false`. It needs this to work. Do not enable
+   the sandbox.
+5. **Full Disk Access is load-bearing.** Without it the app misses most of what it
+   should find. `FullDiskAccessManager` probes with real reads (`FileHandle` / `Data`),
+   not `FileManager.isReadableFile` or `fileExists`. Metadata-only calls do not trigger
+   TCC, and macOS then never lists the app in the Full Disk Access pane. Do not
+   "optimise" that probe into a metadata check.
+6. **Destructive UI actions always sit behind `.confirmationDialog` or `.alert`.**
+   No exceptions.
+7. `Info.plist` declares an `NSServices` entry (`NSMessage` `uninstallApp`). It powers
+   the Finder right-click "Uninstall with PureMac". Do not remove it by accident.
+
+## 7. Common tasks
+
+### Add a cleaning category
+
+1. Add the case to `CleaningCategory` in `Models/Models.swift`.
+2. Add its search paths to `Logic/Scanning/Locations.swift`. Add per-app exceptions to
+   `Logic/Scanning/Conditions.swift` if the category needs them.
+3. Wire discovery into `Services/ScanEngine.swift`.
+4. Confirm removal goes through `Services/CleaningEngine.swift` and, for orphan-style
+   paths, that the roots are inside `OrphanSafetyPolicy.allowedRoots`.
+5. Surface it in `ViewModels/AppState.swift` and the relevant view.
+6. Add the display name and any count strings to **all 11** `Localizable.strings` files.
+7. Run the tests. Run the app and confirm the destructive action shows a confirmation.
+
+### Add a user-facing string
+
+1. Add the key and English value to `PureMac/en.lproj/Localizable.strings`.
+2. Add the same key to the other 10 `.lproj/Localizable.strings` files. Translate, or
+   fall back to the English value. The key must exist in all 11.
+3. Keep format specifiers identical across all 11. Use `%lld` with `Int64(n)`.
+4. Use it with the right pattern from section 3.
+5. Run `xcodebuild test -project PureMac.xcodeproj -scheme PureMac`.
+
+### Add a view
+
+1. Put the file in `Views/`, or in `Apps/`, `Components/`, `Orphans/` or `Settings/`
+   if it belongs to one of those areas.
+2. No header comment block. Start with `import SwiftUI`.
+3. Read shared state with `@EnvironmentObject var appState: AppState`. Do not create a
+   second store.
+4. Use `AppTheme` pieces (CardSurface, IconTile, Tint, EmptyStateView) instead of new
+   one-off styling.
+5. Gate every animation on `@Environment(\.accessibilityReduceMotion)`.
+6. Add all its strings to the 11 `Localizable.strings` files.
+7. `xcodegen generate` picks the new file up automatically. There is no project file
+   to edit.
+
+## 8. Contributing and release
+
+- Fork, clone, `brew install xcodegen`, `xcodegen generate`, `open PureMac.xcodeproj`.
+- One focused change per PR. Test on macOS 13.0 at minimum. Update `README.md` if
+  user-facing behaviour changes.
+- Issue titles are prefixed `[Bug]` (label `bug`) or `[Feature]` (label `enhancement`).
+- The PR template asks for: what the PR does, type of change, tested-on checkboxes for
+  Ventura 13.x / Sonoma 14.x / Sequoia 15.x, and screenshots.
+- There is no documented commit message convention. Observed style in automation is a
+  lowercase scope prefix and a colon, for example `homebrew: bump to 2.9.7`.
+
+Release: bump `MARKETING_VERSION` in `project.yml`, then push a matching tag
+`v*.*.*`. `.github/workflows/release.yml` archives, signs with Developer ID, builds a
+DMG, notarizes, staples, writes checksums, publishes the GitHub release, and bumps both
+`homebrew/puremac.rb` and the external `momenbasel/homebrew-tap`. It needs 6 secrets,
+documented in `scripts/SECRETS.md`. A fork cannot run this without its own Apple
+Developer ID. Local fallback:
+
+```bash
+scripts/release-local.sh <version> [notary_profile]
+```

--- a/PureMac.xcodeproj/project.pbxproj
+++ b/PureMac.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		013EF7B96BF046D4DB38FBC5 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 241E0895B09C71AB423B2F9E /* Localizable.strings */; };
+		13C51193A0B728AA1CDD3753 /* FileSort.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53EA36E4307DFABBCA35C32 /* FileSort.swift */; };
 		1B0D043102FDB245312A5147 /* AppFilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 798B80977D14647A5691B0A0 /* AppFilesView.swift */; };
 		2253F11BDF561B617439C96B /* FullDiskAccessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E866A1541D289C69144A5E62 /* FullDiskAccessManager.swift */; };
 		25E2304A3FF257F1740E304B /* FileProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7953B398E47A4C603DE287F1 /* FileProtection.swift */; };
@@ -17,6 +18,7 @@
 		41B27CACD7C6C7471EFD03F9 /* UpdateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022D0EAEE2B6E54069FC2CBE /* UpdateService.swift */; };
 		47C5ECD49C4DD75F271DB6CE /* StringNormalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3AC5F17D7CA94FAB1E8D7A /* StringNormalization.swift */; };
 		48D1431A7C99C19EEBDB056B /* CleaningEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A8DE5D45BA19E2670B57DC5 /* CleaningEngine.swift */; };
+		48FD368F84592E36449B0F3D /* SortMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB911FA38E4D306E8F2D2458 /* SortMenu.swift */; };
 		4F754D89F4CE5142BE384062 /* AppConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31F91226CDCFBB8E303B7DA /* AppConstants.swift */; };
 		50304378D99F2E9E48B642AF /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 9CC8F66E27BE52A6639E904B /* Sparkle */; };
 		52F11962555C639F0EECADD6 /* FDADemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231FF7CBB5F621B66F2AB8A5 /* FDADemoView.swift */; };
@@ -137,6 +139,7 @@
 		B2CD0028599BE178B96F18A6 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B2EA41E1096FA8E3B916AD13 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B71E8F62DB76D85F41F9A2E9 /* OrphanListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrphanListView.swift; sourceTree = "<group>"; };
+		BB911FA38E4D306E8F2D2458 /* SortMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortMenu.swift; sourceTree = "<group>"; };
 		C0899FE169D270DF95334905 /* LanguageFilesScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageFilesScanner.swift; sourceTree = "<group>"; };
 		C4332033E243C3571C49A5E9 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C5963EBBEE5BA6E147700821 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -148,6 +151,7 @@
 		DAA389C4F50505795FB31A51 /* SmartCareCoreArtwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartCareCoreArtwork.swift; sourceTree = "<group>"; };
 		DB798781B99987F55D77E2E3 /* SystemMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMonitor.swift; sourceTree = "<group>"; };
 		DFC4A1FD7DB92C82725B4314 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		E53EA36E4307DFABBCA35C32 /* FileSort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSort.swift; sourceTree = "<group>"; };
 		E866A1541D289C69144A5E62 /* FullDiskAccessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullDiskAccessManager.swift; sourceTree = "<group>"; };
 		ED0C4D8912DA94F81B2AEF8F /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		EEF15CB1B8EFCA78EF491824 /* ScanError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanError.swift; sourceTree = "<group>"; };
@@ -193,6 +197,7 @@
 			isa = PBXGroup;
 			children = (
 				82BB0904726B38DEB141BECA /* AppLanguage.swift */,
+				E53EA36E4307DFABBCA35C32 /* FileSort.swift */,
 				3667D46D8E2004EB4D73835A /* Models.swift */,
 				EEF15CB1B8EFCA78EF491824 /* ScanError.swift */,
 			);
@@ -269,6 +274,7 @@
 				A27DB5A70FA829B6C3ED0AC3 /* MenuBarMonitorView.swift */,
 				069AAE87E3F9EDE5593AD8B3 /* PermissionSheet.swift */,
 				DAA389C4F50505795FB31A51 /* SmartCareCoreArtwork.swift */,
+				BB911FA38E4D306E8F2D2458 /* SortMenu.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -498,6 +504,7 @@
 				52F11962555C639F0EECADD6 /* FDADemoView.swift in Sources */,
 				25E2304A3FF257F1740E304B /* FileProtection.swift in Sources */,
 				B51E5A95BB49A6C0F5273E21 /* FileSize.swift in Sources */,
+				13C51193A0B728AA1CDD3753 /* FileSort.swift in Sources */,
 				2253F11BDF561B617439C96B /* FullDiskAccessManager.swift in Sources */,
 				A549D8A39A9E5E70D91B90A6 /* Haptics.swift in Sources */,
 				9E87638A3F12C12D93995DA7 /* LanguageFilesScanner.swift in Sources */,
@@ -520,6 +527,7 @@
 				93743B036059418560D876E6 /* SettingsView.swift in Sources */,
 				6753946A301B2EB2FEF6998B /* SimulatorRuntimeSupport.swift in Sources */,
 				B928E4369A3FC4369F014A29 /* SmartCareCoreArtwork.swift in Sources */,
+				48FD368F84592E36449B0F3D /* SortMenu.swift in Sources */,
 				47C5ECD49C4DD75F271DB6CE /* StringNormalization.swift in Sources */,
 				DBFD73E3D9BDA74EC1CA56AB /* SystemMonitor.swift in Sources */,
 				340E424F759ACCDE7372F99F /* Theme.swift in Sources */,

--- a/PureMac/Models/FileSort.swift
+++ b/PureMac/Models/FileSort.swift
@@ -1,0 +1,209 @@
+import Foundation
+import SwiftUI
+
+// MARK: - Sort Field
+
+/// The dimension a file list is ordered by.
+///
+/// One preference is shared by every list in the app rather than one per
+/// screen. The complaint this solves is that sorting was missing or forgotten,
+/// not that each screen needed its own memory.
+enum FileSortField: String, CaseIterable, Identifiable {
+    case name
+    case size
+    case date
+    case path
+
+    var id: String { rawValue }
+
+    /// English source string. Resolved through the standard literal lookup, so
+    /// the returned value must exist as a key in every Localizable.strings.
+    var label: String {
+        switch self {
+        case .name: return "Name"
+        case .size: return "Size"
+        case .date: return "Date Modified"
+        case .path: return "Path"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .name: return "textformat"
+        case .size: return "externaldrive"
+        case .date: return "calendar"
+        case .path: return "folder"
+        }
+    }
+
+    /// "Largest First" reads better than "Descending" for a cleaner, so each
+    /// field names its own directions.
+    func directionLabel(ascending: Bool) -> String {
+        switch self {
+        case .size: return ascending ? "Smallest First" : "Largest First"
+        case .date: return ascending ? "Oldest First" : "Newest First"
+        case .name, .path: return ascending ? "A to Z" : "Z to A"
+        }
+    }
+
+    /// Fields that need a modification date. Lists rendering bare URLs do not
+    /// carry one, so they offer the remaining fields only.
+    static let fieldsWithoutDate: [FileSortField] = [.name, .size, .path]
+}
+
+// MARK: - Sortable
+
+/// Anything a file list can order.
+///
+/// Views that render bare URLs cannot conform, because size and date do not
+/// live on the URL. Those use `FileSort.sortedURLs(_:by:ascending:context:)`.
+protocol SortableItem {
+    var sortName: String { get }
+    var sortSize: Int64 { get }
+    var sortDate: Date? { get }
+    var sortPath: String { get }
+}
+
+extension CleanableItem: SortableItem {
+    var sortName: String { name }
+    var sortSize: Int64 { size }
+    var sortDate: Date? { lastModified }
+    var sortPath: String { path }
+}
+
+extension Sequence where Element: SortableItem {
+    func sorted(by field: FileSortField, ascending: Bool) -> [Element] {
+        sorted { FileSort.isOrderedBefore($0, $1, by: field, ascending: ascending) }
+    }
+}
+
+// MARK: - Comparators
+
+enum FileSort {
+    /// Matches the behaviour the size-only toolbar toggle used to default to.
+    static let defaultField: FileSortField = .size
+    static let defaultAscending = false
+
+    static let fieldPreferenceKey = "settings.sort.field"
+    static let ascendingPreferenceKey = "settings.sort.ascending"
+
+    static func isOrderedBefore<T: SortableItem>(
+        _ lhs: T,
+        _ rhs: T,
+        by field: FileSortField,
+        ascending: Bool
+    ) -> Bool {
+        switch field {
+        case .name:
+            let order = lhs.sortName.localizedStandardCompare(rhs.sortName)
+            if order != .orderedSame {
+                return ascending ? order == .orderedAscending : order == .orderedDescending
+            }
+        case .path:
+            let order = lhs.sortPath.localizedStandardCompare(rhs.sortPath)
+            if order != .orderedSame {
+                return ascending ? order == .orderedAscending : order == .orderedDescending
+            }
+        case .size:
+            if lhs.sortSize != rhs.sortSize {
+                return ascending ? lhs.sortSize < rhs.sortSize : lhs.sortSize > rhs.sortSize
+            }
+        case .date:
+            // Undated rows sink to the bottom in both directions so the list
+            // never leads with unknowns.
+            switch (lhs.sortDate, rhs.sortDate) {
+            case let (left?, right?):
+                if left != right { return ascending ? left < right : left > right }
+            case (nil, _?):
+                return false
+            case (_?, nil):
+                return true
+            case (nil, nil):
+                break
+            }
+        }
+
+        // Stable tie-break. Without it, equal rows shuffle between renders and
+        // the removal transitions animate the wrong row out.
+        return lhs.sortName.localizedStandardCompare(rhs.sortName) == .orderedAscending
+    }
+}
+
+// MARK: - URL Lists
+
+extension FileSort {
+    /// Sizes and dates for lists that render bare URLs.
+    ///
+    /// Both callers already keep a size cache built off the main thread, so the
+    /// comparator never touches the filesystem. A comparator runs O(n log n)
+    /// times, and a cache miss in `AppFilesView` falls through to a live
+    /// recursive directory walk, which would beachball the UI.
+    struct Context {
+        var sizes: [URL: Int64]
+        var dates: [URL: Date]
+
+        init(sizes: [URL: Int64] = [:], dates: [URL: Date] = [:]) {
+            self.sizes = sizes
+            self.dates = dates
+        }
+    }
+
+    private struct SortableURL: SortableItem {
+        let url: URL
+        let sortSize: Int64
+        let sortDate: Date?
+
+        var sortName: String { url.lastPathComponent }
+        var sortPath: String { url.path }
+    }
+
+    static func sortedURLs(
+        _ urls: [URL],
+        by field: FileSortField,
+        ascending: Bool,
+        context: Context
+    ) -> [URL] {
+        urls
+            .map { SortableURL(url: $0, sortSize: context.sizes[$0] ?? 0, sortDate: context.dates[$0]) }
+            .sorted(by: field, ascending: ascending)
+            .map(\.url)
+    }
+}
+
+// MARK: - Table Bridge
+
+extension FileSort {
+    /// Feeds the shared preference into the one native `Table` in the app.
+    ///
+    /// `InstalledApp` has no modification date and the table shows no path
+    /// column, so both fall back to the name column.
+    static func comparators(
+        for field: FileSortField,
+        ascending: Bool
+    ) -> [KeyPathComparator<InstalledApp>] {
+        let order: SortOrder = ascending ? .forward : .reverse
+        switch field {
+        case .size:
+            return [KeyPathComparator(\InstalledApp.size, order: order)]
+        case .name, .date, .path:
+            return [KeyPathComparator(\InstalledApp.appName, order: order)]
+        }
+    }
+
+    /// Maps a column click back onto the shared preference so the choice
+    /// carries over to the other lists.
+    static func preference(
+        from comparators: [KeyPathComparator<InstalledApp>]
+    ) -> (field: FileSortField, ascending: Bool)? {
+        guard let first = comparators.first else { return nil }
+        let ascending = first.order == .forward
+
+        if first.keyPath == \InstalledApp.size {
+            return (.size, ascending)
+        }
+        if first.keyPath == \InstalledApp.appName {
+            return (.name, ascending)
+        }
+        return nil
+    }
+}

--- a/PureMac/Views/Apps/AppFilesView.swift
+++ b/PureMac/Views/Apps/AppFilesView.swift
@@ -63,6 +63,8 @@ struct AppFilesView: View {
     /// One-pass size cache so group headers and the selected-size counter
     /// don't re-stat the disk on every render.
     @State private var sizeCache: [URL: Int64] = [:]
+    @AppStorage(FileSort.fieldPreferenceKey) private var sortField: FileSortField = FileSort.defaultField
+    @AppStorage(FileSort.ascendingPreferenceKey) private var sortAscending: Bool = FileSort.defaultAscending
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private var totalSelectedSize: Int64 {
@@ -71,13 +73,24 @@ struct AppFilesView: View {
         }
     }
 
-    /// Discovered files bucketed for display, preserving the sorted order
-    /// inside each bucket. Only non-empty groups are shown.
+    /// Discovered files bucketed for display, ordered inside each bucket by the
+    /// shared sort preference. Only non-empty groups are shown, and the group
+    /// order stays fixed to `LeftoverGroup.allCases` so headers do not jump when
+    /// the sort changes.
     private var groupedFiles: [(group: LeftoverGroup, urls: [URL])] {
         let buckets = Dictionary(grouping: appState.discoveredFiles, by: LeftoverGroup.categorize)
+        // Read the cache once. `cachedSize` falls through to a live recursive
+        // walk on a miss, and a comparator runs O(n log n) times.
+        let context = FileSort.Context(sizes: sizeCache)
         return LeftoverGroup.allCases.compactMap { group in
             guard let urls = buckets[group], !urls.isEmpty else { return nil }
-            return (group, urls)
+            let ordered = FileSort.sortedURLs(
+                urls,
+                by: sortField,
+                ascending: sortAscending,
+                context: context
+            )
+            return (group, ordered)
         }
     }
 
@@ -312,6 +325,17 @@ struct AppFilesView: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
+
+            // This view has no toolbar, so the sort control lives in the
+            // action bar. Leftovers are bare URLs with no modification date.
+            SortMenu(
+                field: $sortField,
+                ascending: $sortAscending,
+                fields: FileSortField.fieldsWithoutDate
+            )
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .fixedSize()
 
             Spacer()
 

--- a/PureMac/Views/Apps/AppListView.swift
+++ b/PureMac/Views/Apps/AppListView.swift
@@ -5,9 +5,21 @@ struct AppListView: View {
     @State private var searchText = ""
     @State private var selection: InstalledApp.ID?
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var sortOrder: [KeyPathComparator<InstalledApp>] = [
-        .init(\.appName, order: .forward)
-    ]
+    @AppStorage(FileSort.fieldPreferenceKey) private var sortField: FileSortField = FileSort.defaultField
+    @AppStorage(FileSort.ascendingPreferenceKey) private var sortAscending: Bool = FileSort.defaultAscending
+
+    /// Derived from the shared preference rather than held in `@State`, so a
+    /// column click here and a sort menu choice elsewhere stay in step.
+    private var sortOrderBinding: Binding<[KeyPathComparator<InstalledApp>]> {
+        Binding(
+            get: { FileSort.comparators(for: sortField, ascending: sortAscending) },
+            set: { newValue in
+                guard let preference = FileSort.preference(from: newValue) else { return }
+                sortField = preference.field
+                sortAscending = preference.ascending
+            }
+        )
+    }
 
     private var filteredApps: [InstalledApp] {
         let base: [InstalledApp]
@@ -20,7 +32,7 @@ struct AppListView: View {
                 $0.bundleIdentifier.lowercased().contains(query)
             }
         }
-        return base.sorted(using: sortOrder)
+        return base.sorted(using: FileSort.comparators(for: sortField, ascending: sortAscending))
     }
 
     var body: some View {
@@ -84,7 +96,7 @@ struct AppListView: View {
                     actionLabel: "Retry"
                 )
             } else {
-                Table(filteredApps, selection: $selection, sortOrder: $sortOrder) {
+                Table(filteredApps, selection: $selection, sortOrder: sortOrderBinding) {
                     TableColumn("Application", value: \.appName) { app in
                         HStack(spacing: 8) {
                             HoverScaleIcon(icon: app.icon)

--- a/PureMac/Views/CategoryDetailView.swift
+++ b/PureMac/Views/CategoryDetailView.swift
@@ -4,7 +4,8 @@ struct CategoryDetailView: View {
     @EnvironmentObject var appState: AppState
     let category: CleaningCategory
 
-    @State private var sortDescending: Bool = true
+    @AppStorage(FileSort.fieldPreferenceKey) private var sortField: FileSortField = FileSort.defaultField
+    @AppStorage(FileSort.ascendingPreferenceKey) private var sortAscending: Bool = FileSort.defaultAscending
     @State private var searchText = ""
     @State private var showConfirmation = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -51,14 +52,7 @@ struct CategoryDetailView: View {
 
             ToolbarItem(placement: .automatic) {
                 if let result = result, !result.items.isEmpty {
-                    Button(action: { sortDescending.toggle() }) {
-                        Label {
-                            Text(LocalizedStringKey(sortDescending ? "Largest First" : "Smallest First"))
-                        } icon: {
-                            Image(systemName: "arrow.up.arrow.down")
-                        }
-                    }
-                    .help(LocalizedStringKey(sortDescending ? "Sorted: Largest First" : "Sorted: Smallest First"))
+                    SortMenu(field: $sortField, ascending: $sortAscending)
                 }
             }
         }
@@ -226,12 +220,13 @@ struct CategoryDetailView: View {
         }
         // CleanableItem ids are stable, so SwiftUI move-animates re-sorts and
         // fades filtered rows instead of snapping.
-        .animation(reduceMotion ? nil : .spring(response: 0.4, dampingFraction: 0.85), value: sortDescending)
+        .animation(reduceMotion ? nil : .spring(response: 0.4, dampingFraction: 0.85), value: sortField)
+        .animation(reduceMotion ? nil : .spring(response: 0.4, dampingFraction: 0.85), value: sortAscending)
         .animation(reduceMotion ? nil : .easeOut(duration: 0.2), value: searchText)
     }
 
     private func sortedItems(_ items: [CleanableItem]) -> [CleanableItem] {
-        items.sorted { sortDescending ? $0.size > $1.size : $0.size < $1.size }
+        items.sorted(by: sortField, ascending: sortAscending)
     }
 }
 

--- a/PureMac/Views/Components/SortMenu.swift
+++ b/PureMac/Views/Components/SortMenu.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// The sort control shared by every file list.
+///
+/// It replaces the old icon-only toolbar toggle, which offered size order
+/// only and read as no control at all because the macOS toolbar collapses
+/// the button title.
+struct SortMenu: View {
+    @Binding var field: FileSortField
+    @Binding var ascending: Bool
+
+    /// Lists that render bare URLs have no modification date, so they pass
+    /// `FileSortField.fieldsWithoutDate` rather than showing a field that
+    /// cannot order anything.
+    var fields: [FileSortField] = FileSortField.allCases
+
+    var body: some View {
+        Menu {
+            Picker(selection: $field) {
+                ForEach(fields) { option in
+                    Label(LocalizedStringKey(option.label), systemImage: option.systemImage)
+                        .tag(option)
+                }
+            } label: {
+                Text("Sort By")
+            }
+            .pickerStyle(.inline)
+
+            Divider()
+
+            Picker(selection: $ascending) {
+                Text(LocalizedStringKey(field.directionLabel(ascending: true))).tag(true)
+                Text(LocalizedStringKey(field.directionLabel(ascending: false))).tag(false)
+            } label: {
+                Text("Order")
+            }
+            .pickerStyle(.inline)
+        } label: {
+            Label("Sort", systemImage: "arrow.up.arrow.down")
+        }
+        .help(helpText)
+    }
+
+    private var helpText: String {
+        String(
+            format: String(localized: "Sorted by %@"),
+            String(localized: String.LocalizationValue(field.label))
+        )
+    }
+}

--- a/PureMac/Views/MainWindow.swift
+++ b/PureMac/Views/MainWindow.swift
@@ -555,7 +555,7 @@ private struct SidebarNavRow: View {
                 Text(badge)
                     .font(.system(size: 9.75, weight: .semibold))
                     .monospacedDigit()
-                    .foregroundStyle(isFeatured && isSelected ? tint : .secondary)
+                    .foregroundStyle(isFeatured && isSelected ? tint : badgeColor)
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
                     .background(
@@ -629,6 +629,18 @@ private struct SidebarNavRow: View {
         colorScheme == .dark
             ? Color.white.opacity(0.92)
             : Color.black.opacity(0.85)
+    }
+
+    /// Dimmed counterpart to `labelColor` for the count badge.
+    ///
+    /// The #117 fix assumed badges were safe because they were "explicitly
+    /// colored". They were not: `.secondary` is a hierarchical style resolved
+    /// through the same vibrancy path that made the row label disappear, so on
+    /// the affected configs the badge rendered as an empty capsule (issue #141).
+    private var badgeColor: Color {
+        colorScheme == .dark
+            ? Color.white.opacity(0.62)
+            : Color.black.opacity(0.55)
     }
 }
 

--- a/PureMac/Views/Orphans/OrphanListView.swift
+++ b/PureMac/Views/Orphans/OrphanListView.swift
@@ -11,7 +11,24 @@ struct OrphanListView: View {
     /// every realized row on each selection toggle and beachball the UI. We walk
     /// once off-main per result set and rows read the cached value.
     @State private var sizeCache: [URL: Int64] = [:]
+    /// Modification dates gathered in the same off-main walk as the sizes, so
+    /// ordering by date costs no extra pass over the disk.
+    @State private var dateCache: [URL: Date] = [:]
+    @AppStorage(FileSort.fieldPreferenceKey) private var sortField: FileSortField = FileSort.defaultField
+    @AppStorage(FileSort.ascendingPreferenceKey) private var sortAscending: Bool = FileSort.defaultAscending
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Rows read from the caches only. Both start empty and fill in from the
+    /// task below, so an unmeasured row sorts as zero and the list re-sorts
+    /// once the walk lands.
+    private var sortedOrphans: [URL] {
+        FileSort.sortedURLs(
+            appState.orphanedFiles,
+            by: sortField,
+            ascending: sortAscending,
+            context: FileSort.Context(sizes: sizeCache, dates: dateCache)
+        )
+    }
 
     var body: some View {
         Group {
@@ -29,7 +46,7 @@ struct OrphanListView: View {
                     // No .staggered(): List is lazy, so a delayed-reveal would
                     // blank each row as it scrolls in. The removal transition
                     // below still gives the sweep-out on delete.
-                    ForEach(Array(appState.orphanedFiles.enumerated()), id: \.element) { _, fileURL in
+                    ForEach(Array(sortedOrphans.enumerated()), id: \.element) { _, fileURL in
                         OrphanRowView(
                             fileURL: fileURL,
                             isSelected: orphanBinding(for: fileURL),
@@ -54,6 +71,10 @@ struct OrphanListView: View {
                 }
             }
         }
+        // URLs are stable ids, so SwiftUI move-animates a re-sort instead of
+        // snapping the rows.
+        .animation(reduceMotion ? nil : .spring(response: 0.4, dampingFraction: 0.85), value: sortField)
+        .animation(reduceMotion ? nil : .spring(response: 0.4, dampingFraction: 0.85), value: sortAscending)
         .navigationTitle(orphanedFilesTitle)
         .task(id: appState.orphanedFiles) {
             // Recompute off the main thread whenever the orphan set changes
@@ -61,18 +82,31 @@ struct OrphanListView: View {
             // with no main-actor isolation, so it runs safely on a detached
             // background task; the result is applied back on the main actor.
             let urls = appState.orphanedFiles
-            let sizes = await Task.detached(priority: .utility) { () -> [URL: Int64] in
-                var out: [URL: Int64] = [:]
+            let measured = await Task.detached(priority: .utility) { () -> (sizes: [URL: Int64], dates: [URL: Date]) in
+                var sizes: [URL: Int64] = [:]
+                var dates: [URL: Date] = [:]
                 for url in urls {
-                    out[url] = FileSizeCalculator.size(of: url) ?? 0
+                    sizes[url] = FileSizeCalculator.size(of: url) ?? 0
+                    // Same walk, one extra stat. Undated entries are left out
+                    // and sink to the bottom when ordering by date.
+                    if let date = try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate {
+                        dates[url] = date
+                    }
                 }
-                return out
+                return (sizes, dates)
             }.value
-            sizeCache = sizes
+            sizeCache = measured.sizes
+            dateCache = measured.dates
         }
         .toolbar {
             ToolbarItemGroup {
                 if !appState.orphanedFiles.isEmpty {
+                    SortMenu(
+                        field: $sortField,
+                        ascending: $sortAscending,
+                        fields: FileSortField.allCases
+                    )
+
                     Button(LocalizedStringKey(selectedOrphans.count == appState.orphanedFiles.count ? "Deselect All" : "Select All")) {
                         if selectedOrphans.count == appState.orphanedFiles.count {
                             selectedOrphans.removeAll()

--- a/PureMac/ar.lproj/Localizable.strings
+++ b/PureMac/ar.lproj/Localizable.strings
@@ -460,3 +460,16 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "وقت تشغيل المحاكي";
+
+/* Sorting */
+"Sort" = "فرز";
+"Sort By" = "الفرز حسب";
+"Order" = "الترتيب";
+"Name" = "الاسم";
+"Date Modified" = "تاريخ التعديل";
+"Path" = "المسار";
+"Oldest First" = "الأقدم أولاً";
+"Newest First" = "الأحدث أولاً";
+"A to Z" = "من الألف إلى الياء";
+"Z to A" = "من الياء إلى الألف";
+"Sorted by %@" = "مرتب حسب %@";

--- a/PureMac/en.lproj/Localizable.strings
+++ b/PureMac/en.lproj/Localizable.strings
@@ -460,3 +460,16 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "Simulator runtime";
+
+/* Sorting */
+"Sort" = "Sort";
+"Sort By" = "Sort By";
+"Order" = "Order";
+"Name" = "Name";
+"Date Modified" = "Date Modified";
+"Path" = "Path";
+"Oldest First" = "Oldest First";
+"Newest First" = "Newest First";
+"A to Z" = "A to Z";
+"Z to A" = "Z to A";
+"Sorted by %@" = "Sorted by %@";

--- a/PureMac/es.lproj/Localizable.strings
+++ b/PureMac/es.lproj/Localizable.strings
@@ -460,3 +460,16 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "Runtime del simulador";
+
+/* Sorting */
+"Sort" = "Ordenar";
+"Sort By" = "Ordenar por";
+"Order" = "Orden";
+"Name" = "Nombre";
+"Date Modified" = "Fecha de modificación";
+"Path" = "Ruta";
+"Oldest First" = "Más antiguos primero";
+"Newest First" = "Más recientes primero";
+"A to Z" = "De la A a la Z";
+"Z to A" = "De la Z a la A";
+"Sorted by %@" = "Ordenado por %@";

--- a/PureMac/fr.lproj/Localizable.strings
+++ b/PureMac/fr.lproj/Localizable.strings
@@ -456,3 +456,16 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "Runtime de simulateur";
+
+/* Sorting */
+"Sort" = "Trier";
+"Sort By" = "Trier par";
+"Order" = "Ordre";
+"Name" = "Nom";
+"Date Modified" = "Date de modification";
+"Path" = "Chemin";
+"Oldest First" = "Les plus anciens d'abord";
+"Newest First" = "Les plus récents d'abord";
+"A to Z" = "De A à Z";
+"Z to A" = "De Z à A";
+"Sorted by %@" = "Trié par %@";

--- a/PureMac/ja.lproj/Localizable.strings
+++ b/PureMac/ja.lproj/Localizable.strings
@@ -460,3 +460,16 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "シミュレータランタイム";
+
+/* Sorting */
+"Sort" = "並べ替え";
+"Sort By" = "並べ替えの基準";
+"Order" = "順序";
+"Name" = "名前";
+"Date Modified" = "変更日";
+"Path" = "パス";
+"Oldest First" = "古い順";
+"Newest First" = "新しい順";
+"A to Z" = "昇順 (A→Z)";
+"Z to A" = "降順 (Z→A)";
+"Sorted by %@" = "%@ で並べ替え";

--- a/PureMac/pl.lproj/Localizable.strings
+++ b/PureMac/pl.lproj/Localizable.strings
@@ -460,3 +460,16 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "Środowisko uruchomieniowe symulatora";
+
+/* Sorting */
+"Sort" = "Sortuj";
+"Sort By" = "Sortuj według";
+"Order" = "Kolejność";
+"Name" = "Nazwa";
+"Date Modified" = "Data modyfikacji";
+"Path" = "Ścieżka";
+"Oldest First" = "Najstarsze najpierw";
+"Newest First" = "Najnowsze najpierw";
+"A to Z" = "Od A do Z";
+"Z to A" = "Od Z do A";
+"Sorted by %@" = "Posortowano według %@";

--- a/PureMac/pt-BR.lproj/Localizable.strings
+++ b/PureMac/pt-BR.lproj/Localizable.strings
@@ -460,3 +460,16 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "Runtime do simulador";
+
+/* Sorting */
+"Sort" = "Ordenar";
+"Sort By" = "Ordenar por";
+"Order" = "Ordem";
+"Name" = "Nome";
+"Date Modified" = "Data de modificação";
+"Path" = "Caminho";
+"Oldest First" = "Mais antigos primeiro";
+"Newest First" = "Mais recentes primeiro";
+"A to Z" = "De A a Z";
+"Z to A" = "De Z a A";
+"Sorted by %@" = "Ordenado por %@";

--- a/PureMac/ru.lproj/Localizable.strings
+++ b/PureMac/ru.lproj/Localizable.strings
@@ -460,3 +460,16 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "Среда выполнения симулятора";
+
+/* Sorting */
+"Sort" = "Сортировка";
+"Sort By" = "Сортировать по";
+"Order" = "Порядок";
+"Name" = "Имя";
+"Date Modified" = "Дата изменения";
+"Path" = "Путь";
+"Oldest First" = "Сначала старые";
+"Newest First" = "Сначала новые";
+"A to Z" = "От А до Я";
+"Z to A" = "От Я до А";
+"Sorted by %@" = "Сортировка по %@";

--- a/PureMac/uk.lproj/Localizable.strings
+++ b/PureMac/uk.lproj/Localizable.strings
@@ -460,3 +460,16 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "Середовище виконання симулятора";
+
+/* Sorting */
+"Sort" = "Сортування";
+"Sort By" = "Сортувати за";
+"Order" = "Порядок";
+"Name" = "Назва";
+"Date Modified" = "Дата зміни";
+"Path" = "Шлях";
+"Oldest First" = "Спочатку старі";
+"Newest First" = "Спочатку нові";
+"A to Z" = "Від А до Я";
+"Z to A" = "Від Я до А";
+"Sorted by %@" = "Сортування за %@";

--- a/PureMac/zh-Hans.lproj/Localizable.strings
+++ b/PureMac/zh-Hans.lproj/Localizable.strings
@@ -460,3 +460,16 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "模拟器运行时";
+
+/* Sorting */
+"Sort" = "排序";
+"Sort By" = "排序方式";
+"Order" = "顺序";
+"Name" = "名称";
+"Date Modified" = "修改日期";
+"Path" = "路径";
+"Oldest First" = "最旧优先";
+"Newest First" = "最新优先";
+"A to Z" = "A 到 Z";
+"Z to A" = "Z 到 A";
+"Sorted by %@" = "按 %@ 排序";

--- a/PureMac/zh-Hant.lproj/Localizable.strings
+++ b/PureMac/zh-Hant.lproj/Localizable.strings
@@ -460,3 +460,16 @@
 
 /* Simulator runtimes */
 "Simulator runtime" = "模擬器執行環境";
+
+/* Sorting */
+"Sort" = "排序";
+"Sort By" = "排序方式";
+"Order" = "順序";
+"Name" = "名稱";
+"Date Modified" = "修改日期";
+"Path" = "路徑";
+"Oldest First" = "最舊優先";
+"Newest First" = "最新優先";
+"A to Z" = "A 到 Z";
+"Z to A" = "Z 到 A";
+"Sorted by %@" = "按 %@ 排序";


### PR DESCRIPTION
## What does this PR do

Three separate commits. The first is the feature, the second is a one-line bug fix, the third is documentation. Happy to split them into separate PRs if you would rather review them apart.

### 1. `sort:` a shared sort control on every file list

Today sorting exists in one and a half places:

| List | Sort available before |
| --- | --- |
| `CategoryDetailView` | Size only, via an icon-only toolbar button |
| `AppListView` | Yes, native `Table` column sort |
| `AppFilesView` (app leftovers) | None |
| `OrphanListView` | None |

Three problems with that:

- The `CategoryDetailView` control is a `Button` whose `Label` title the macOS toolbar collapses, so it renders as a bare `arrow.up.arrow.down` glyph. It reads as decoration, not a control.
- The orphan list and the leftovers list both show a size per row and give you no way to order by it. That is the exact screen where someone hunting for the big item expects "sort by size".
- Sort choice was `@State`, so it reset on every navigation.

This adds:

- `PureMac/Models/FileSort.swift` - `FileSortField` (name, size, date, path), a `SortableItem` protocol with a `CleanableItem` conformance, a stable comparator, a `sortedURLs` helper for the two lists that render bare `URL`s, and a bridge to `KeyPathComparator` for the existing `Table`.
- `PureMac/Views/Components/SortMenu.swift` - one `Menu` used by all four lists.

Details worth flagging for review:

- **One shared preference**, two `@AppStorage` keys (`settings.sort.field`, `settings.sort.ascending`), following the `settings.<area>.<name>` convention already in `SettingsView`. It survives navigation and relaunch. A column click in the apps `Table` writes back to the same preference, so the choice carries across screens. I deliberately did not put this on `AppState`, since every `@Published` there re-renders the tree.
- **Direction labels are per field.** Size reads "Largest First", date reads "Newest First", name reads "Z to A". "Descending" would be worse copy for a cleaner.
- **The two URL lists keep their existing `List` layout.** `Table` is not viable for them: `CategoryDetailView` rows carry per-row checkbox bindings into `selectedCleanupItems`, `AppFilesView` rows sit inside `DisclosureGroup`s and hierarchical `Table` is macOS 14+, and the deployment target is 13.0.
- **Comparators never touch the filesystem.** `AppFilesView.cachedSize` falls through to a live recursive walk on a miss and a comparator runs O(n log n) times, so the cache is snapshotted into a local `FileSort.Context` before sorting.
- **`OrphanListView` now also collects modification dates** in the same off-main walk that already measured sizes. One extra `resourceValues` read per URL, no extra pass over the disk.
- Undated rows sink to the bottom in both directions. A name tie-break keeps the order stable, so equal rows do not shuffle between renders and the removal transitions animate the right row out.
- Group order in `AppFilesView` stays pinned to `LeftoverGroup.allCases` so headers do not jump when the sort changes.
- Re-sort animations are gated on `accessibilityReduceMotion`, matching the rest of the codebase.
- 11 new keys added to **all 11** `Localizable.strings` files. `LocalizationFilesTests` passes.

### 2. `sidebar:` count badge uses a literal color (fixes #141)

The #117 fix gave the sidebar row label an explicit `colorScheme`-driven color, because the inherited vibrant label style resolved transparent on some configs. Its reasoning recorded that "explicitly-colored text (headers, badges) stayed visible", and left the badge alone.

The badge was not explicitly colored. It used `.secondary`, a hierarchical style resolved through the same vibrancy path. On the affected configs it collapses too, which is why the #141 screenshot shows an empty grey capsule where the count should be: the `Capsule` fill paints, the `Text` does not. Icons were never affected because `IconTile` always sets a concrete `Color`.

One line, plus a `badgeColor` computed property mirroring the existing `labelColor`.

**I could not reproduce #141 on my hardware**, so this is a root-cause fix reasoned from the code, not a confirmed repro. Worth having one of the reporters on the issue confirm before you cut a release on it.

### 3. `docs:` CLAUDE.md and AGENTS.md

Records what an agent or a new contributor gets wrong on a first pass: that `PureMac.xcodeproj` is generated by XcodeGen and must not be hand-edited, that `LocalizationFilesTests` enforces key parity across all 11 languages and fails on **extra** keys as well as missing ones, that CI builds but does not run tests so a broken string set still goes green, and that destructive work must route through `CleaningEngine` and `OrphanSafetyPolicy` rather than a new delete path.

Drop this commit if you would rather not carry agent docs in the repo.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] UI/UX improvement
- [x] Documentation

## Tested on

- [ ] macOS Ventura 13.x
- [x] macOS Sonoma 14.x
- [x] macOS Sequoia 15.x

**Not tested on any of the above.** Built and run on macOS 26.0 (arm64) with Xcode 26.6 only. Every API used is macOS 13 compatible and the project still builds against the 13.0 deployment target, but I have no 13/14/15 machine to confirm on. Please treat the compatibility checkboxes as unverified.

Verified locally:

- `xcodebuild -project PureMac.xcodeproj -scheme PureMac -configuration Debug -destination 'platform=macOS' build` - **BUILD SUCCEEDED**, no new warnings
- `xcodebuild ... test` - **19/19 pass**, including all 5 `LocalizationFilesTests`
- Ran the app and confirmed by hand: the sort menu renders in the toolbar with Sort By (Name / Size / Date Modified / Path) and Order, the direction labels change with the selected field, the choice persists across navigation, and the apps `Table` now opens on the shared preference instead of its old name-ascending default.
- `xcodegen generate` was re-run; the `project.pbxproj` diff is +8 lines for the two new sources and nothing else.

## Notes for the maintainer

Two things I found while working in here but did **not** touch, since both are behavioural changes that deserve your call rather than a drive-by in a sorting PR:

1. `CleaningEngine.swift:150` uses `FileManager.removeItem`, not `trashItem`, and it is the primary delete path for every general scan category. `OrphanListView.swift` has a second `removeItem` call outside `CleaningEngine` entirely. The README promises "Trash, never `rm`". I suspect the current behaviour is deliberate, since trashing a cache does not free the space until the Trash is emptied, but then the README overclaims. Either way the two disagree.
2. `CleaningEngine.isExplicitSingleFileDeletable` (around line 724) does not call `ProviderPaths.isProviderOwned`, unlike `isSafeToDelete`. Today it fails safe by accident: the resolved path of an iCloud-synced Desktop lands under `Mobile Documents`, so the `hasPrefix` check simply does not match. That is a side effect of symlink resolution rather than an explicit guard, and it is the same class of thing as #142.

Happy to open issues for either.
