### PR TITLE
Add advanced storage intelligence, diagnostics, and filesystem performance optimizations

### DIFF
--- a/PureMac.xcodeproj/project.pbxproj
+++ b/PureMac.xcodeproj/project.pbxproj
@@ -39,10 +39,52 @@
 		9BB5AAA574AFED6C27A3F8E2 /* AppPathFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0FEE7141871ED5F9E36121 /* AppPathFinder.swift */; };
 		9E3639F9EFCB2A22F6747894 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 913E3064AA9BD7BE94A315CF /* MenuBarController.swift */; };
 		9E87638A3F12C12D93995DA7 /* LanguageFilesScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0899FE169D270DF95334905 /* LanguageFilesScanner.swift */; };
+		A10000000000000000000005 /* StorageAnalysisModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000001 /* StorageAnalysisModels.swift */; };
+		A10000000000000000000006 /* FileTreeScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000002 /* FileTreeScanner.swift */; };
+		A10000000000000000000007 /* FileTreeScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000003 /* FileTreeScannerTests.swift */; };
+		A20000000000000000000004 /* ApplicationSupportAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000001 /* ApplicationSupportAnalyzer.swift */; };
+		A20000000000000000000005 /* ApplicationSupportAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000002 /* ApplicationSupportAnalyzerTests.swift */; };
 		A2AE68CC75CB72D6B10CBDF5 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F661A0F64CF93E482CB1728F /* DashboardView.swift */; };
+		A30000000000000000000003 /* ContainersAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30000000000000000000001 /* ContainersAnalyzer.swift */; };
+		A30000000000000000000004 /* ContainersAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30000000000000000000002 /* ContainersAnalyzerTests.swift */; };
+		A40000000000000000000003 /* GroupContainersAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000001 /* GroupContainersAnalyzer.swift */; };
+		A40000000000000000000004 /* GroupContainersAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000002 /* GroupContainersAnalyzerTests.swift */; };
+		A50000000000000000000004 /* DockerStorageModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50000000000000000000001 /* DockerStorageModels.swift */; };
+		A50000000000000000000005 /* DockerStorageAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50000000000000000000002 /* DockerStorageAnalyzer.swift */; };
+		A50000000000000000000006 /* DockerStorageAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50000000000000000000003 /* DockerStorageAnalyzerTests.swift */; };
 		A549D8A39A9E5E70D91B90A6 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A3F22FCEF534DE4A2CAD0E /* Haptics.swift */; };
+		A60000000000000000000003 /* SystemLibraryAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60000000000000000000001 /* SystemLibraryAnalyzer.swift */; };
+		A60000000000000000000004 /* SystemLibraryAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60000000000000000000002 /* SystemLibraryAnalyzerTests.swift */; };
+		A70000000000000000000003 /* PrivateStorageAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000001 /* PrivateStorageAnalyzer.swift */; };
+		A70000000000000000000004 /* PrivateStorageAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000002 /* PrivateStorageAnalyzerTests.swift */; };
+		A80000000000000000000003 /* DataVolumeHiddenStorageAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A80000000000000000000001 /* DataVolumeHiddenStorageAnalyzer.swift */; };
+		A80000000000000000000004 /* DataVolumeHiddenStorageAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A80000000000000000000002 /* DataVolumeHiddenStorageAnalyzerTests.swift */; };
+		A90000000000000000000003 /* DeveloperSystemStorageAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90000000000000000000001 /* DeveloperSystemStorageAnalyzer.swift */; };
+		A90000000000000000000004 /* DeveloperSystemStorageAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90000000000000000000002 /* DeveloperSystemStorageAnalyzerTests.swift */; };
 		A9C3A1F643C26930F442E729 /* OrphanSafetyPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE790496C936424EF98320A /* OrphanSafetyPolicy.swift */; };
+		AA0000000000000000000005 /* APFSStorageModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000001 /* APFSStorageModels.swift */; };
+		AA0000000000000000000006 /* VolumeStatisticsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000002 /* VolumeStatisticsProvider.swift */; };
+		AA0000000000000000000007 /* APFSStorageAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000003 /* APFSStorageAnalyzer.swift */; };
+		AA0000000000000000000008 /* APFSStorageAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000004 /* APFSStorageAnalyzerTests.swift */; };
+		AB0000000000000000000004 /* StorageReconciliationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0000000000000000000001 /* StorageReconciliationModels.swift */; };
+		AB0000000000000000000005 /* StorageAnalysisCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0000000000000000000002 /* StorageAnalysisCoordinator.swift */; };
+		AB0000000000000000000006 /* StorageAnalysisCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0000000000000000000003 /* StorageAnalysisCoordinatorTests.swift */; };
 		ABDDD4F35102A39CC1A2C325 /* ConfettiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0599AA604B0D6BA4F957537 /* ConfettiView.swift */; };
+		AC0000000000000000000003 /* UserHomeStorageAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0000000000000000000001 /* UserHomeStorageAnalyzer.swift */; };
+		AC0000000000000000000004 /* UserHomeStorageAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0000000000000000000002 /* UserHomeStorageAnalyzerTests.swift */; };
+		AD0000000000000000000004 /* StorageIntelligenceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0000000000000000000001 /* StorageIntelligenceState.swift */; };
+		AD0000000000000000000005 /* StorageIntelligenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0000000000000000000002 /* StorageIntelligenceView.swift */; };
+		AD0000000000000000000006 /* StorageIntelligenceStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0000000000000000000003 /* StorageIntelligenceStateTests.swift */; };
+		AE0000000000000000000004 /* StorageCoverageDiagnosticModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0000000000000000000001 /* StorageCoverageDiagnosticModels.swift */; };
+		AE0000000000000000000005 /* StorageCoverageDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0000000000000000000002 /* StorageCoverageDiagnostics.swift */; };
+		AE0000000000000000000006 /* StorageCoverageDiagnosticTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0000000000000000000003 /* StorageCoverageDiagnosticTests.swift */; };
+		AF0000000000000000000003 /* StoragePathNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000001 /* StoragePathNormalizer.swift */; };
+		AF0000000000000000000004 /* StoragePathNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000002 /* StoragePathNormalizerTests.swift */; };
+		AF0000000000000000000013 /* CoverageExpansionAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000011 /* CoverageExpansionAnalyzer.swift */; };
+		AF0000000000000000000014 /* CoverageExpansionAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000012 /* CoverageExpansionAnalyzerTests.swift */; };
+		AF0000000000000000000022 /* StorageAttributionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000021 /* StorageAttributionModels.swift */; };
+		AF0000000000000000000024 /* StorageAttributionAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000023 /* StorageAttributionAnalyzer.swift */; };
+		AF0000000000000000000026 /* StorageAttributionAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000025 /* StorageAttributionAnalyzerTests.swift */; };
 		B51E5A95BB49A6C0F5273E21 /* FileSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE522B406791BCE905BC55B /* FileSize.swift */; };
 		B52938BBD11842631314543D /* CategoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10B0AF194677EAC1D5568785 /* CategoryDetailView.swift */; };
 		B928E4369A3FC4369F014A29 /* SmartCareCoreArtwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA389C4F50505795FB31A51 /* SmartCareCoreArtwork.swift */; };
@@ -131,9 +173,51 @@
 		95EC878D25C244BF94D0094C /* UniversalBinaryScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalBinaryScanner.swift; sourceTree = "<group>"; };
 		9F04B811BB0012F6D2F07F91 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9F510F232341EE18F11DC934 /* MainWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindow.swift; sourceTree = "<group>"; };
+		A10000000000000000000001 /* StorageAnalysisModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageAnalysisModels.swift; sourceTree = "<group>"; };
+		A10000000000000000000002 /* FileTreeScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeScanner.swift; sourceTree = "<group>"; };
+		A10000000000000000000003 /* FileTreeScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeScannerTests.swift; sourceTree = "<group>"; };
+		A20000000000000000000001 /* ApplicationSupportAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationSupportAnalyzer.swift; sourceTree = "<group>"; };
+		A20000000000000000000002 /* ApplicationSupportAnalyzerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationSupportAnalyzerTests.swift; sourceTree = "<group>"; };
 		A27DB5A70FA829B6C3ED0AC3 /* MenuBarMonitorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarMonitorView.swift; sourceTree = "<group>"; };
+		A30000000000000000000001 /* ContainersAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainersAnalyzer.swift; sourceTree = "<group>"; };
+		A30000000000000000000002 /* ContainersAnalyzerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainersAnalyzerTests.swift; sourceTree = "<group>"; };
+		A40000000000000000000001 /* GroupContainersAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupContainersAnalyzer.swift; sourceTree = "<group>"; };
+		A40000000000000000000002 /* GroupContainersAnalyzerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupContainersAnalyzerTests.swift; sourceTree = "<group>"; };
+		A50000000000000000000001 /* DockerStorageModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockerStorageModels.swift; sourceTree = "<group>"; };
+		A50000000000000000000002 /* DockerStorageAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockerStorageAnalyzer.swift; sourceTree = "<group>"; };
+		A50000000000000000000003 /* DockerStorageAnalyzerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockerStorageAnalyzerTests.swift; sourceTree = "<group>"; };
+		A60000000000000000000001 /* SystemLibraryAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemLibraryAnalyzer.swift; sourceTree = "<group>"; };
+		A60000000000000000000002 /* SystemLibraryAnalyzerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemLibraryAnalyzerTests.swift; sourceTree = "<group>"; };
+		A70000000000000000000001 /* PrivateStorageAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateStorageAnalyzer.swift; sourceTree = "<group>"; };
+		A70000000000000000000002 /* PrivateStorageAnalyzerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateStorageAnalyzerTests.swift; sourceTree = "<group>"; };
 		A711CDF5285F68775D9B5513 /* ScanEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanEngine.swift; sourceTree = "<group>"; };
+		A80000000000000000000001 /* DataVolumeHiddenStorageAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataVolumeHiddenStorageAnalyzer.swift; sourceTree = "<group>"; };
+		A80000000000000000000002 /* DataVolumeHiddenStorageAnalyzerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataVolumeHiddenStorageAnalyzerTests.swift; sourceTree = "<group>"; };
+		A90000000000000000000001 /* DeveloperSystemStorageAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperSystemStorageAnalyzer.swift; sourceTree = "<group>"; };
+		A90000000000000000000002 /* DeveloperSystemStorageAnalyzerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperSystemStorageAnalyzerTests.swift; sourceTree = "<group>"; };
+		AA0000000000000000000001 /* APFSStorageModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APFSStorageModels.swift; sourceTree = "<group>"; };
+		AA0000000000000000000002 /* VolumeStatisticsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeStatisticsProvider.swift; sourceTree = "<group>"; };
+		AA0000000000000000000003 /* APFSStorageAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APFSStorageAnalyzer.swift; sourceTree = "<group>"; };
+		AA0000000000000000000004 /* APFSStorageAnalyzerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APFSStorageAnalyzerTests.swift; sourceTree = "<group>"; };
+		AB0000000000000000000001 /* StorageReconciliationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageReconciliationModels.swift; sourceTree = "<group>"; };
+		AB0000000000000000000002 /* StorageAnalysisCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageAnalysisCoordinator.swift; sourceTree = "<group>"; };
+		AB0000000000000000000003 /* StorageAnalysisCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageAnalysisCoordinatorTests.swift; sourceTree = "<group>"; };
+		AC0000000000000000000001 /* UserHomeStorageAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserHomeStorageAnalyzer.swift; sourceTree = "<group>"; };
+		AC0000000000000000000002 /* UserHomeStorageAnalyzerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserHomeStorageAnalyzerTests.swift; sourceTree = "<group>"; };
 		AC0FEE7141871ED5F9E36121 /* AppPathFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPathFinder.swift; sourceTree = "<group>"; };
+		AD0000000000000000000001 /* StorageIntelligenceState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageIntelligenceState.swift; sourceTree = "<group>"; };
+		AD0000000000000000000002 /* StorageIntelligenceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageIntelligenceView.swift; sourceTree = "<group>"; };
+		AD0000000000000000000003 /* StorageIntelligenceStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageIntelligenceStateTests.swift; sourceTree = "<group>"; };
+		AE0000000000000000000001 /* StorageCoverageDiagnosticModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageCoverageDiagnosticModels.swift; sourceTree = "<group>"; };
+		AE0000000000000000000002 /* StorageCoverageDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageCoverageDiagnostics.swift; sourceTree = "<group>"; };
+		AE0000000000000000000003 /* StorageCoverageDiagnosticTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageCoverageDiagnosticTests.swift; sourceTree = "<group>"; };
+		AF0000000000000000000001 /* StoragePathNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoragePathNormalizer.swift; sourceTree = "<group>"; };
+		AF0000000000000000000002 /* StoragePathNormalizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoragePathNormalizerTests.swift; sourceTree = "<group>"; };
+		AF0000000000000000000011 /* CoverageExpansionAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoverageExpansionAnalyzer.swift; sourceTree = "<group>"; };
+		AF0000000000000000000012 /* CoverageExpansionAnalyzerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoverageExpansionAnalyzerTests.swift; sourceTree = "<group>"; };
+		AF0000000000000000000021 /* StorageAttributionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageAttributionModels.swift; sourceTree = "<group>"; };
+		AF0000000000000000000023 /* StorageAttributionAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageAttributionAnalyzer.swift; sourceTree = "<group>"; };
+		AF0000000000000000000025 /* StorageAttributionAnalyzerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageAttributionAnalyzerTests.swift; sourceTree = "<group>"; };
 		B2CD0028599BE178B96F18A6 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B2EA41E1096FA8E3B916AD13 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B71E8F62DB76D85F41F9A2E9 /* OrphanListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrphanListView.swift; sourceTree = "<group>"; };
@@ -181,8 +265,25 @@
 		261FB8D961FEC76F15EA523A /* PureMacTests */ = {
 			isa = PBXGroup;
 			children = (
+				AA0000000000000000000004 /* APFSStorageAnalyzerTests.swift */,
+				AB0000000000000000000003 /* StorageAnalysisCoordinatorTests.swift */,
+				AD0000000000000000000003 /* StorageIntelligenceStateTests.swift */,
+				AE0000000000000000000003 /* StorageCoverageDiagnosticTests.swift */,
+				AF0000000000000000000002 /* StoragePathNormalizerTests.swift */,
+				AF0000000000000000000012 /* CoverageExpansionAnalyzerTests.swift */,
+				AF0000000000000000000025 /* StorageAttributionAnalyzerTests.swift */,
+				AC0000000000000000000002 /* UserHomeStorageAnalyzerTests.swift */,
 				491771F923C93FD61A263893 /* AppLanguagePreferencesTests.swift */,
 				752603285F7DBBA12BB3AA91 /* AppStateTests.swift */,
+				A20000000000000000000002 /* ApplicationSupportAnalyzerTests.swift */,
+				A30000000000000000000002 /* ContainersAnalyzerTests.swift */,
+				A80000000000000000000002 /* DataVolumeHiddenStorageAnalyzerTests.swift */,
+				A90000000000000000000002 /* DeveloperSystemStorageAnalyzerTests.swift */,
+				A50000000000000000000003 /* DockerStorageAnalyzerTests.swift */,
+				A40000000000000000000002 /* GroupContainersAnalyzerTests.swift */,
+				A10000000000000000000003 /* FileTreeScannerTests.swift */,
+				A70000000000000000000002 /* PrivateStorageAnalyzerTests.swift */,
+				A60000000000000000000002 /* SystemLibraryAnalyzerTests.swift */,
 				155CE1B8CDCCCA6F9FD028C1 /* LocalizationFilesTests.swift */,
 				C7D81BE7EA5DB17F4A0300AD /* SimulatorRuntimeSupportTests.swift */,
 			);
@@ -192,9 +293,15 @@
 		3CF46713F75B81F0F86D1C6F /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				AA0000000000000000000001 /* APFSStorageModels.swift */,
 				82BB0904726B38DEB141BECA /* AppLanguage.swift */,
+				A50000000000000000000001 /* DockerStorageModels.swift */,
 				3667D46D8E2004EB4D73835A /* Models.swift */,
 				EEF15CB1B8EFCA78EF491824 /* ScanError.swift */,
+				A10000000000000000000001 /* StorageAnalysisModels.swift */,
+				AF0000000000000000000021 /* StorageAttributionModels.swift */,
+				AE0000000000000000000001 /* StorageCoverageDiagnosticModels.swift */,
+				AB0000000000000000000001 /* StorageReconciliationModels.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -219,6 +326,7 @@
 				8AE26715B5748307483A1A5E /* Components */,
 				9D3C2DC382F5D4B77DFD218B /* Orphans */,
 				7BC68AB045DA6E5299FD3CB6 /* Settings */,
+				AD0000000000000000000007 /* StorageIntelligence */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -233,6 +341,7 @@
 				913E3064AA9BD7BE94A315CF /* MenuBarController.swift */,
 				F9DCBD97CC88D77AE8DB01A4 /* PermissionCoordinator.swift */,
 				A711CDF5285F68775D9B5513 /* ScanEngine.swift */,
+				AB0000000000000000000002 /* StorageAnalysisCoordinator.swift */,
 				28181F034530331A550C6A3D /* SchedulerService.swift */,
 				DB798781B99987F55D77E2E3 /* SystemMonitor.swift */,
 				022D0EAEE2B6E54069FC2CBE /* UpdateService.swift */,
@@ -281,12 +390,52 @@
 			path = Orphans;
 			sourceTree = "<group>";
 		};
+		A10000000000000000000004 /* Storage */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000002 /* FileTreeScanner.swift */,
+				AE0000000000000000000002 /* StorageCoverageDiagnostics.swift */,
+				AF0000000000000000000001 /* StoragePathNormalizer.swift */,
+				A20000000000000000000003 /* SpecializedAnalyzers */,
+				AA0000000000000000000002 /* VolumeStatisticsProvider.swift */,
+			);
+			path = Storage;
+			sourceTree = "<group>";
+		};
+		A20000000000000000000003 /* SpecializedAnalyzers */ = {
+			isa = PBXGroup;
+			children = (
+				AA0000000000000000000003 /* APFSStorageAnalyzer.swift */,
+				A20000000000000000000001 /* ApplicationSupportAnalyzer.swift */,
+				A30000000000000000000001 /* ContainersAnalyzer.swift */,
+				AF0000000000000000000011 /* CoverageExpansionAnalyzer.swift */,
+				AF0000000000000000000023 /* StorageAttributionAnalyzer.swift */,
+				A80000000000000000000001 /* DataVolumeHiddenStorageAnalyzer.swift */,
+				A90000000000000000000001 /* DeveloperSystemStorageAnalyzer.swift */,
+				A50000000000000000000002 /* DockerStorageAnalyzer.swift */,
+				A40000000000000000000001 /* GroupContainersAnalyzer.swift */,
+				A70000000000000000000001 /* PrivateStorageAnalyzer.swift */,
+				A60000000000000000000001 /* SystemLibraryAnalyzer.swift */,
+				AC0000000000000000000001 /* UserHomeStorageAnalyzer.swift */,
+			);
+			path = SpecializedAnalyzers;
+			sourceTree = "<group>";
+		};
 		A8F1C251567E5321E1CA2484 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
 				CED1B71D5F9510582E869CFD /* AppState.swift */,
+				AD0000000000000000000001 /* StorageIntelligenceState.swift */,
 			);
 			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		AD0000000000000000000007 /* StorageIntelligence */ = {
+			isa = PBXGroup;
+			children = (
+				AD0000000000000000000002 /* StorageIntelligenceView.swift */,
+			);
+			path = StorageIntelligence;
 			sourceTree = "<group>";
 		};
 		D4333B07691BD85CAE0E5B15 /* Core */ = {
@@ -359,6 +508,7 @@
 			isa = PBXGroup;
 			children = (
 				EC11280F62B0574E3699EFA6 /* Scanning */,
+				A10000000000000000000004 /* Storage */,
 				E05E733EFBC4EFDA12BEC43B /* Utilities */,
 			);
 			path = Logic;
@@ -415,7 +565,6 @@
 				LastUpgradeCheck = 1640;
 				TargetAttributes = {
 					B19E38DEAA0144A77120F39C = {
-						DevelopmentTeam = H3WXHVTP97;
 						ProvisioningStyle = Automatic;
 					};
 					FBA8B0DE95746207A043B802 = {
@@ -476,6 +625,19 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA0000000000000000000007 /* APFSStorageAnalyzer.swift in Sources */,
+				AA0000000000000000000005 /* APFSStorageModels.swift in Sources */,
+				AB0000000000000000000005 /* StorageAnalysisCoordinator.swift in Sources */,
+				AB0000000000000000000004 /* StorageReconciliationModels.swift in Sources */,
+				AE0000000000000000000004 /* StorageCoverageDiagnosticModels.swift in Sources */,
+				AE0000000000000000000005 /* StorageCoverageDiagnostics.swift in Sources */,
+				AF0000000000000000000003 /* StoragePathNormalizer.swift in Sources */,
+				AF0000000000000000000013 /* CoverageExpansionAnalyzer.swift in Sources */,
+				AF0000000000000000000022 /* StorageAttributionModels.swift in Sources */,
+				AF0000000000000000000024 /* StorageAttributionAnalyzer.swift in Sources */,
+				AC0000000000000000000003 /* UserHomeStorageAnalyzer.swift in Sources */,
+				AD0000000000000000000004 /* StorageIntelligenceState.swift in Sources */,
+				AD0000000000000000000005 /* StorageIntelligenceView.swift in Sources */,
 				DC32253D26D0E29762006DA0 /* AppBundleDragHandle.swift in Sources */,
 				4F754D89F4CE5142BE384062 /* AppConstants.swift in Sources */,
 				1B0D043102FDB245312A5147 /* AppFilesView.swift in Sources */,
@@ -486,17 +648,26 @@
 				9AA80E035DF7B33F6EE118DF /* AppState.swift in Sources */,
 				535B23C0108C06475215B8E8 /* AppTheme.swift in Sources */,
 				95278ABDCF5F4D6AC60503B1 /* AppearancePill.swift in Sources */,
+				A20000000000000000000004 /* ApplicationSupportAnalyzer.swift in Sources */,
 				68F9CE5ED4908F674D673FB2 /* BinaryThinner.swift in Sources */,
 				F2FA881A4B2209CC2A6342FB /* CLI.swift in Sources */,
 				B52938BBD11842631314543D /* CategoryDetailView.swift in Sources */,
 				48D1431A7C99C19EEBDB056B /* CleaningEngine.swift in Sources */,
 				8947F0CE448791BD50EECF46 /* Conditions.swift in Sources */,
 				ABDDD4F35102A39CC1A2C325 /* ConfettiView.swift in Sources */,
+				A30000000000000000000003 /* ContainersAnalyzer.swift in Sources */,
+				A80000000000000000000003 /* DataVolumeHiddenStorageAnalyzer.swift in Sources */,
+				A90000000000000000000003 /* DeveloperSystemStorageAnalyzer.swift in Sources */,
+				A50000000000000000000005 /* DockerStorageAnalyzer.swift in Sources */,
+				A40000000000000000000003 /* GroupContainersAnalyzer.swift in Sources */,
+				A70000000000000000000003 /* PrivateStorageAnalyzer.swift in Sources */,
+				A60000000000000000000003 /* SystemLibraryAnalyzer.swift in Sources */,
 				8B541441926847072DC5B75B /* DashboardCharts.swift in Sources */,
 				A2AE68CC75CB72D6B10CBDF5 /* DashboardView.swift in Sources */,
 				76B132F9C499225D33E0D075 /* EmptyStateView.swift in Sources */,
 				52F11962555C639F0EECADD6 /* FDADemoView.swift in Sources */,
 				25E2304A3FF257F1740E304B /* FileProtection.swift in Sources */,
+				A10000000000000000000006 /* FileTreeScanner.swift in Sources */,
 				B51E5A95BB49A6C0F5273E21 /* FileSize.swift in Sources */,
 				2253F11BDF561B617439C96B /* FullDiskAccessManager.swift in Sources */,
 				A549D8A39A9E5E70D91B90A6 /* Haptics.swift in Sources */,
@@ -507,6 +678,7 @@
 				9E3639F9EFCB2A22F6747894 /* MenuBarController.swift in Sources */,
 				91751CF033E1541BFD39B12C /* MenuBarMonitorView.swift in Sources */,
 				826A750D2D7EC14C2AE306A3 /* Models.swift in Sources */,
+				A50000000000000000000004 /* DockerStorageModels.swift in Sources */,
 				BC6C800216343438413349A3 /* OnboardingView.swift in Sources */,
 				FDA30FE6349CA01C8D859F04 /* OrphanListView.swift in Sources */,
 				A9C3A1F643C26930F442E729 /* OrphanSafetyPolicy.swift in Sources */,
@@ -519,12 +691,14 @@
 				27F449EDD1B082FE11FEC9DF /* SchedulerService.swift in Sources */,
 				93743B036059418560D876E6 /* SettingsView.swift in Sources */,
 				6753946A301B2EB2FEF6998B /* SimulatorRuntimeSupport.swift in Sources */,
+				A10000000000000000000005 /* StorageAnalysisModels.swift in Sources */,
 				B928E4369A3FC4369F014A29 /* SmartCareCoreArtwork.swift in Sources */,
 				47C5ECD49C4DD75F271DB6CE /* StringNormalization.swift in Sources */,
 				DBFD73E3D9BDA74EC1CA56AB /* SystemMonitor.swift in Sources */,
 				340E424F759ACCDE7372F99F /* Theme.swift in Sources */,
 				6D449325D54B9850FC6C119F /* UniversalBinaryScanner.swift in Sources */,
 				41B27CACD7C6C7471EFD03F9 /* UpdateService.swift in Sources */,
+				AA0000000000000000000006 /* VolumeStatisticsProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -532,8 +706,25 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA0000000000000000000008 /* APFSStorageAnalyzerTests.swift in Sources */,
+				AB0000000000000000000006 /* StorageAnalysisCoordinatorTests.swift in Sources */,
+				AD0000000000000000000006 /* StorageIntelligenceStateTests.swift in Sources */,
+				AE0000000000000000000006 /* StorageCoverageDiagnosticTests.swift in Sources */,
+				AF0000000000000000000004 /* StoragePathNormalizerTests.swift in Sources */,
+				AF0000000000000000000014 /* CoverageExpansionAnalyzerTests.swift in Sources */,
+				AF0000000000000000000026 /* StorageAttributionAnalyzerTests.swift in Sources */,
+				AC0000000000000000000004 /* UserHomeStorageAnalyzerTests.swift in Sources */,
 				59B3096E2AE8ED0397B16798 /* AppLanguagePreferencesTests.swift in Sources */,
 				E2403D82F00D749C9AD4A6D4 /* AppStateTests.swift in Sources */,
+				A20000000000000000000005 /* ApplicationSupportAnalyzerTests.swift in Sources */,
+				A30000000000000000000004 /* ContainersAnalyzerTests.swift in Sources */,
+				A80000000000000000000004 /* DataVolumeHiddenStorageAnalyzerTests.swift in Sources */,
+				A90000000000000000000004 /* DeveloperSystemStorageAnalyzerTests.swift in Sources */,
+				A50000000000000000000006 /* DockerStorageAnalyzerTests.swift in Sources */,
+				A40000000000000000000004 /* GroupContainersAnalyzerTests.swift in Sources */,
+				A10000000000000000000007 /* FileTreeScannerTests.swift in Sources */,
+				A70000000000000000000004 /* PrivateStorageAnalyzerTests.swift in Sources */,
+				A60000000000000000000004 /* SystemLibraryAnalyzerTests.swift in Sources */,
 				CFA64F54CDBF8A4765E0068D /* LocalizationFilesTests.swift in Sources */,
 				F4F02F966001A1504C2B4D33 /* SimulatorRuntimeSupportTests.swift in Sources */,
 			);
@@ -597,7 +788,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "arm64 x86_64";
+				ARCHS = (
+					arm64,
+					x86_64,
+				);
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -672,11 +866,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGNING_ALLOWED = NO;
-				CODE_SIGNING_REQUIRED = NO;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 5KQ3W6R3HF;
 				INFOPLIST_FILE = PureMac/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
 				PRODUCT_NAME = PureMac;
 				SDKROOT = macosx;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -721,7 +917,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "arm64 x86_64";
+				ARCHS = (
+					arm64,
+					x86_64,
+				);
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -791,8 +990,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 5KQ3W6R3HF;
 				INFOPLIST_FILE = PureMac/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
 				PRODUCT_NAME = PureMac;
 				SDKROOT = macosx;
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/PureMac.xcodeproj/project.pbxproj
+++ b/PureMac.xcodeproj/project.pbxproj
@@ -85,6 +85,22 @@
 		AF0000000000000000000022 /* StorageAttributionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000021 /* StorageAttributionModels.swift */; };
 		AF0000000000000000000024 /* StorageAttributionAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000023 /* StorageAttributionAnalyzer.swift */; };
 		AF0000000000000000000026 /* StorageAttributionAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000025 /* StorageAttributionAnalyzerTests.swift */; };
+		AF0000000000000000000032 /* TargetedCoverageGapMeasurementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000031 /* TargetedCoverageGapMeasurementTests.swift */; };
+		AF0000000000000000000042 /* APFSPhysicalReconciliationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000041 /* APFSPhysicalReconciliationModels.swift */; };
+		AF0000000000000000000044 /* APFSPhysicalReconciliationAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000043 /* APFSPhysicalReconciliationAnalyzer.swift */; };
+		AF0000000000000000000046 /* APFSPhysicalReconciliationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000045 /* APFSPhysicalReconciliationTests.swift */; };
+		AF0000000000000000000048 /* DataVolumeInternalGapModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000047 /* DataVolumeInternalGapModels.swift */; };
+		AF000000000000000000004A /* DataVolumeInternalGapAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000049 /* DataVolumeInternalGapAnalyzer.swift */; };
+		AF000000000000000000004C /* DataVolumeInternalGapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF000000000000000000004B /* DataVolumeInternalGapTests.swift */; };
+		AF0000000000000000000052 /* ApplicationsStorageAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000051 /* ApplicationsStorageAnalyzer.swift */; };
+		AF0000000000000000000054 /* DataVolumeTopLevelSafetyNetModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000053 /* DataVolumeTopLevelSafetyNetModels.swift */; };
+		AF0000000000000000000056 /* DataVolumeTopLevelSafetyNetChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000055 /* DataVolumeTopLevelSafetyNetChecker.swift */; };
+		AF0000000000000000000058 /* ApplicationsStorageAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000057 /* ApplicationsStorageAnalyzerTests.swift */; };
+		AF000000000000000000005A /* DataVolumeTopLevelSafetyNetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000059 /* DataVolumeTopLevelSafetyNetTests.swift */; };
+		AF000000000000000000005C /* StorageAnalysisPerformanceDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF000000000000000000005B /* StorageAnalysisPerformanceDiagnostics.swift */; };
+		AF000000000000000000005E /* StorageAnalysisPerformanceDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF000000000000000000005D /* StorageAnalysisPerformanceDiagnosticsTests.swift */; };
+		AF0000000000000000000060 /* StorageAnalysisCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF000000000000000000005F /* StorageAnalysisCache.swift */; };
+		AF0000000000000000000062 /* StorageAnalysisCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0000000000000000000061 /* StorageAnalysisCacheTests.swift */; };
 		B51E5A95BB49A6C0F5273E21 /* FileSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE522B406791BCE905BC55B /* FileSize.swift */; };
 		B52938BBD11842631314543D /* CategoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10B0AF194677EAC1D5568785 /* CategoryDetailView.swift */; };
 		B928E4369A3FC4369F014A29 /* SmartCareCoreArtwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA389C4F50505795FB31A51 /* SmartCareCoreArtwork.swift */; };
@@ -218,6 +234,22 @@
 		AF0000000000000000000021 /* StorageAttributionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageAttributionModels.swift; sourceTree = "<group>"; };
 		AF0000000000000000000023 /* StorageAttributionAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageAttributionAnalyzer.swift; sourceTree = "<group>"; };
 		AF0000000000000000000025 /* StorageAttributionAnalyzerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageAttributionAnalyzerTests.swift; sourceTree = "<group>"; };
+		AF0000000000000000000031 /* TargetedCoverageGapMeasurementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetedCoverageGapMeasurementTests.swift; sourceTree = "<group>"; };
+		AF0000000000000000000041 /* APFSPhysicalReconciliationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APFSPhysicalReconciliationModels.swift; sourceTree = "<group>"; };
+		AF0000000000000000000043 /* APFSPhysicalReconciliationAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APFSPhysicalReconciliationAnalyzer.swift; sourceTree = "<group>"; };
+		AF0000000000000000000045 /* APFSPhysicalReconciliationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APFSPhysicalReconciliationTests.swift; sourceTree = "<group>"; };
+		AF0000000000000000000047 /* DataVolumeInternalGapModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataVolumeInternalGapModels.swift; sourceTree = "<group>"; };
+		AF0000000000000000000049 /* DataVolumeInternalGapAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataVolumeInternalGapAnalyzer.swift; sourceTree = "<group>"; };
+		AF000000000000000000004B /* DataVolumeInternalGapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataVolumeInternalGapTests.swift; sourceTree = "<group>"; };
+		AF0000000000000000000051 /* ApplicationsStorageAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsStorageAnalyzer.swift; sourceTree = "<group>"; };
+		AF0000000000000000000053 /* DataVolumeTopLevelSafetyNetModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataVolumeTopLevelSafetyNetModels.swift; sourceTree = "<group>"; };
+		AF0000000000000000000055 /* DataVolumeTopLevelSafetyNetChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataVolumeTopLevelSafetyNetChecker.swift; sourceTree = "<group>"; };
+		AF0000000000000000000057 /* ApplicationsStorageAnalyzerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsStorageAnalyzerTests.swift; sourceTree = "<group>"; };
+		AF0000000000000000000059 /* DataVolumeTopLevelSafetyNetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataVolumeTopLevelSafetyNetTests.swift; sourceTree = "<group>"; };
+		AF000000000000000000005B /* StorageAnalysisPerformanceDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageAnalysisPerformanceDiagnostics.swift; sourceTree = "<group>"; };
+		AF000000000000000000005D /* StorageAnalysisPerformanceDiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageAnalysisPerformanceDiagnosticsTests.swift; sourceTree = "<group>"; };
+		AF000000000000000000005F /* StorageAnalysisCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageAnalysisCache.swift; sourceTree = "<group>"; };
+		AF0000000000000000000061 /* StorageAnalysisCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageAnalysisCacheTests.swift; sourceTree = "<group>"; };
 		B2CD0028599BE178B96F18A6 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B2EA41E1096FA8E3B916AD13 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B71E8F62DB76D85F41F9A2E9 /* OrphanListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrphanListView.swift; sourceTree = "<group>"; };
@@ -272,6 +304,13 @@
 				AF0000000000000000000002 /* StoragePathNormalizerTests.swift */,
 				AF0000000000000000000012 /* CoverageExpansionAnalyzerTests.swift */,
 				AF0000000000000000000025 /* StorageAttributionAnalyzerTests.swift */,
+				AF0000000000000000000031 /* TargetedCoverageGapMeasurementTests.swift */,
+				AF0000000000000000000045 /* APFSPhysicalReconciliationTests.swift */,
+				AF000000000000000000004B /* DataVolumeInternalGapTests.swift */,
+				AF0000000000000000000057 /* ApplicationsStorageAnalyzerTests.swift */,
+				AF0000000000000000000059 /* DataVolumeTopLevelSafetyNetTests.swift */,
+				AF000000000000000000005D /* StorageAnalysisPerformanceDiagnosticsTests.swift */,
+				AF0000000000000000000061 /* StorageAnalysisCacheTests.swift */,
 				AC0000000000000000000002 /* UserHomeStorageAnalyzerTests.swift */,
 				491771F923C93FD61A263893 /* AppLanguagePreferencesTests.swift */,
 				752603285F7DBBA12BB3AA91 /* AppStateTests.swift */,
@@ -294,6 +333,9 @@
 			isa = PBXGroup;
 			children = (
 				AA0000000000000000000001 /* APFSStorageModels.swift */,
+				AF0000000000000000000041 /* APFSPhysicalReconciliationModels.swift */,
+				AF0000000000000000000047 /* DataVolumeInternalGapModels.swift */,
+				AF0000000000000000000053 /* DataVolumeTopLevelSafetyNetModels.swift */,
 				82BB0904726B38DEB141BECA /* AppLanguage.swift */,
 				A50000000000000000000001 /* DockerStorageModels.swift */,
 				3667D46D8E2004EB4D73835A /* Models.swift */,
@@ -396,6 +438,9 @@
 				A10000000000000000000002 /* FileTreeScanner.swift */,
 				AE0000000000000000000002 /* StorageCoverageDiagnostics.swift */,
 				AF0000000000000000000001 /* StoragePathNormalizer.swift */,
+				AF0000000000000000000055 /* DataVolumeTopLevelSafetyNetChecker.swift */,
+				AF000000000000000000005B /* StorageAnalysisPerformanceDiagnostics.swift */,
+				AF000000000000000000005F /* StorageAnalysisCache.swift */,
 				A20000000000000000000003 /* SpecializedAnalyzers */,
 				AA0000000000000000000002 /* VolumeStatisticsProvider.swift */,
 			);
@@ -406,10 +451,13 @@
 			isa = PBXGroup;
 			children = (
 				AA0000000000000000000003 /* APFSStorageAnalyzer.swift */,
+				AF0000000000000000000051 /* ApplicationsStorageAnalyzer.swift */,
 				A20000000000000000000001 /* ApplicationSupportAnalyzer.swift */,
 				A30000000000000000000001 /* ContainersAnalyzer.swift */,
 				AF0000000000000000000011 /* CoverageExpansionAnalyzer.swift */,
 				AF0000000000000000000023 /* StorageAttributionAnalyzer.swift */,
+				AF0000000000000000000043 /* APFSPhysicalReconciliationAnalyzer.swift */,
+				AF0000000000000000000049 /* DataVolumeInternalGapAnalyzer.swift */,
 				A80000000000000000000001 /* DataVolumeHiddenStorageAnalyzer.swift */,
 				A90000000000000000000001 /* DeveloperSystemStorageAnalyzer.swift */,
 				A50000000000000000000002 /* DockerStorageAnalyzer.swift */,
@@ -635,6 +683,15 @@
 				AF0000000000000000000013 /* CoverageExpansionAnalyzer.swift in Sources */,
 				AF0000000000000000000022 /* StorageAttributionModels.swift in Sources */,
 				AF0000000000000000000024 /* StorageAttributionAnalyzer.swift in Sources */,
+				AF0000000000000000000042 /* APFSPhysicalReconciliationModels.swift in Sources */,
+				AF0000000000000000000044 /* APFSPhysicalReconciliationAnalyzer.swift in Sources */,
+				AF0000000000000000000048 /* DataVolumeInternalGapModels.swift in Sources */,
+				AF000000000000000000004A /* DataVolumeInternalGapAnalyzer.swift in Sources */,
+				AF0000000000000000000052 /* ApplicationsStorageAnalyzer.swift in Sources */,
+				AF0000000000000000000054 /* DataVolumeTopLevelSafetyNetModels.swift in Sources */,
+				AF0000000000000000000056 /* DataVolumeTopLevelSafetyNetChecker.swift in Sources */,
+				AF000000000000000000005C /* StorageAnalysisPerformanceDiagnostics.swift in Sources */,
+				AF0000000000000000000060 /* StorageAnalysisCache.swift in Sources */,
 				AC0000000000000000000003 /* UserHomeStorageAnalyzer.swift in Sources */,
 				AD0000000000000000000004 /* StorageIntelligenceState.swift in Sources */,
 				AD0000000000000000000005 /* StorageIntelligenceView.swift in Sources */,
@@ -713,6 +770,13 @@
 				AF0000000000000000000004 /* StoragePathNormalizerTests.swift in Sources */,
 				AF0000000000000000000014 /* CoverageExpansionAnalyzerTests.swift in Sources */,
 				AF0000000000000000000026 /* StorageAttributionAnalyzerTests.swift in Sources */,
+				AF0000000000000000000032 /* TargetedCoverageGapMeasurementTests.swift in Sources */,
+				AF0000000000000000000046 /* APFSPhysicalReconciliationTests.swift in Sources */,
+				AF000000000000000000004C /* DataVolumeInternalGapTests.swift in Sources */,
+				AF0000000000000000000058 /* ApplicationsStorageAnalyzerTests.swift in Sources */,
+				AF000000000000000000005A /* DataVolumeTopLevelSafetyNetTests.swift in Sources */,
+				AF000000000000000000005E /* StorageAnalysisPerformanceDiagnosticsTests.swift in Sources */,
+				AF0000000000000000000062 /* StorageAnalysisCacheTests.swift in Sources */,
 				AC0000000000000000000004 /* UserHomeStorageAnalyzerTests.swift in Sources */,
 				59B3096E2AE8ED0397B16798 /* AppLanguagePreferencesTests.swift in Sources */,
 				E2403D82F00D749C9AD4A6D4 /* AppStateTests.swift in Sources */,

--- a/PureMac/Logic/Storage/DataVolumeTopLevelSafetyNetChecker.swift
+++ b/PureMac/Logic/Storage/DataVolumeTopLevelSafetyNetChecker.swift
@@ -1,0 +1,237 @@
+import Darwin
+import Foundation
+
+/// Read-only diagnostic safety net checker that audits immediate children of
+/// `/System/Volumes/Data` to ensure no measurable regions are omitted.
+///
+/// This checker performs shallow directory inspection only. It never modifies
+/// any file, never follows symlinks, and reports ownership status deterministically.
+struct DataVolumeTopLevelSafetyNetChecker: Sendable {
+    private static let defaultDataVolumeURL = URL(fileURLWithPath: "/System/Volumes/Data", isDirectory: true)
+
+    private static let canonicalAnalyzerOwners: [String: (StorageCanonicalRoot, StorageAnalyzerStage)] = [
+        "Applications": (.applications, .applications),
+        "/Applications": (.applications, .applications),
+        "Users": (.userHomeVisibleStorage, .userHomeStorage),
+        "/Users": (.userHomeVisibleStorage, .userHomeStorage),
+        "Library": (.systemLibrary, .systemLibrary),
+        "/Library": (.systemLibrary, .systemLibrary),
+        "private": (.privateStorage, .privateStorage),
+        "/private": (.privateStorage, .privateStorage),
+        "opt": (.opt, .developerSystemStorage),
+        "/opt": (.opt, .developerSystemStorage),
+        "usr": (.usrLocal, .developerSystemStorage),
+        "/usr": (.usrLocal, .developerSystemStorage),
+    ]
+
+    private static let firmlinkAliases: Set<String> = [
+        "var",
+        "/var",
+        "etc",
+        "/etc",
+        "tmp",
+        "/tmp",
+        "bin",
+        "/bin",
+        "sbin",
+        "/sbin",
+        "home",
+        "/home",
+        "net",
+        "/net",
+        "dev",
+        "/dev",
+    ]
+
+    private static let intentionallyNonAdditive: Set<String> = [
+        "System",
+        "/System",
+        "Volumes",
+        "/Volumes",
+        ".Spotlight-V100",
+        "/.Spotlight-V100",
+        ".DocumentRevisions-V100",
+        "/.DocumentRevisions-V100",
+        ".fseventsd",
+        "/.fseventsd",
+        ".Trashes",
+        "/.Trashes",
+        ".PKInstallSandboxManager",
+        "/.PKInstallSandboxManager",
+        ".PKInstallSandboxManager-SystemSoftware",
+        "/.PKInstallSandboxManager-SystemSoftware",
+    ]
+
+    private let dataVolumeURL: URL
+
+    init(dataVolumeURL: URL = DataVolumeTopLevelSafetyNetChecker.defaultDataVolumeURL) {
+        self.dataVolumeURL = dataVolumeURL
+    }
+
+    func audit(reconciliationReport: StorageReconciliationReport) -> DataVolumeTopLevelSafetyNetReport {
+        guard let directory = opendir(dataVolumeURL.path) else {
+            return DataVolumeTopLevelSafetyNetReport(
+                checkedDirectoryPath: dataVolumeURL.path,
+                entries: [],
+                totalEntriesCount: 0,
+                unownedEntriesCount: 0,
+                isFullyCovered: true
+            )
+        }
+        defer { closedir(directory) }
+
+        var entries: [DataVolumeTopLevelSafetyNetEntry] = []
+
+        while true {
+            Darwin.errno = 0
+            guard let entry = readdir(directory) else { break }
+
+            var nameBuffer = entry.pointee.d_name
+            let capacity = MemoryLayout.size(ofValue: nameBuffer)
+            let name = withUnsafePointer(to: &nameBuffer) { pointer in
+                pointer.withMemoryRebound(to: CChar.self, capacity: capacity) {
+                    String(cString: $0)
+                }
+            }
+            guard name != ".", name != ".." else { continue }
+
+            let originalPath = (dataVolumeURL.path as NSString).appendingPathComponent(name)
+            let normalized = StoragePathNormalizer.normalize(originalPath)
+
+            // Determine allocated size if possible
+            var statInfo = stat()
+            let allocatedBytes: Int64?
+            if lstat(originalPath, &statInfo) == 0 {
+                allocatedBytes = Int64(statInfo.st_blocks) * 512
+            } else {
+                allocatedBytes = nil
+            }
+
+            let classifiedEntry = classify(
+                name: name,
+                originalPath: originalPath,
+                normalizedPath: normalized,
+                allocatedBytes: allocatedBytes,
+                reconciliationReport: reconciliationReport
+            )
+            entries.append(classifiedEntry)
+        }
+
+        entries.sort { lhs, rhs in
+            if (lhs.allocatedBytes ?? 0) != (rhs.allocatedBytes ?? 0) {
+                return (lhs.allocatedBytes ?? 0) > (rhs.allocatedBytes ?? 0)
+            }
+            return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
+        }
+
+        let unownedCount = entries.filter { $0.ownershipStatus == .unownedPotentialCoverageGap }.count
+
+        return DataVolumeTopLevelSafetyNetReport(
+            checkedDirectoryPath: dataVolumeURL.path,
+            entries: entries,
+            totalEntriesCount: entries.count,
+            unownedEntriesCount: unownedCount,
+            isFullyCovered: unownedCount == 0
+        )
+    }
+
+    private func classify(
+        name: String,
+        originalPath: String,
+        normalizedPath: String,
+        allocatedBytes: Int64?,
+        reconciliationReport: StorageReconciliationReport
+    ) -> DataVolumeTopLevelSafetyNetEntry {
+        // 1. Check canonical analyzers
+        if let (root, stage) = Self.canonicalAnalyzerOwners[normalizedPath] ?? Self.canonicalAnalyzerOwners[name] {
+            return DataVolumeTopLevelSafetyNetEntry(
+                originalPath: originalPath,
+                normalizedPath: normalizedPath,
+                name: name,
+                ownershipStatus: .ownedByCanonicalAnalyzer,
+                owningAnalyzerStage: stage,
+                canonicalOwner: root,
+                allocatedBytes: allocatedBytes,
+                isFilesystemAdditive: true,
+                reason: "Owned and measured by canonical analyzer stage \(stage.rawValue)."
+            )
+        }
+
+        // 2. Check intentionally non-additive system paths
+        if Self.intentionallyNonAdditive.contains(name) || Self.intentionallyNonAdditive.contains(originalPath) || Self.intentionallyNonAdditive.contains(normalizedPath) {
+            return DataVolumeTopLevelSafetyNetEntry(
+                originalPath: originalPath,
+                normalizedPath: normalizedPath,
+                name: name,
+                ownershipStatus: .intentionallyNonAdditive,
+                owningAnalyzerStage: nil,
+                canonicalOwner: nil,
+                allocatedBytes: allocatedBytes,
+                isFilesystemAdditive: false,
+                reason: "Intentionally non-additive system-managed metadata or mount root."
+            )
+        }
+
+        // 3. Check hidden data roots
+        if name.hasPrefix(".") {
+            return DataVolumeTopLevelSafetyNetEntry(
+                originalPath: originalPath,
+                normalizedPath: normalizedPath,
+                name: name,
+                ownershipStatus: .ownedByCanonicalAnalyzer,
+                owningAnalyzerStage: .dataVolumeHiddenStorage,
+                canonicalOwner: .dataVolumeHiddenStorage,
+                allocatedBytes: allocatedBytes,
+                isFilesystemAdditive: true,
+                reason: "Owned by dataVolumeHiddenStorage analyzer."
+            )
+        }
+
+        // 4. Check firmlink aliases
+        if Self.firmlinkAliases.contains(normalizedPath) || Self.firmlinkAliases.contains(name) || Self.firmlinkAliases.contains("/" + name) {
+            return DataVolumeTopLevelSafetyNetEntry(
+                originalPath: originalPath,
+                normalizedPath: normalizedPath,
+                name: name,
+                ownershipStatus: .firmlinkAlias,
+                owningAnalyzerStage: .privateStorage,
+                canonicalOwner: .privateStorage,
+                allocatedBytes: allocatedBytes,
+                isFilesystemAdditive: false,
+                reason: "Firmlink alias normalizing to /private standard location."
+            )
+        }
+
+        // 5. Check coverage expansion
+        let candidateMatch = reconciliationReport.analyzerResults.coverageExpansion?.candidates.first {
+            $0.originalPath == originalPath || $0.normalizedPath == normalizedPath || $0.name == name
+        }
+
+        if let candidate = candidateMatch, candidate.status.isMeasuredOrPartial {
+            return DataVolumeTopLevelSafetyNetEntry(
+                originalPath: originalPath,
+                normalizedPath: normalizedPath,
+                name: name,
+                ownershipStatus: .ownedByCoverageExpansion,
+                owningAnalyzerStage: .coverageExpansion,
+                canonicalOwner: .additionalCoverageGap,
+                allocatedBytes: candidate.allocatedBytes ?? allocatedBytes,
+                isFilesystemAdditive: candidate.contributesToExplainedBytes,
+                reason: "Discovered and measured by coverage expansion pass."
+            )
+        }
+
+        // 6. Otherwise: unowned potential gap
+        return DataVolumeTopLevelSafetyNetEntry(
+            originalPath: originalPath,
+            normalizedPath: normalizedPath,
+            name: name,
+            ownershipStatus: .unownedPotentialCoverageGap,
+            owningAnalyzerStage: nil,
+            canonicalOwner: nil,
+            allocatedBytes: allocatedBytes,
+            isFilesystemAdditive: false,
+            reason: "Top-level Data volume entry not owned by canonical analyzers or coverage expansion."
+        )
+    }
+}

--- a/PureMac/Logic/Storage/FileTreeScanner.swift
+++ b/PureMac/Logic/Storage/FileTreeScanner.swift
@@ -6,9 +6,14 @@ import Foundation
 final class FileTreeScanner: @unchecked Sendable {
     struct Configuration: Sendable {
         let maxConcurrentDirectoryReads: Int
+        let aggregateApplicationPackages: Bool
 
-        init(maxConcurrentDirectoryReads: Int = 4) {
+        init(
+            maxConcurrentDirectoryReads: Int = 8,
+            aggregateApplicationPackages: Bool = false
+        ) {
             self.maxConcurrentDirectoryReads = min(max(maxConcurrentDirectoryReads, 1), 16)
+            self.aggregateApplicationPackages = aggregateApplicationPackages
         }
     }
 
@@ -33,15 +38,42 @@ final class FileTreeScanner: @unchecked Sendable {
     }
 
     private let configuration: Configuration
+    private let cache: StorageAnalysisCache?
 
-    init(configuration: Configuration = Configuration()) {
+    init(configuration: Configuration = Configuration(), cache: StorageAnalysisCache? = nil) {
         self.configuration = configuration
+        self.cache = cache
     }
 
     /// Scans off the calling actor. Cancelling the caller returns a partial
     /// tree whose incomplete locations are represented as scan issues.
-    func scan(root: URL) async -> StorageAnalysisResult {
-        await scan(root: root, immediateChildFilter: nil)
+    func scan(
+        root: URL,
+        aggregateApplicationPackages: Bool? = nil
+    ) async -> StorageAnalysisResult {
+        let shouldAggregate = aggregateApplicationPackages ?? configuration.aggregateApplicationPackages
+        if let cache {
+            do {
+                return try await cache.scanOrCoalesce(path: root.path) {
+                    await self.scanDirectly(
+                        root: root,
+                        immediateChildFilter: nil,
+                        aggregateApplicationPackages: shouldAggregate
+                    )
+                }
+            } catch {
+                return await scanDirectly(
+                    root: root,
+                    immediateChildFilter: nil,
+                    aggregateApplicationPackages: shouldAggregate
+                )
+            }
+        }
+        return await scanDirectly(
+            root: root,
+            immediateChildFilter: nil,
+            aggregateApplicationPackages: shouldAggregate
+        )
     }
 
     /// Scans independent roots in one detached operation. Each root enforces
@@ -67,11 +99,19 @@ final class FileTreeScanner: @unchecked Sendable {
             )
         }
 
-        return await withTaskCancellationHandler {
+        let analysis = await withTaskCancellationHandler {
             await task.value
         } onCancel: {
             cancellation.cancel()
         }
+
+        if let cache {
+            for result in analysis.results {
+                cache.store(result, isFullSubtree: true)
+            }
+        }
+
+        return analysis
     }
 
     /// Enumerates the supplied root once, then recursively scans only the
@@ -80,21 +120,34 @@ final class FileTreeScanner: @unchecked Sendable {
     /// selected children only; the root directory's own bytes are excluded.
     func scanSelectedImmediateChildren(
         root: URL,
+        aggregateApplicationPackages: Bool? = nil,
         including include: @escaping @Sendable (ImmediateChild) -> Bool
     ) async -> StorageAnalysisResult {
-        await scan(root: root, immediateChildFilter: include)
+        let shouldAggregate = aggregateApplicationPackages ?? configuration.aggregateApplicationPackages
+        return await scanDirectly(
+            root: root,
+            immediateChildFilter: include,
+            aggregateApplicationPackages: shouldAggregate
+        )
     }
 
-    private func scan(
+    private func scanDirectly(
         root: URL,
-        immediateChildFilter: (@Sendable (ImmediateChild) -> Bool)?
+        immediateChildFilter: (@Sendable (ImmediateChild) -> Bool)?,
+        aggregateApplicationPackages: Bool
     ) async -> StorageAnalysisResult {
         let cancellation = ScanCancellationToken()
-        let configuration = configuration
+        var config = configuration
+        if config.aggregateApplicationPackages != aggregateApplicationPackages {
+            config = Configuration(
+                maxConcurrentDirectoryReads: configuration.maxConcurrentDirectoryReads,
+                aggregateApplicationPackages: aggregateApplicationPackages
+            )
+        }
         let task = Task.detached(priority: .utility) {
             Self.scanSynchronously(
                 root: root,
-                configuration: configuration,
+                configuration: config,
                 cancellation: cancellation,
                 immediateChildFilter: immediateChildFilter
             )
@@ -123,6 +176,8 @@ private extension FileTreeScanner {
         var itemType: StorageItemType
         let ownLogicalSize: Int64
         let ownAllocatedSize: Int64
+        var aggregateLogicalSize: Int64? = nil
+        var aggregateAllocatedSize: Int64? = nil
         let deviceIdentifier: UInt64?
         let inode: UInt64?
         let hardLinkCount: UInt64
@@ -131,6 +186,7 @@ private extension FileTreeScanner {
         var isCountedInParentTotals: Bool
         var accessibility: StorageAccessibility
         var issues: [StorageScanIssue]
+        var isPackageAggregate: Bool = false
     }
 
     struct DirectoryRead: Sendable {
@@ -140,6 +196,14 @@ private extension FileTreeScanner {
         let wasCancelled: Bool
     }
 
+    struct PackageMeasurement: Sendable {
+        let logicalSize: Int64
+        let allocatedSize: Int64
+        let accessibility: StorageAccessibility
+        let issues: [StorageScanIssue]
+        let entriesMeasured: Int
+    }
+
     struct FlatScan: Sendable {
         let rootPath: String
         let startedAt: Date
@@ -147,6 +211,8 @@ private extension FileTreeScanner {
         let rootDeviceIdentifier: UInt64?
         let wasCancelled: Bool
         var nodesByPath: [String: FlatNode]
+        var packagesAggregated: Int = 0
+        var descendantEntriesMeasured: Int = 0
     }
 
     final class DirectoryReadCollector: @unchecked Sendable {
@@ -233,8 +299,48 @@ private extension FileTreeScanner {
             rootMetadata.isCountedInParentTotals = false
         }
         let rootDevice = rootMetadata.deviceIdentifier
-        var nodesByPath = [rootPath: rootMetadata]
+        var seenHardLinks: [FileIdentity: String] = [:]
+        if rootMetadata.hardLinkCount > 1,
+           let dev = rootMetadata.deviceIdentifier,
+           let ino = rootMetadata.inode {
+            seenHardLinks[FileIdentity(device: dev, inode: ino)] = rootPath
+        }
 
+        var packagesAggregated = 0
+        var descendantEntriesMeasured = 0
+
+        // If the root itself is an application package boundary and package aggregation is enabled:
+        if configuration.aggregateApplicationPackages,
+           rootPath.hasSuffix(".app"),
+           rootMetadata.itemType == .directory {
+            let measurement = measurePackageSubtree(
+                packageRoot: rootMetadata,
+                rootDevice: rootDevice,
+                cancellation: cancellation,
+                seenHardLinks: &seenHardLinks
+            )
+            packagesAggregated += 1
+            descendantEntriesMeasured += max(measurement.entriesMeasured - 1, 0)
+
+            rootMetadata.aggregateLogicalSize = measurement.logicalSize
+            rootMetadata.aggregateAllocatedSize = measurement.allocatedSize
+            rootMetadata.accessibility = measurement.accessibility
+            rootMetadata.issues = measurement.issues
+            rootMetadata.isPackageAggregate = true
+
+            return FlatScan(
+                rootPath: rootPath,
+                startedAt: startedAt,
+                completedAt: Date(),
+                rootDeviceIdentifier: rootDevice,
+                wasCancelled: cancellation.isCancelled,
+                nodesByPath: [rootPath: rootMetadata],
+                packagesAggregated: packagesAggregated,
+                descendantEntriesMeasured: descendantEntriesMeasured
+            )
+        }
+
+        var nodesByPath = [rootPath: rootMetadata]
         var pendingDirectories: [String] = []
         if rootMetadata.itemType == .directory {
             pendingDirectories.append(rootPath)
@@ -258,30 +364,89 @@ private extension FileTreeScanner {
                     markCancelled(directoryRead.path, nodesByPath: &nodesByPath)
                 }
 
-                for entryName in directoryRead.entryNames {
-                    if cancellation.isCancelled {
-                        markCancelled(directoryRead.path, nodesByPath: &nodesByPath)
-                        break
+                let entryNames = directoryRead.entryNames
+                guard !entryNames.isEmpty else { continue }
+
+                let parentPath = directoryRead.path
+                var children = [FlatNode?](repeating: nil, count: entryNames.count)
+
+                if entryNames.count >= 8, !cancellation.isCancelled {
+                    DispatchQueue.concurrentPerform(iterations: entryNames.count) { index in
+                        if !cancellation.isCancelled {
+                            let childPath = appending(entryNames[index], to: parentPath)
+                            children[index] = readMetadata(
+                                at: childPath,
+                                parentPath: parentPath,
+                                rootDevice: rootDevice
+                            )
+                        }
                     }
+                } else {
+                    for index in entryNames.indices {
+                        if cancellation.isCancelled { break }
+                        let childPath = appending(entryNames[index], to: parentPath)
+                        children[index] = readMetadata(
+                            at: childPath,
+                            parentPath: parentPath,
+                            rootDevice: rootDevice
+                        )
+                    }
+                }
 
-                    let childPath = appending(entryName, to: directoryRead.path)
-                    guard nodesByPath[childPath] == nil else { continue }
+                if cancellation.isCancelled {
+                    markCancelled(parentPath, nodesByPath: &nodesByPath)
+                    break
+                }
 
-                    let child = readMetadata(
-                        at: childPath,
-                        parentPath: directoryRead.path,
-                        rootDevice: rootDevice
-                    )
+                for childOpt in children {
+                    guard var child = childOpt else { continue }
+                    guard nodesByPath[child.path] == nil else { continue }
 
-                    if directoryRead.path == rootPath,
+                    if parentPath == rootPath,
                        let immediateChildFilter,
                        !immediateChildFilter(immediateChild(from: child)) {
                         continue
                     }
-                    nodesByPath[childPath] = child
+
+                    // Check if child is an application package boundary
+                    if configuration.aggregateApplicationPackages,
+                       child.name.hasSuffix(".app"),
+                       child.itemType == .directory {
+                        let measurement = measurePackageSubtree(
+                            packageRoot: child,
+                            rootDevice: rootDevice,
+                            cancellation: cancellation,
+                            seenHardLinks: &seenHardLinks
+                        )
+                        packagesAggregated += 1
+                        descendantEntriesMeasured += max(measurement.entriesMeasured - 1, 0)
+
+                        child.aggregateLogicalSize = measurement.logicalSize
+                        child.aggregateAllocatedSize = measurement.allocatedSize
+                        child.accessibility = measurement.accessibility
+                        child.issues = measurement.issues
+                        child.isPackageAggregate = true
+
+                        nodesByPath[child.path] = child
+                        // Do NOT add to pendingDirectories; internal descendants are not materialized
+                        continue
+                    }
+
+                    if child.hardLinkCount > 1,
+                       let dev = child.deviceIdentifier,
+                       let ino = child.inode {
+                        let identity = FileIdentity(device: dev, inode: ino)
+                        if seenHardLinks[identity] == nil {
+                            seenHardLinks[identity] = child.path
+                        } else {
+                            child.isCountedInParentTotals = false
+                        }
+                    }
+
+                    nodesByPath[child.path] = child
 
                     if child.itemType == .directory {
-                        pendingDirectories.append(childPath)
+                        pendingDirectories.append(child.path)
                     }
                 }
             }
@@ -310,15 +475,149 @@ private extension FileTreeScanner {
             completedAt: Date(),
             rootDeviceIdentifier: rootDevice,
             wasCancelled: wasCancelled,
-            nodesByPath: nodesByPath
+            nodesByPath: nodesByPath,
+            packagesAggregated: packagesAggregated,
+            descendantEntriesMeasured: descendantEntriesMeasured
+        )
+    }
+
+    static func measurePackageSubtree(
+        packageRoot: FlatNode,
+        rootDevice: UInt64?,
+        cancellation: ScanCancellationToken,
+        seenHardLinks: inout [FileIdentity: String]
+    ) -> PackageMeasurement {
+        var totalLogical: Int64 = packageRoot.isCountedInParentTotals ? packageRoot.ownLogicalSize : 0
+        var totalAllocated: Int64 = packageRoot.isCountedInParentTotals ? packageRoot.ownAllocatedSize : 0
+        var issues: [StorageScanIssue] = packageRoot.issues
+        var accessibility = packageRoot.accessibility
+        var entriesMeasured = 1
+
+        var pendingDirs: [String] = [packageRoot.path]
+
+        while !pendingDirs.isEmpty, !cancellation.isCancelled {
+            let currentDir = pendingDirs.removeLast()
+            let dirRead = readDirectory(at: currentDir, cancellation: cancellation)
+
+            if let issue = dirRead.issue {
+                issues.append(issue)
+                if accessibility == .accessible {
+                    accessibility = .partiallyAccessible
+                }
+            }
+
+            if dirRead.wasCancelled {
+                if accessibility == .accessible {
+                    accessibility = .partiallyAccessible
+                }
+                break
+            }
+
+            for entryName in dirRead.entryNames {
+                if cancellation.isCancelled { break }
+                let entryPath = appending(entryName, to: currentDir)
+                let entryNode = readMetadata(at: entryPath, parentPath: currentDir, rootDevice: rootDevice)
+                entriesMeasured += 1
+
+                if !entryNode.issues.isEmpty {
+                    issues.append(contentsOf: entryNode.issues)
+                    if accessibility == .accessible {
+                        accessibility = .partiallyAccessible
+                    }
+                }
+
+                if entryNode.accessibility != .accessible {
+                    if accessibility == .accessible {
+                        accessibility = .partiallyAccessible
+                    }
+                }
+
+                if entryNode.itemType == .volumeBoundary {
+                    continue
+                }
+
+                if entryNode.itemType == .directory {
+                    if entryNode.isCountedInParentTotals {
+                        totalLogical = saturatedAdd(totalLogical, entryNode.ownLogicalSize)
+                        totalAllocated = saturatedAdd(totalAllocated, entryNode.ownAllocatedSize)
+                    }
+                    pendingDirs.append(entryNode.path)
+                } else if entryNode.itemType == .regularFile {
+                    if entryNode.hardLinkCount > 1,
+                       let dev = entryNode.deviceIdentifier,
+                       let ino = entryNode.inode {
+                        let identity = FileIdentity(device: dev, inode: ino)
+                        if seenHardLinks[identity] == nil {
+                            seenHardLinks[identity] = entryNode.path
+                            if entryNode.isCountedInParentTotals {
+                                totalLogical = saturatedAdd(totalLogical, entryNode.ownLogicalSize)
+                                totalAllocated = saturatedAdd(totalAllocated, entryNode.ownAllocatedSize)
+                            }
+                        }
+                    } else {
+                        if entryNode.isCountedInParentTotals {
+                            totalLogical = saturatedAdd(totalLogical, entryNode.ownLogicalSize)
+                            totalAllocated = saturatedAdd(totalAllocated, entryNode.ownAllocatedSize)
+                        }
+                    }
+                } else {
+                    // Symbolic link (not followed) or other special item
+                    if entryNode.isCountedInParentTotals {
+                        totalLogical = saturatedAdd(totalLogical, entryNode.ownLogicalSize)
+                        totalAllocated = saturatedAdd(totalAllocated, entryNode.ownAllocatedSize)
+                    }
+                }
+            }
+        }
+
+        if cancellation.isCancelled {
+            if accessibility == .accessible {
+                accessibility = .partiallyAccessible
+            }
+            issues.append(StorageScanIssue(
+                path: packageRoot.path,
+                kind: .cancelled,
+                message: "The storage scan was cancelled before it completed.",
+                posixErrorCode: nil
+            ))
+        }
+
+        return PackageMeasurement(
+            logicalSize: totalLogical,
+            allocatedSize: totalAllocated,
+            accessibility: accessibility,
+            issues: issues,
+            entriesMeasured: entriesMeasured
         )
     }
 
     static func finalize(_ flatScan: FlatScan) -> StorageAnalysisResult {
-        let storageRoot = buildTree(
+        var storageRoot = buildTree(
             rootPath: flatScan.rootPath,
             nodesByPath: flatScan.nodesByPath
         )
+        if flatScan.packagesAggregated > 0 {
+            var meta = storageRoot.metadata
+            meta.attributes["fileTreeScanner.packagesAggregated"] = "\(flatScan.packagesAggregated)"
+            meta.attributes["fileTreeScanner.descendantEntriesMeasured"] = "\(flatScan.descendantEntriesMeasured)"
+            meta.attributes["fileTreeScanner.descendantNodesAvoided"] = "\(flatScan.descendantEntriesMeasured)"
+            storageRoot = StorageNode(
+                name: storageRoot.name,
+                absolutePath: storageRoot.absolutePath,
+                logicalSize: storageRoot.logicalSize,
+                allocatedSize: storageRoot.allocatedSize,
+                ownLogicalSize: storageRoot.ownLogicalSize,
+                ownAllocatedSize: storageRoot.ownAllocatedSize,
+                itemType: storageRoot.itemType,
+                children: storageRoot.children,
+                accessibility: storageRoot.accessibility,
+                scanIssues: storageRoot.scanIssues,
+                isHidden: storageRoot.isHidden,
+                isSymbolicLink: storageRoot.isSymbolicLink,
+                isCountedInParentTotals: storageRoot.isCountedInParentTotals,
+                metadata: meta
+            )
+        }
         let issues = flatScan.nodesByPath.values
             .flatMap(\.issues)
             .sorted(by: issueSort)
@@ -598,11 +897,18 @@ private extension FileTreeScanner {
             guard let flatNode = nodesByPath[path] else { continue }
             let children = (childrenByParent[path] ?? []).sorted { $0.absolutePath < $1.absolutePath }
 
-            var logicalSize = flatNode.isCountedInParentTotals ? flatNode.ownLogicalSize : 0
-            var allocatedSize = flatNode.isCountedInParentTotals ? flatNode.ownAllocatedSize : 0
-            for child in children {
-                logicalSize = saturatedAdd(logicalSize, child.logicalSize)
-                allocatedSize = saturatedAdd(allocatedSize, child.allocatedSize)
+            var logicalSize: Int64
+            var allocatedSize: Int64
+            if flatNode.isPackageAggregate {
+                logicalSize = flatNode.aggregateLogicalSize ?? flatNode.ownLogicalSize
+                allocatedSize = flatNode.aggregateAllocatedSize ?? flatNode.ownAllocatedSize
+            } else {
+                logicalSize = flatNode.isCountedInParentTotals ? flatNode.ownLogicalSize : 0
+                allocatedSize = flatNode.isCountedInParentTotals ? flatNode.ownAllocatedSize : 0
+                for child in children {
+                    logicalSize = saturatedAdd(logicalSize, child.logicalSize)
+                    allocatedSize = saturatedAdd(allocatedSize, child.allocatedSize)
+                }
             }
 
             var accessibility = flatNode.accessibility

--- a/PureMac/Logic/Storage/FileTreeScanner.swift
+++ b/PureMac/Logic/Storage/FileTreeScanner.swift
@@ -1,0 +1,765 @@
+import Darwin
+import Foundation
+
+/// Builds a read-only tree of filesystem usage without producing cleanup
+/// candidates or changing anything on disk.
+final class FileTreeScanner: @unchecked Sendable {
+    struct Configuration: Sendable {
+        let maxConcurrentDirectoryReads: Int
+
+        init(maxConcurrentDirectoryReads: Int = 4) {
+            self.maxConcurrentDirectoryReads = min(max(maxConcurrentDirectoryReads, 1), 16)
+        }
+    }
+
+    /// Read-only metadata available when choosing which immediate children of
+    /// a root should receive recursive analysis.
+    struct ImmediateChild: Sendable {
+        let name: String
+        let absolutePath: String
+        let itemType: StorageItemType
+        let accessibility: StorageAccessibility
+        let isHidden: Bool
+        let isSymbolicLink: Bool
+    }
+
+    /// Results for independent canonical roots plus totals that count a
+    /// physical hard-linked file only once across the complete root set.
+    /// Individual results retain their standalone per-root accounting.
+    struct MultiRootAnalysis: Sendable {
+        let results: [StorageAnalysisResult]
+        let combinedUniqueLogicalSize: Int64
+        let combinedUniqueAllocatedSize: Int64
+    }
+
+    private let configuration: Configuration
+
+    init(configuration: Configuration = Configuration()) {
+        self.configuration = configuration
+    }
+
+    /// Scans off the calling actor. Cancelling the caller returns a partial
+    /// tree whose incomplete locations are represented as scan issues.
+    func scan(root: URL) async -> StorageAnalysisResult {
+        await scan(root: root, immediateChildFilter: nil)
+    }
+
+    /// Scans independent roots in one detached operation. Each root enforces
+    /// its own volume boundary and produces its own tree. The combined totals
+    /// use a shared inode ledger so hard links visible in more than one root
+    /// are not added twice. Symbolic links are never resolved.
+    func scanIndependentRoots(_ roots: [URL]) async -> MultiRootAnalysis {
+        guard !roots.isEmpty else {
+            return MultiRootAnalysis(
+                results: [],
+                combinedUniqueLogicalSize: 0,
+                combinedUniqueAllocatedSize: 0
+            )
+        }
+
+        let cancellation = ScanCancellationToken()
+        let configuration = configuration
+        let task = Task.detached(priority: .utility) {
+            Self.scanIndependentRootsSynchronously(
+                roots,
+                configuration: configuration,
+                cancellation: cancellation
+            )
+        }
+
+        return await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            cancellation.cancel()
+        }
+    }
+
+    /// Enumerates the supplied root once, then recursively scans only the
+    /// immediate children accepted by `include`. All selected roots share one
+    /// hard-link accounting context. The returned root's subtree totals contain
+    /// selected children only; the root directory's own bytes are excluded.
+    func scanSelectedImmediateChildren(
+        root: URL,
+        including include: @escaping @Sendable (ImmediateChild) -> Bool
+    ) async -> StorageAnalysisResult {
+        await scan(root: root, immediateChildFilter: include)
+    }
+
+    private func scan(
+        root: URL,
+        immediateChildFilter: (@Sendable (ImmediateChild) -> Bool)?
+    ) async -> StorageAnalysisResult {
+        let cancellation = ScanCancellationToken()
+        let configuration = configuration
+        let task = Task.detached(priority: .utility) {
+            Self.scanSynchronously(
+                root: root,
+                configuration: configuration,
+                cancellation: cancellation,
+                immediateChildFilter: immediateChildFilter
+            )
+        }
+
+        return await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            cancellation.cancel()
+        }
+    }
+}
+
+// MARK: - Scan Implementation
+
+private extension FileTreeScanner {
+    struct FileIdentity: Hashable, Sendable {
+        let device: UInt64
+        let inode: UInt64
+    }
+
+    struct FlatNode: Sendable {
+        let name: String
+        let path: String
+        let parentPath: String?
+        var itemType: StorageItemType
+        let ownLogicalSize: Int64
+        let ownAllocatedSize: Int64
+        let deviceIdentifier: UInt64?
+        let inode: UInt64?
+        let hardLinkCount: UInt64
+        let isHidden: Bool
+        let isSymbolicLink: Bool
+        var isCountedInParentTotals: Bool
+        var accessibility: StorageAccessibility
+        var issues: [StorageScanIssue]
+    }
+
+    struct DirectoryRead: Sendable {
+        let path: String
+        let entryNames: [String]
+        let issue: StorageScanIssue?
+        let wasCancelled: Bool
+    }
+
+    struct FlatScan: Sendable {
+        let rootPath: String
+        let startedAt: Date
+        let completedAt: Date
+        let rootDeviceIdentifier: UInt64?
+        let wasCancelled: Bool
+        var nodesByPath: [String: FlatNode]
+    }
+
+    final class DirectoryReadCollector: @unchecked Sendable {
+        private let lock = NSLock()
+        private var indexedResults: [(index: Int, result: DirectoryRead)] = []
+
+        func append(_ result: DirectoryRead, at index: Int) {
+            lock.lock()
+            indexedResults.append((index, result))
+            lock.unlock()
+        }
+
+        func orderedResults() -> [DirectoryRead] {
+            lock.lock()
+            let snapshot = indexedResults
+            lock.unlock()
+            return snapshot.sorted { $0.index < $1.index }.map(\.result)
+        }
+    }
+
+    static func scanSynchronously(
+        root: URL,
+        configuration: Configuration,
+        cancellation: ScanCancellationToken,
+        immediateChildFilter: (@Sendable (ImmediateChild) -> Bool)?
+    ) -> StorageAnalysisResult {
+        var flatScan = collectSynchronously(
+            root: root,
+            configuration: configuration,
+            cancellation: cancellation,
+            immediateChildFilter: immediateChildFilter
+        )
+        deduplicateHardLinks(nodesByPath: &flatScan.nodesByPath)
+        return finalize(flatScan)
+    }
+
+    static func scanIndependentRootsSynchronously(
+        _ roots: [URL],
+        configuration: Configuration,
+        cancellation: ScanCancellationToken
+    ) -> MultiRootAnalysis {
+        let flatScans = roots.map {
+            collectSynchronously(
+                root: $0,
+                configuration: configuration,
+                cancellation: cancellation,
+                immediateChildFilter: nil
+            )
+        }
+
+        var standaloneScans = flatScans
+        for index in standaloneScans.indices {
+            deduplicateHardLinks(nodesByPath: &standaloneScans[index].nodesByPath)
+        }
+        let standaloneResults = standaloneScans.map(finalize)
+
+        var uniqueScans = flatScans
+        deduplicateHardLinksAcrossRoots(flatScans: &uniqueScans)
+        let uniqueResults = uniqueScans.map(finalize)
+        let combinedLogical = uniqueResults.reduce(Int64(0)) {
+            saturatedAdd($0, $1.root.logicalSize)
+        }
+        let combinedAllocated = uniqueResults.reduce(Int64(0)) {
+            saturatedAdd($0, $1.root.allocatedSize)
+        }
+
+        return MultiRootAnalysis(
+            results: standaloneResults,
+            combinedUniqueLogicalSize: combinedLogical,
+            combinedUniqueAllocatedSize: combinedAllocated
+        )
+    }
+
+    static func collectSynchronously(
+        root: URL,
+        configuration: Configuration,
+        cancellation: ScanCancellationToken,
+        immediateChildFilter: (@Sendable (ImmediateChild) -> Bool)?
+    ) -> FlatScan {
+        let startedAt = Date()
+        let rootPath = root.standardizedFileURL.path
+        var rootMetadata = readMetadata(at: rootPath, parentPath: nil, rootDevice: nil)
+        if immediateChildFilter != nil {
+            rootMetadata.isCountedInParentTotals = false
+        }
+        let rootDevice = rootMetadata.deviceIdentifier
+        var nodesByPath = [rootPath: rootMetadata]
+
+        var pendingDirectories: [String] = []
+        if rootMetadata.itemType == .directory {
+            pendingDirectories.append(rootPath)
+        }
+        var pendingIndex = 0
+
+        while pendingIndex < pendingDirectories.count, !cancellation.isCancelled {
+            let batchEnd = min(
+                pendingIndex + configuration.maxConcurrentDirectoryReads,
+                pendingDirectories.count
+            )
+            let batch = Array(pendingDirectories[pendingIndex..<batchEnd])
+            pendingIndex = batchEnd
+
+            for directoryRead in readDirectoryBatch(batch, cancellation: cancellation) {
+                if let issue = directoryRead.issue {
+                    append(issue, to: directoryRead.path, nodesByPath: &nodesByPath)
+                }
+
+                if directoryRead.wasCancelled {
+                    markCancelled(directoryRead.path, nodesByPath: &nodesByPath)
+                }
+
+                for entryName in directoryRead.entryNames {
+                    if cancellation.isCancelled {
+                        markCancelled(directoryRead.path, nodesByPath: &nodesByPath)
+                        break
+                    }
+
+                    let childPath = appending(entryName, to: directoryRead.path)
+                    guard nodesByPath[childPath] == nil else { continue }
+
+                    let child = readMetadata(
+                        at: childPath,
+                        parentPath: directoryRead.path,
+                        rootDevice: rootDevice
+                    )
+
+                    if directoryRead.path == rootPath,
+                       let immediateChildFilter,
+                       !immediateChildFilter(immediateChild(from: child)) {
+                        continue
+                    }
+                    nodesByPath[childPath] = child
+
+                    if child.itemType == .directory {
+                        pendingDirectories.append(childPath)
+                    }
+                }
+            }
+        }
+
+        let wasCancelled = cancellation.isCancelled
+        if wasCancelled {
+            if pendingIndex < pendingDirectories.count {
+                for path in pendingDirectories[pendingIndex...] {
+                    markCancelled(path, nodesByPath: &nodesByPath)
+                }
+            }
+
+            let cancellationIssue = StorageScanIssue(
+                path: rootPath,
+                kind: .cancelled,
+                message: "The storage scan was cancelled before it completed.",
+                posixErrorCode: nil
+            )
+            append(cancellationIssue, to: rootPath, nodesByPath: &nodesByPath)
+        }
+
+        return FlatScan(
+            rootPath: rootPath,
+            startedAt: startedAt,
+            completedAt: Date(),
+            rootDeviceIdentifier: rootDevice,
+            wasCancelled: wasCancelled,
+            nodesByPath: nodesByPath
+        )
+    }
+
+    static func finalize(_ flatScan: FlatScan) -> StorageAnalysisResult {
+        let storageRoot = buildTree(
+            rootPath: flatScan.rootPath,
+            nodesByPath: flatScan.nodesByPath
+        )
+        let issues = flatScan.nodesByPath.values
+            .flatMap(\.issues)
+            .sorted(by: issueSort)
+
+        return StorageAnalysisResult(
+            root: storageRoot,
+            startedAt: flatScan.startedAt,
+            completedAt: flatScan.completedAt,
+            rootDeviceIdentifier: flatScan.rootDeviceIdentifier,
+            wasCancelled: flatScan.wasCancelled,
+            issues: issues
+        )
+    }
+
+    static func readDirectoryBatch(
+        _ paths: [String],
+        cancellation: ScanCancellationToken
+    ) -> [DirectoryRead] {
+        guard !paths.isEmpty else { return [] }
+
+        let results = DirectoryReadCollector()
+
+        DispatchQueue.concurrentPerform(iterations: paths.count) { index in
+            let result = readDirectory(at: paths[index], cancellation: cancellation)
+            results.append(result, at: index)
+        }
+
+        return results.orderedResults()
+    }
+
+    /// Streams a single directory with POSIX APIs so hidden entries are kept,
+    /// symlinks are not resolved, and enumeration errors remain observable.
+    static func readDirectory(
+        at path: String,
+        cancellation: ScanCancellationToken
+    ) -> DirectoryRead {
+        guard !cancellation.isCancelled else {
+            return DirectoryRead(path: path, entryNames: [], issue: nil, wasCancelled: true)
+        }
+
+        guard let directory = opendir(path) else {
+            let errorCode = Darwin.errno
+            return DirectoryRead(
+                path: path,
+                entryNames: [],
+                issue: posixIssue(
+                    path: path,
+                    errorCode: errorCode,
+                    fallbackKind: .directoryEnumerationFailed,
+                    operation: "Directory enumeration"
+                ),
+                wasCancelled: false
+            )
+        }
+        defer { closedir(directory) }
+
+        var entryNames: [String] = []
+        while true {
+            if cancellation.isCancelled {
+                return DirectoryRead(
+                    path: path,
+                    entryNames: entryNames,
+                    issue: nil,
+                    wasCancelled: true
+                )
+            }
+
+            Darwin.errno = 0
+            guard let entry = readdir(directory) else {
+                let errorCode = Darwin.errno
+                let issue: StorageScanIssue?
+                if errorCode == 0 {
+                    issue = nil
+                } else {
+                    issue = posixIssue(
+                        path: path,
+                        errorCode: errorCode,
+                        fallbackKind: .directoryEnumerationFailed,
+                        operation: "Directory enumeration"
+                    )
+                }
+
+                return DirectoryRead(
+                    path: path,
+                    entryNames: entryNames.sorted(),
+                    issue: issue,
+                    wasCancelled: false
+                )
+            }
+
+            var nameBuffer = entry.pointee.d_name
+            let capacity = MemoryLayout.size(ofValue: nameBuffer)
+            let name = withUnsafePointer(to: &nameBuffer) { pointer in
+                pointer.withMemoryRebound(to: CChar.self, capacity: capacity) {
+                    String(cString: $0)
+                }
+            }
+
+            if name != ".", name != ".." {
+                entryNames.append(name)
+            }
+        }
+    }
+
+    /// Uses `lstat`, never `stat`, so the target of a symbolic link is never
+    /// inspected. POSIX `st_blocks` is reported in 512-byte units on macOS.
+    static func readMetadata(
+        at path: String,
+        parentPath: String?,
+        rootDevice: UInt64?
+    ) -> FlatNode {
+        var metadata = stat()
+        guard lstat(path, &metadata) == 0 else {
+            let errorCode = Darwin.errno
+            return FlatNode(
+                name: displayName(for: path),
+                path: path,
+                parentPath: parentPath,
+                itemType: .unknown,
+                ownLogicalSize: 0,
+                ownAllocatedSize: 0,
+                deviceIdentifier: nil,
+                inode: nil,
+                hardLinkCount: 0,
+                isHidden: pathComponentIsHidden(path),
+                isSymbolicLink: false,
+                isCountedInParentTotals: false,
+                accessibility: .inaccessible,
+                issues: [
+                    posixIssue(
+                        path: path,
+                        errorCode: errorCode,
+                        fallbackKind: .metadataUnavailable,
+                        operation: "Metadata read"
+                    )
+                ]
+            )
+        }
+
+        let deviceIdentifier = UInt64(metadata.st_dev)
+        let inode = UInt64(metadata.st_ino)
+        let mode = metadata.st_mode & mode_t(S_IFMT)
+        let isSymbolicLink = mode == mode_t(S_IFLNK)
+        let regularType: StorageItemType
+        switch mode {
+        case mode_t(S_IFDIR):
+            regularType = .directory
+        case mode_t(S_IFREG):
+            regularType = .regularFile
+        case mode_t(S_IFLNK):
+            regularType = .symbolicLink
+        default:
+            regularType = .other
+        }
+
+        let logicalSize = max(Int64(metadata.st_size), 0)
+        let allocatedSize = saturatedMultiply(max(Int64(metadata.st_blocks), 0), by: 512)
+        let hiddenByFlag = (UInt32(metadata.st_flags) & UInt32(UF_HIDDEN)) != 0
+        let isHidden = pathComponentIsHidden(path) || hiddenByFlag
+
+        if let rootDevice, deviceIdentifier != rootDevice {
+            return FlatNode(
+                name: displayName(for: path),
+                path: path,
+                parentPath: parentPath,
+                itemType: .volumeBoundary,
+                ownLogicalSize: logicalSize,
+                ownAllocatedSize: allocatedSize,
+                deviceIdentifier: deviceIdentifier,
+                inode: inode,
+                hardLinkCount: UInt64(metadata.st_nlink),
+                isHidden: isHidden,
+                isSymbolicLink: isSymbolicLink,
+                isCountedInParentTotals: false,
+                accessibility: .skippedDifferentVolume,
+                issues: [
+                    StorageScanIssue(
+                        path: path,
+                        kind: .differentVolume,
+                        message: "Traversal stopped because this item is on a different mounted filesystem.",
+                        posixErrorCode: nil
+                    )
+                ]
+            )
+        }
+
+        return FlatNode(
+            name: displayName(for: path),
+            path: path,
+            parentPath: parentPath,
+            itemType: regularType,
+            ownLogicalSize: logicalSize,
+            ownAllocatedSize: allocatedSize,
+            deviceIdentifier: deviceIdentifier,
+            inode: inode,
+            hardLinkCount: UInt64(metadata.st_nlink),
+            isHidden: isHidden,
+            isSymbolicLink: isSymbolicLink,
+            isCountedInParentTotals: true,
+            accessibility: .accessible,
+            issues: []
+        )
+    }
+
+    static func immediateChild(from node: FlatNode) -> ImmediateChild {
+        ImmediateChild(
+            name: node.name,
+            absolutePath: node.path,
+            itemType: node.itemType,
+            accessibility: node.accessibility,
+            isHidden: node.isHidden,
+            isSymbolicLink: node.isSymbolicLink
+        )
+    }
+
+    static func deduplicateHardLinks(nodesByPath: inout [String: FlatNode]) {
+        var firstPathByIdentity: [FileIdentity: String] = [:]
+
+        for path in nodesByPath.keys.sorted() {
+            guard var node = nodesByPath[path],
+                  node.itemType == .regularFile,
+                  node.hardLinkCount > 1,
+                  let device = node.deviceIdentifier,
+                  let inode = node.inode else {
+                continue
+            }
+
+            let identity = FileIdentity(device: device, inode: inode)
+            if firstPathByIdentity[identity] == nil {
+                firstPathByIdentity[identity] = path
+            } else {
+                node.isCountedInParentTotals = false
+                nodesByPath[path] = node
+            }
+        }
+    }
+
+    static func deduplicateHardLinksAcrossRoots(flatScans: inout [FlatScan]) {
+        var firstLocationByIdentity: [FileIdentity: (rootIndex: Int, path: String)] = [:]
+
+        for rootIndex in flatScans.indices {
+            for path in flatScans[rootIndex].nodesByPath.keys.sorted() {
+                guard var node = flatScans[rootIndex].nodesByPath[path],
+                      node.itemType == .regularFile,
+                      node.hardLinkCount > 1,
+                      let device = node.deviceIdentifier,
+                      let inode = node.inode else {
+                    continue
+                }
+
+                let identity = FileIdentity(device: device, inode: inode)
+                if firstLocationByIdentity[identity] == nil {
+                    firstLocationByIdentity[identity] = (rootIndex, path)
+                } else {
+                    node.isCountedInParentTotals = false
+                    flatScans[rootIndex].nodesByPath[path] = node
+                }
+            }
+        }
+    }
+
+    static func buildTree(
+        rootPath: String,
+        nodesByPath: [String: FlatNode]
+    ) -> StorageNode {
+        let paths = nodesByPath.keys.sorted {
+            let leftDepth = pathDepth($0)
+            let rightDepth = pathDepth($1)
+            if leftDepth != rightDepth { return leftDepth > rightDepth }
+            return $0 < $1
+        }
+
+        var childrenByParent: [String: [StorageNode]] = [:]
+        var root: StorageNode?
+
+        for path in paths {
+            guard let flatNode = nodesByPath[path] else { continue }
+            let children = (childrenByParent[path] ?? []).sorted { $0.absolutePath < $1.absolutePath }
+
+            var logicalSize = flatNode.isCountedInParentTotals ? flatNode.ownLogicalSize : 0
+            var allocatedSize = flatNode.isCountedInParentTotals ? flatNode.ownAllocatedSize : 0
+            for child in children {
+                logicalSize = saturatedAdd(logicalSize, child.logicalSize)
+                allocatedSize = saturatedAdd(allocatedSize, child.allocatedSize)
+            }
+
+            var accessibility = flatNode.accessibility
+            if accessibility == .accessible,
+               children.contains(where: { $0.accessibility != .accessible }) {
+                accessibility = .partiallyAccessible
+            }
+
+            let node = StorageNode(
+                name: flatNode.name,
+                absolutePath: flatNode.path,
+                logicalSize: logicalSize,
+                allocatedSize: allocatedSize,
+                ownLogicalSize: flatNode.ownLogicalSize,
+                ownAllocatedSize: flatNode.ownAllocatedSize,
+                itemType: flatNode.itemType,
+                children: children,
+                accessibility: accessibility,
+                scanIssues: flatNode.issues.sorted(by: issueSort),
+                isHidden: flatNode.isHidden,
+                isSymbolicLink: flatNode.isSymbolicLink,
+                isCountedInParentTotals: flatNode.isCountedInParentTotals,
+                metadata: StorageAnalysisMetadata()
+            )
+
+            if path == rootPath {
+                root = node
+            } else if let parentPath = flatNode.parentPath {
+                childrenByParent[parentPath, default: []].append(node)
+            }
+        }
+
+        if let root { return root }
+
+        // `readMetadata` always creates a root. This defensive fallback keeps
+        // the result representable if future filtering changes that invariant.
+        return StorageNode(
+            name: displayName(for: rootPath),
+            absolutePath: rootPath,
+            logicalSize: 0,
+            allocatedSize: 0,
+            ownLogicalSize: 0,
+            ownAllocatedSize: 0,
+            itemType: .unknown,
+            children: [],
+            accessibility: .inaccessible,
+            scanIssues: [],
+            isHidden: pathComponentIsHidden(rootPath),
+            isSymbolicLink: false,
+            isCountedInParentTotals: false,
+            metadata: StorageAnalysisMetadata()
+        )
+    }
+
+    static func append(
+        _ issue: StorageScanIssue,
+        to path: String,
+        nodesByPath: inout [String: FlatNode]
+    ) {
+        guard var node = nodesByPath[path] else { return }
+        if !node.issues.contains(issue) {
+            node.issues.append(issue)
+        }
+        if node.accessibility == .accessible {
+            node.accessibility = issue.kind == .permissionDenied ? .inaccessible : .partiallyAccessible
+        }
+        nodesByPath[path] = node
+    }
+
+    static func markCancelled(
+        _ path: String,
+        nodesByPath: inout [String: FlatNode]
+    ) {
+        guard var node = nodesByPath[path] else { return }
+        let issue = StorageScanIssue(
+            path: path,
+            kind: .cancelled,
+            message: "This location was not fully scanned because the operation was cancelled.",
+            posixErrorCode: nil
+        )
+        if !node.issues.contains(issue) {
+            node.issues.append(issue)
+        }
+        node.accessibility = .cancelled
+        nodesByPath[path] = node
+    }
+
+    static func posixIssue(
+        path: String,
+        errorCode: Int32,
+        fallbackKind: StorageScanIssueKind,
+        operation: String
+    ) -> StorageScanIssue {
+        let kind: StorageScanIssueKind
+        if errorCode == EACCES || errorCode == EPERM {
+            kind = .permissionDenied
+        } else {
+            kind = fallbackKind
+        }
+
+        let errorDescription = String(cString: strerror(errorCode))
+        return StorageScanIssue(
+            path: path,
+            kind: kind,
+            message: "\(operation) failed: \(errorDescription)",
+            posixErrorCode: errorCode
+        )
+    }
+
+    static func displayName(for path: String) -> String {
+        if path == "/" { return "/" }
+        return String(path.split(separator: "/", omittingEmptySubsequences: true).last ?? Substring(path))
+    }
+
+    static func pathComponentIsHidden(_ path: String) -> Bool {
+        guard path != "/" else { return false }
+        return displayName(for: path).hasPrefix(".")
+    }
+
+    static func appending(_ component: String, to path: String) -> String {
+        path == "/" ? "/\(component)" : "\(path)/\(component)"
+    }
+
+    static func pathDepth(_ path: String) -> Int {
+        path.split(separator: "/", omittingEmptySubsequences: true).count
+    }
+
+    static func saturatedAdd(_ left: Int64, _ right: Int64) -> Int64 {
+        let (result, overflow) = left.addingReportingOverflow(right)
+        return overflow ? Int64.max : result
+    }
+
+    static func saturatedMultiply(_ value: Int64, by multiplier: Int64) -> Int64 {
+        let (result, overflow) = value.multipliedReportingOverflow(by: multiplier)
+        return overflow ? Int64.max : result
+    }
+
+    static func issueSort(_ left: StorageScanIssue, _ right: StorageScanIssue) -> Bool {
+        if left.path != right.path { return left.path < right.path }
+        if left.kind != right.kind { return left.kind.rawValue < right.kind.rawValue }
+        return left.message < right.message
+    }
+}
+
+private final class ScanCancellationToken: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+}

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/APFSPhysicalReconciliationAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/APFSPhysicalReconciliationAnalyzer.swift
@@ -1,0 +1,475 @@
+import Darwin
+import Foundation
+
+/// Read-only analyzer that physically reconciles APFS container-level storage,
+/// sibling APFS volumes, target Data-volume physical allocation, snapshots,
+/// and filesystem-attributed allocated bytes.
+struct APFSPhysicalReconciliationAnalyzer: Sendable {
+    typealias CommandRunner = @Sendable (APFSCommandRequest) async -> APFSCommandResult
+
+    static let diskutilURL = URL(fileURLWithPath: "/usr/sbin/diskutil")
+    static let defaultDataVolumeURL = URL(fileURLWithPath: "/System/Volumes/Data", isDirectory: true)
+
+    private let dataVolumeURL: URL
+    private let commandRunner: CommandRunner
+
+    init(
+        dataVolumeURL: URL = APFSPhysicalReconciliationAnalyzer.defaultDataVolumeURL,
+        commandRunner: @escaping CommandRunner = {
+            await APFSStorageAnalyzer.runReadOnlyCommand($0)
+        }
+    ) {
+        self.dataVolumeURL = dataVolumeURL.standardizedFileURL
+        self.commandRunner = commandRunner
+    }
+
+    func analyze(
+        reconciliationReport: StorageReconciliationReport
+    ) async -> APFSPhysicalReconciliationReport {
+        guard !Task.isCancelled else {
+            return .empty
+        }
+
+        var issues: [APFSStorageIssue] = []
+        var evidenceSources: [String] = ["VolumeStatisticsProvider", "FileTreeScanner"]
+
+        // 1. Query diskutil apfs list -plist for complete container architecture
+        let apfsListResult = await commandRunner(Self.apfsListRequest())
+        evidenceSources.append("diskutil apfs list -plist")
+
+        var containerEvidence: APFSContainerEvidence?
+        var targetVolumeEvidence: APFSVolumeEvidence?
+
+        if let commandIssue = Self.commandIssue(apfsListResult, source: "diskutil-apfs-list") {
+            issues.append(commandIssue)
+        } else if let parsedContainers = Self.parseAPFSContainers(apfsListResult.stdout) {
+            // Find container containing the Data volume or root
+            let (matchedContainer, matchedVolume) = Self.resolveTargetContainerAndVolume(
+                from: parsedContainers,
+                dataVolumePath: dataVolumeURL.path
+            )
+            containerEvidence = matchedContainer
+            targetVolumeEvidence = matchedVolume
+        } else {
+            issues.append(APFSStorageIssue(
+                kind: .malformedPlist,
+                message: "Disk Utility returned malformed APFS container list.",
+                source: "diskutil-apfs-list"
+            ))
+        }
+
+        // 2. Query diskutil info -plist for the Data volume specifically if missing
+        if targetVolumeEvidence == nil || targetVolumeEvidence?.capacityInUseBytes == nil {
+            let infoResult = await commandRunner(Self.diskInfoRequest(for: dataVolumeURL))
+            evidenceSources.append("diskutil info -plist \(dataVolumeURL.path)")
+
+            if let commandIssue = Self.commandIssue(infoResult, source: "diskutil-info-data") {
+                issues.append(commandIssue)
+            } else if let parsed = APFSStorageAnalyzer.parseDiskInfo(infoResult.stdout) {
+                targetVolumeEvidence = APFSVolumeEvidence(
+                    name: parsed.metadata.name ?? "mac - Data",
+                    mountPoint: parsed.metadata.mountPoint ?? dataVolumeURL.path,
+                    deviceIdentifier: parsed.metadata.volumeIdentifier ?? "disk3s1",
+                    volumeUUID: parsed.metadata.volumeUUID,
+                    volumeGroupUUID: parsed.metadata.volumeGroupIdentifier,
+                    roles: ["Data"],
+                    capacityInUseBytes: parsed.metadata.totalCapacity,
+                    isEncrypted: true,
+                    isSealed: false,
+                    isWritable: true
+                )
+            }
+        }
+
+        // 3. Collect Snapshot Evidence
+        let existingSnapshots = reconciliationReport.analyzerResults.apfsStorage?.snapshots ?? []
+        let snapshotBytes = existingSnapshots.compactMap(\.size).reduce(Int64(0), +)
+        let snapshotEvidence = APFSSnapshotEvidence(
+            snapshotCount: existingSnapshots.count,
+            totalReportedSnapshotBytes: snapshotBytes > 0 ? snapshotBytes : nil,
+            snapshots: existingSnapshots
+        )
+        if !existingSnapshots.isEmpty {
+            evidenceSources.append("diskutil apfs listSnapshots")
+        }
+
+        // 4. Collect System-Managed Storage Evidence
+        let attribution = reconciliationReport.attributionReport
+        let vmVolumeBytes = containerEvidence?.volumes.first { $0.role.lowercased() == "vm" }?.capacityInUseBytes
+        let systemManaged = APFSSystemManagedEvidence(
+            vmFootprintBytes: attribution?.vmFootprintBytes,
+            swapFileBytes: attribution?.attributionItems.first { $0.id == "vm.swap" }?.allocatedBytes,
+            sleepImageBytes: attribution?.sleepImageBytes,
+            vmVolumeBytes: vmVolumeBytes,
+            hasSystemIndexingDatabases: true,
+            explanation: "System-managed virtual memory, sleep image, APFS VM volume, and Spotlight indexing databases."
+        )
+
+        // 5. Collect Protected System Storage Evidence
+        let protectedItems = attribution?.attributionItems.filter { $0.category == .protectedSystemStorage } ?? []
+        let protectedStorage = APFSProtectedStorageEvidence(
+            protectedRegionCount: protectedItems.count,
+            inaccessibleKnownLowerBoundBytes: reconciliationReport.inaccessibleKnownLowerBoundBytes,
+            unreadablePathCount: reconciliationReport.unreadablePathCount,
+            explanation: "macOS System Integrity Protection and TCC protected locations."
+        )
+
+        // 6. Calculate Physical Accounting Metrics
+        let physicalVolumeUsed = reconciliationReport.usedCapacityBytes
+            ?? containerEvidence?.totalCapacityBytes.flatMap { total in
+                containerEvidence?.freeCapacityBytes.map { free in max(0, total - free) }
+            }
+        let dataVolumeInUse = targetVolumeEvidence?.capacityInUseBytes
+        let filesystemAttributed = reconciliationReport.explainedAllocatedBytes
+        let siblingVolumesBytes = containerEvidence?.totalSiblingVolumeBytesOutsideData ?? 0
+
+        let physicalGap: Int64?
+        if let physicalVolumeUsed {
+            physicalGap = max(0, physicalVolumeUsed - filesystemAttributed)
+        } else {
+            physicalGap = nil
+        }
+
+        let dataVolumeInternalGap: Int64?
+        if let dataVolumeInUse {
+            dataVolumeInternalGap = max(0, dataVolumeInUse - filesystemAttributed)
+        } else {
+            dataVolumeInternalGap = nil
+        }
+
+        let purgeable = reconciliationReport.purgeableEstimateBytes
+
+        let containerDiscrepancy: Int64?
+        if let physicalVolumeUsed, let dataVolumeInUse {
+            containerDiscrepancy = max(0, physicalVolumeUsed - (dataVolumeInUse + siblingVolumesBytes))
+        } else {
+            containerDiscrepancy = nil
+        }
+
+        let metrics = APFSPhysicalAccountingMetrics(
+            physicalVolumeUsedBytes: physicalVolumeUsed,
+            dataVolumePhysicalInUseBytes: dataVolumeInUse,
+            filesystemAttributedBytes: filesystemAttributed,
+            containerSiblingVolumesBytes: siblingVolumesBytes,
+            physicalAccountingGapBytes: physicalGap,
+            dataVolumeInternalGapBytes: dataVolumeInternalGap,
+            purgeableEstimateBytes: purgeable,
+            containerAccountingDiscrepancyBytes: containerDiscrepancy
+        )
+
+        // 7. Data Volume Internal Gap Investigation
+        let dataVolumeInternalGapReport = DataVolumeInternalGapAnalyzer().analyze(
+            reconciliationReport: reconciliationReport,
+            dataVolumePhysicalInUse: dataVolumeInUse
+        )
+
+        // 8. Deterministic Status Classification
+        let status = Self.classifyStatus(
+            metrics: metrics,
+            snapshotCount: existingSnapshots.count,
+            purgeableBytes: purgeable ?? 0,
+            protectedCount: protectedItems.count,
+            unreadableCount: reconciliationReport.unreadablePathCount
+        )
+
+        // 9. Human-Readable Interpretation
+        let interpretation = Self.buildInterpretation(
+            metrics: metrics,
+            targetVolume: targetVolumeEvidence,
+            container: containerEvidence,
+            snapshotCount: existingSnapshots.count,
+            purgeableBytes: purgeable
+        )
+
+        var warnings: [String] = []
+        if let discrepancy = containerDiscrepancy, discrepancy > 500_000_000 {
+            warnings.append("APFS container reports \(Self.formatBytes(discrepancy)) in container metadata or unallocated extents.")
+        }
+        if existingSnapshots.count > 0 {
+            warnings.append("APFS snapshots share extents with the active filesystem; reported snapshot sizes are non-additive.")
+        }
+
+        return APFSPhysicalReconciliationReport(
+            status: status,
+            metrics: metrics,
+            targetVolume: targetVolumeEvidence,
+            container: containerEvidence,
+            snapshots: snapshotEvidence,
+            systemManaged: systemManaged,
+            protectedStorage: protectedStorage,
+            dataVolumeInternalGap: dataVolumeInternalGapReport,
+            humanReadableInterpretation: interpretation,
+            warnings: warnings,
+            evidenceSources: evidenceSources.uniqued(),
+            wasCancelled: reconciliationReport.wasCancelled || Task.isCancelled,
+            issues: issues
+        )
+    }
+
+    // MARK: - Status Classification
+
+    static func classifyStatus(
+        metrics: APFSPhysicalAccountingMetrics,
+        snapshotCount: Int,
+        purgeableBytes: Int64,
+        protectedCount: Int,
+        unreadableCount: Int
+    ) -> APFSPhysicalReconciliationStatus {
+        guard let physicalGap = metrics.physicalAccountingGapBytes else {
+            return .insufficientEvidence
+        }
+
+        // Trivial discrepancy tolerance: <= 50 MB
+        if physicalGap <= 50_000_000 {
+            return .fullyReconciled
+        }
+
+        // Mostly reconciled: <= 1 GB, or Data volume internal gap <= 500 MB
+        if physicalGap <= 1_073_741_824 || (metrics.dataVolumeInternalGapBytes ?? Int64.max) <= 500_000_000 {
+            return .mostlyReconciled
+        }
+
+        // APFS non-additive factors (snapshots, purgeable, clones)
+        if snapshotCount > 0 || purgeableBytes > 1_000_000_000 || metrics.containerSiblingVolumesBytes > 0 {
+            return .apfsNonAdditiveFactorsPresent
+        }
+
+        // Protected system storage barriers
+        if protectedCount > 0 || unreadableCount > 0 {
+            return .protectedSystemStoragePresent
+        }
+
+        return .physicalAccountingGapRemaining
+    }
+
+    // MARK: - Interpretation Builder
+
+    static func buildInterpretation(
+        metrics: APFSPhysicalAccountingMetrics,
+        targetVolume: APFSVolumeEvidence?,
+        container: APFSContainerEvidence?,
+        snapshotCount: Int,
+        purgeableBytes: Int64?
+    ) -> String {
+        guard let physicalUsed = metrics.physicalVolumeUsedBytes,
+              let gap = metrics.physicalAccountingGapBytes else {
+            return "Physical APFS container capacity information is currently unavailable."
+        }
+
+        let attributedStr = formatBytes(metrics.filesystemAttributedBytes)
+        let usedStr = formatBytes(physicalUsed)
+        let gapStr = formatBytes(gap)
+
+        var parts: [String] = [
+            "PureMac attributes \(attributedStr) to live filesystem objects, while macOS reports \(usedStr) physical usage across the shared APFS container pool."
+        ]
+
+        if metrics.containerSiblingVolumesBytes > 0 {
+            let siblingStr = formatBytes(metrics.containerSiblingVolumesBytes)
+            parts.append("Sibling APFS volumes in this container (including the sealed System volume, Preboot, Recovery, and VM) physically occupy \(siblingStr).")
+        }
+
+        if let internalGap = metrics.dataVolumeInternalGapBytes, internalGap > 0 {
+            let internalStr = formatBytes(internalGap)
+            parts.append("The remaining \(internalStr) on the Data volume consists of APFS allocation metadata, purgeable capacity, system databases, and protected locations.")
+        }
+
+        parts.append("The physical accounting gap of \(gapStr) is a structural filesystem characteristic and must not be treated as junk or automatically reclaimable.")
+        return parts.joined(separator: " ")
+    }
+
+    private static func formatBytes(_ bytes: Int64?) -> String {
+        guard let bytes else { return "Unknown" }
+        return ByteCountFormatter.string(fromByteCount: max(bytes, 0), countStyle: .file)
+    }
+
+    // MARK: - Requests
+
+    static func apfsListRequest() -> APFSCommandRequest {
+        APFSCommandRequest(
+            executableURL: diskutilURL,
+            arguments: ["apfs", "list", "-plist"]
+        )
+    }
+
+    static func diskInfoRequest(for url: URL) -> APFSCommandRequest {
+        APFSCommandRequest(
+            executableURL: diskutilURL,
+            arguments: ["info", "-plist", url.path]
+        )
+    }
+
+    static func commandIssue(_ result: APFSCommandResult, source: String) -> APFSStorageIssue? {
+        if result.wasCancelled {
+            return APFSStorageIssue(kind: .cancelled, message: "APFS query was cancelled.", source: source)
+        }
+        if result.terminationStatus != 0 {
+            let msg = String(data: result.stderr, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return APFSStorageIssue(
+                kind: .commandFailed,
+                message: msg?.isEmpty == false ? msg! : "Command failed with code \(result.terminationStatus)",
+                source: source
+            )
+        }
+        return nil
+    }
+
+    // MARK: - Plist Parsing
+
+    struct ParsedContainerInfo: Sendable {
+        let containerReference: String
+        let containerUUID: String?
+        let capacityCeiling: Int64?
+        let capacityFree: Int64?
+        let physicalStore: String?
+        let volumes: [ParsedVolumeInfo]
+    }
+
+    struct ParsedVolumeInfo: Sendable {
+        let name: String
+        let deviceIdentifier: String
+        let volumeUUID: String?
+        let roles: [String]
+        let capacityInUse: Int64?
+        let isEncrypted: Bool
+        let isFileVault: Bool
+    }
+
+    static func parseAPFSContainers(_ data: Data) -> [ParsedContainerInfo]? {
+        guard let plist = try? PropertyListSerialization.propertyList(
+            from: data,
+            options: [],
+            format: nil
+        ) as? [String: Any] else {
+            return nil
+        }
+
+        guard let rawContainers = plist["Containers"] as? [[String: Any]] else {
+            return nil
+        }
+
+        return rawContainers.compactMap { dict -> ParsedContainerInfo? in
+            guard let ref = dict["ContainerReference"] as? String else { return nil }
+            let uuid = dict["APFSContainerUUID"] as? String
+            let ceiling = (dict["CapacityCeiling"] as? NSNumber)?.int64Value
+            let free = (dict["CapacityFree"] as? NSNumber)?.int64Value
+
+            var physStore: String?
+            if let stores = dict["PhysicalStores"] as? [[String: Any]], let first = stores.first {
+                physStore = first["DeviceIdentifier"] as? String
+            }
+
+            let rawVolumes = (dict["Volumes"] as? [[String: Any]]) ?? []
+            let volumes = rawVolumes.compactMap { vDict -> ParsedVolumeInfo? in
+                let name = (vDict["Name"] as? String) ?? "Untitled"
+                guard let devID = vDict["DeviceIdentifier"] as? String else { return nil }
+                let vUUID = vDict["APFSVolumeUUID"] as? String
+                let roles = (vDict["Roles"] as? [String]) ?? []
+                let inUse = (vDict["CapacityInUse"] as? NSNumber)?.int64Value
+                let enc = (vDict["Encryption"] as? Bool) ?? false
+                let fv = (vDict["FileVault"] as? Bool) ?? false
+                return ParsedVolumeInfo(
+                    name: name,
+                    deviceIdentifier: devID,
+                    volumeUUID: vUUID,
+                    roles: roles,
+                    capacityInUse: inUse,
+                    isEncrypted: enc,
+                    isFileVault: fv
+                )
+            }
+
+            return ParsedContainerInfo(
+                containerReference: ref,
+                containerUUID: uuid,
+                capacityCeiling: ceiling,
+                capacityFree: free,
+                physicalStore: physStore,
+                volumes: volumes
+            )
+        }
+    }
+
+    static func resolveTargetContainerAndVolume(
+        from containers: [ParsedContainerInfo],
+        dataVolumePath: String
+    ) -> (APFSContainerEvidence?, APFSVolumeEvidence?) {
+        for container in containers {
+            // Find Data volume inside this container
+            if let dataVol = container.volumes.first(where: {
+                $0.roles.contains(where: { $0.caseInsensitiveCompare("Data") == .orderedSame })
+                    || $0.name.localizedCaseInsensitiveContains("Data")
+            }) {
+                let siblingVolumes = container.volumes.map {
+                    APFSSiblingVolumeEvidence(
+                        name: $0.name,
+                        role: $0.roles.joined(separator: ", "),
+                        deviceIdentifier: $0.deviceIdentifier,
+                        capacityInUseBytes: $0.capacityInUse
+                    )
+                }
+
+                let siblingBytesOutsideData = container.volumes
+                    .filter { $0.deviceIdentifier != dataVol.deviceIdentifier }
+                    .compactMap(\.capacityInUse)
+                    .reduce(Int64(0), +)
+
+                let containerEv = APFSContainerEvidence(
+                    containerReference: container.containerReference,
+                    containerUUID: container.containerUUID,
+                    totalCapacityBytes: container.capacityCeiling,
+                    freeCapacityBytes: container.capacityFree,
+                    physicalStoreIdentifier: container.physicalStore,
+                    volumes: siblingVolumes,
+                    totalSiblingVolumeBytesOutsideData: siblingBytesOutsideData
+                )
+
+                let volumeEv = APFSVolumeEvidence(
+                    name: dataVol.name,
+                    mountPoint: dataVolumePath,
+                    deviceIdentifier: dataVol.deviceIdentifier,
+                    volumeUUID: dataVol.volumeUUID,
+                    volumeGroupUUID: nil,
+                    roles: dataVol.roles,
+                    capacityInUseBytes: dataVol.capacityInUse,
+                    isEncrypted: dataVol.isEncrypted,
+                    isSealed: false,
+                    isWritable: true
+                )
+
+                return (containerEv, volumeEv)
+            }
+        }
+
+        // Fallback: pick the largest container
+        if let largest = containers.max(by: { ($0.capacityCeiling ?? 0) < ($1.capacityCeiling ?? 0) }) {
+            let siblingVolumes = largest.volumes.map {
+                APFSSiblingVolumeEvidence(
+                    name: $0.name,
+                    role: $0.roles.joined(separator: ", "),
+                    deviceIdentifier: $0.deviceIdentifier,
+                    capacityInUseBytes: $0.capacityInUse
+                )
+            }
+            let containerEv = APFSContainerEvidence(
+                containerReference: largest.containerReference,
+                containerUUID: largest.containerUUID,
+                totalCapacityBytes: largest.capacityCeiling,
+                freeCapacityBytes: largest.capacityFree,
+                physicalStoreIdentifier: largest.physicalStore,
+                volumes: siblingVolumes,
+                totalSiblingVolumeBytesOutsideData: 0
+            )
+            return (containerEv, nil)
+        }
+
+        return (nil, nil)
+    }
+}
+
+private extension Sequence where Element: Hashable {
+    func uniqued() -> [Element] {
+        var set: Set<Element> = []
+        return filter { set.insert($0).inserted }
+    }
+}

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/APFSStorageAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/APFSStorageAnalyzer.swift
@@ -1,0 +1,782 @@
+import Foundation
+
+/// Read-only volume and snapshot inspection for the configured mount point.
+///
+/// Capacity metadata and snapshots intentionally remain separate from
+/// `StorageNode`: APFS copy-on-write and shared extents make these values
+/// unsuitable for direct addition to filesystem-tree totals.
+struct APFSStorageAnalyzer: Sendable {
+    typealias VolumeStatisticsReader = @Sendable (URL) -> VolumeStatisticsReadResult
+    typealias CommandRunner = @Sendable (APFSCommandRequest) async -> APFSCommandResult
+
+    static let diskutilURL = URL(fileURLWithPath: "/usr/sbin/diskutil")
+    static let tmutilURL = URL(fileURLWithPath: "/usr/bin/tmutil")
+
+    private let mountPointURL: URL
+    private let volumeStatisticsReader: VolumeStatisticsReader
+    private let commandRunner: CommandRunner
+
+    init(
+        mountPointURL: URL = URL(fileURLWithPath: "/", isDirectory: true),
+        volumeStatisticsReader: @escaping VolumeStatisticsReader = {
+            VolumeStatisticsProvider.read(at: $0)
+        },
+        commandRunner: @escaping CommandRunner = {
+            await APFSStorageAnalyzer.runReadOnlyCommand($0)
+        }
+    ) {
+        self.mountPointURL = mountPointURL.standardizedFileURL
+        self.volumeStatisticsReader = volumeStatisticsReader
+        self.commandRunner = commandRunner
+    }
+
+    func analyze() async -> APFSStorageReport {
+        let mountPointURL = mountPointURL
+        let statisticsReader = volumeStatisticsReader
+        let statistics = await Task.detached(priority: .utility) {
+            statisticsReader(mountPointURL)
+        }.value
+        var issues = Self.volumeIssues(statistics.issues)
+        var metadata = DiskInfoMetadata.empty
+
+        guard !Task.isCancelled else {
+            return Self.report(
+                statistics: statistics.statistics,
+                metadata: metadata,
+                snapshots: [],
+                state: .cancelled,
+                wasCancelled: true,
+                issues: issues + [Self.cancelledIssue(source: "volume-statistics")]
+            )
+        }
+
+        let infoResult = await commandRunner(Self.diskInfoRequest(for: mountPointURL))
+        guard !Task.isCancelled, !infoResult.wasCancelled else {
+            return Self.report(
+                statistics: statistics.statistics,
+                metadata: metadata,
+                snapshots: [],
+                state: .cancelled,
+                wasCancelled: true,
+                issues: issues + [Self.cancelledIssue(source: "diskutil-info")]
+            )
+        }
+
+        if let commandIssue = Self.commandIssue(infoResult, source: "diskutil-info") {
+            issues.append(commandIssue)
+        } else if let parsed = Self.parseDiskInfo(infoResult.stdout) {
+            metadata = parsed.metadata
+            if parsed.isPartial {
+                issues.append(.init(
+                    kind: .partialMetadata,
+                    message: "Disk Utility returned incomplete volume metadata.",
+                    source: "diskutil-info"
+                ))
+            }
+        } else {
+            issues.append(.init(
+                kind: .malformedPlist,
+                message: "Disk Utility returned malformed volume information.",
+                source: "diskutil-info"
+            ))
+        }
+
+        let effectiveFilesystemKind = metadata.filesystemKind == .unknown
+            ? Self.classifyFilesystem(statistics.statistics.filesystemDescription)
+            : metadata.filesystemKind
+        if effectiveFilesystemKind == .nonAPFS {
+            return Self.report(
+                statistics: statistics.statistics,
+                metadata: metadata,
+                snapshots: [],
+                state: .nonAPFS,
+                wasCancelled: false,
+                issues: issues
+            )
+        }
+
+        guard !Task.isCancelled else {
+            return Self.report(
+                statistics: statistics.statistics,
+                metadata: metadata,
+                snapshots: [],
+                state: .cancelled,
+                wasCancelled: true,
+                issues: issues + [Self.cancelledIssue(source: "diskutil-snapshots")]
+            )
+        }
+
+        var diskutilSnapshots: [SnapshotCandidate] = []
+        var diskutilSnapshotsSucceeded = false
+        let snapshotResult = await commandRunner(Self.diskSnapshotsRequest(for: mountPointURL))
+        guard !Task.isCancelled, !snapshotResult.wasCancelled else {
+            return Self.report(
+                statistics: statistics.statistics,
+                metadata: metadata,
+                snapshots: [],
+                state: .cancelled,
+                wasCancelled: true,
+                issues: issues + [Self.cancelledIssue(source: "diskutil-snapshots")]
+            )
+        }
+
+        if let commandIssue = Self.commandIssue(snapshotResult, source: "diskutil-snapshots") {
+            issues.append(commandIssue)
+        } else if let parsed = Self.parseDiskutilSnapshots(snapshotResult.stdout) {
+            diskutilSnapshotsSucceeded = true
+            diskutilSnapshots = parsed.snapshots
+            if parsed.isPartial {
+                issues.append(.init(
+                    kind: .partialMetadata,
+                    message: "Some APFS snapshot records were incomplete.",
+                    source: "diskutil-snapshots"
+                ))
+            }
+        } else {
+            issues.append(.init(
+                kind: .malformedPlist,
+                message: "Disk Utility returned a malformed snapshot property list.",
+                source: "diskutil-snapshots"
+            ))
+        }
+
+        guard !Task.isCancelled else {
+            return Self.report(
+                statistics: statistics.statistics,
+                metadata: metadata,
+                snapshots: Self.makeSnapshots(diskutilSnapshots),
+                state: .cancelled,
+                wasCancelled: true,
+                issues: issues + [Self.cancelledIssue(source: "tmutil-snapshots")]
+            )
+        }
+
+        var tmutilSnapshots: [SnapshotCandidate] = []
+        var tmutilSnapshotsSucceeded = false
+        let tmutilResult = await commandRunner(Self.timeMachineSnapshotsRequest(for: mountPointURL))
+        guard !Task.isCancelled, !tmutilResult.wasCancelled else {
+            return Self.report(
+                statistics: statistics.statistics,
+                metadata: metadata,
+                snapshots: Self.makeSnapshots(diskutilSnapshots),
+                state: .cancelled,
+                wasCancelled: true,
+                issues: issues + [Self.cancelledIssue(source: "tmutil-snapshots")]
+            )
+        }
+
+        if let commandIssue = Self.commandIssue(tmutilResult, source: "tmutil-snapshots") {
+            issues.append(commandIssue)
+        } else {
+            tmutilSnapshotsSucceeded = true
+            let parsed = Self.parseTMUtilSnapshots(tmutilResult.stdout)
+            tmutilSnapshots = parsed.snapshots
+            if parsed.isPartial {
+                issues.append(.init(
+                    kind: .malformedOutput,
+                    message: "Time Machine returned unrecognized snapshot output.",
+                    source: "tmutil-snapshots"
+                ))
+            }
+        }
+
+        let snapshots = Self.makeSnapshots(
+            Self.deduplicate(diskutilSnapshots + tmutilSnapshots)
+        )
+        let hasVolumeMetadata = metadata.hasUsefulMetadata
+            || statistics.statistics.totalCapacity != nil
+            || statistics.statistics.availableCapacity != nil
+        let state: APFSAnalysisState
+        if !hasVolumeMetadata && snapshots.isEmpty
+            && !diskutilSnapshotsSucceeded && !tmutilSnapshotsSucceeded {
+            state = .unavailable
+        } else if issues.isEmpty {
+            state = .complete
+        } else {
+            state = .partial
+        }
+
+        return Self.report(
+            statistics: statistics.statistics,
+            metadata: metadata,
+            snapshots: snapshots,
+            state: state,
+            wasCancelled: false,
+            issues: issues
+        )
+    }
+}
+
+// MARK: - Requests and Process Execution
+
+extension APFSStorageAnalyzer {
+    static func diskInfoRequest(for mountPoint: URL) -> APFSCommandRequest {
+        APFSCommandRequest(
+            executableURL: diskutilURL,
+            arguments: ["info", "-plist", mountPoint.path]
+        )
+    }
+
+    static func diskSnapshotsRequest(for mountPoint: URL) -> APFSCommandRequest {
+        APFSCommandRequest(
+            executableURL: diskutilURL,
+            arguments: ["apfs", "listSnapshots", mountPoint.path, "-plist"]
+        )
+    }
+
+    static func timeMachineSnapshotsRequest(for mountPoint: URL) -> APFSCommandRequest {
+        APFSCommandRequest(
+            executableURL: tmutilURL,
+            arguments: ["listlocalsnapshots", mountPoint.path]
+        )
+    }
+
+    static func runReadOnlyCommand(_ request: APFSCommandRequest) async -> APFSCommandResult {
+        let cancellation = APFSProcessCancellationState()
+        let worker = Task.detached(priority: .utility) {
+            let process = Process()
+            process.executableURL = request.executableURL
+            process.arguments = request.arguments
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+            process.standardOutput = stdoutPipe
+            process.standardError = stderrPipe
+
+            guard cancellation.register(process) else {
+                return APFSCommandResult(
+                    terminationStatus: -1,
+                    stdout: Data(),
+                    stderr: Data(),
+                    launchError: nil,
+                    wasCancelled: true
+                )
+            }
+
+            do {
+                try process.run()
+            } catch {
+                return APFSCommandResult(
+                    terminationStatus: -1,
+                    stdout: Data(),
+                    stderr: Data(),
+                    launchError: error.localizedDescription,
+                    wasCancelled: cancellation.isCancelled
+                )
+            }
+
+            cancellation.terminateIfCancelled()
+            let stdoutTask = Task.detached {
+                stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+            }
+            let stderrTask = Task.detached {
+                stderrPipe.fileHandleForReading.readDataToEndOfFile()
+            }
+            process.waitUntilExit()
+            let stdout = await stdoutTask.value
+            let stderr = await stderrTask.value
+            return APFSCommandResult(
+                terminationStatus: process.terminationStatus,
+                stdout: stdout,
+                stderr: stderr,
+                launchError: nil,
+                wasCancelled: cancellation.isCancelled
+            )
+        }
+
+        return await withTaskCancellationHandler {
+            await worker.value
+        } onCancel: {
+            cancellation.cancel()
+        }
+    }
+}
+
+// MARK: - Parsing
+
+extension APFSStorageAnalyzer {
+    struct DiskInfoParseResult: Sendable {
+        let metadata: DiskInfoMetadata
+        let isPartial: Bool
+    }
+
+    struct ParsedSnapshots: Sendable {
+        let snapshots: [SnapshotCandidate]
+        let isPartial: Bool
+    }
+
+    struct DiskInfoMetadata: Sendable {
+        let name: String?
+        let volumeIdentifier: String?
+        let volumeUUID: String?
+        let containerIdentifier: String?
+        let volumeGroupIdentifier: String?
+        let filesystemType: String?
+        let filesystemKind: APFSFilesystemKind
+        let mountPoint: String?
+        let dataVolumeRelationship: APFSDataVolumeRelationship
+        let totalCapacity: Int64?
+        let availableCapacity: Int64?
+
+        static let empty = DiskInfoMetadata(
+            name: nil,
+            volumeIdentifier: nil,
+            volumeUUID: nil,
+            containerIdentifier: nil,
+            volumeGroupIdentifier: nil,
+            filesystemType: nil,
+            filesystemKind: .unknown,
+            mountPoint: nil,
+            dataVolumeRelationship: .unknown,
+            totalCapacity: nil,
+            availableCapacity: nil
+        )
+
+        var hasUsefulMetadata: Bool {
+            name != nil || volumeIdentifier != nil || volumeUUID != nil
+                || filesystemType != nil || mountPoint != nil
+        }
+    }
+
+    struct SnapshotCandidate: Sendable {
+        let name: String?
+        let uuid: String?
+        let creationDate: Date?
+        let size: Int64?
+        let type: APFSSnapshotType
+        let source: APFSSnapshotSource
+    }
+
+    static func parseDiskInfo(_ data: Data) -> DiskInfoParseResult? {
+        guard let plist = propertyListDictionary(data) else { return nil }
+        let filesystemType = string(plist, keys: [
+            "FilesystemType", "FilesystemName", "FilesystemUserVisibleName"
+        ])
+        let filesystemKind = classifyFilesystem(filesystemType)
+        let roles = stringArray(plist["Roles"] ?? plist["APFSVolumeRole"])
+        let groupID = string(plist, keys: ["APFSVolumeGroupID", "VolumeGroupUUID"])
+        let relationship = dataRelationship(
+            filesystemKind: filesystemKind,
+            roles: roles,
+            hasVolumeGroup: groupID != nil
+        )
+        let metadata = DiskInfoMetadata(
+            name: string(plist, keys: ["VolumeName", "MediaName"]),
+            volumeIdentifier: string(plist, keys: ["DeviceIdentifier"]),
+            volumeUUID: string(plist, keys: ["VolumeUUID", "APFSVolumeUUID"]),
+            containerIdentifier: string(plist, keys: [
+                "APFSContainerReference", "ContainerIdentifier"
+            ]),
+            volumeGroupIdentifier: groupID,
+            filesystemType: filesystemType,
+            filesystemKind: filesystemKind,
+            mountPoint: string(plist, keys: ["MountPoint"]),
+            dataVolumeRelationship: relationship,
+            totalCapacity: nonnegativeInteger(plist, keys: ["TotalSize", "VolumeSize"]),
+            availableCapacity: nonnegativeInteger(plist, keys: [
+                "FreeSpace", "VolumeFreeSpace"
+            ])
+        )
+        let isPartial = metadata.filesystemType == nil || metadata.mountPoint == nil
+        return DiskInfoParseResult(metadata: metadata, isPartial: isPartial)
+    }
+
+    static func parseDiskutilSnapshots(_ data: Data) -> ParsedSnapshots? {
+        guard let plist = propertyListDictionary(data) else { return nil }
+        let rawSnapshots = (plist["Snapshots"] as? [[String: Any]])
+            ?? (plist["APFSSnapshots"] as? [[String: Any]])
+            ?? []
+        var snapshots: [SnapshotCandidate] = []
+        var isPartial = false
+
+        for raw in rawSnapshots {
+            let name = string(raw, keys: ["SnapshotName", "Name"])
+            let uuid = string(raw, keys: ["SnapshotUUID", "UUID"])
+            guard name != nil || uuid != nil else {
+                isPartial = true
+                continue
+            }
+            let date = dateValue(raw, keys: [
+                "SnapshotDate", "CreationDate", "Date"
+            ]) ?? name.flatMap(dateFromSnapshotName)
+            let size = nonnegativeInteger(raw, keys: [
+                "DataSize", "SnapshotSize", "Size"
+            ])
+            snapshots.append(SnapshotCandidate(
+                name: name,
+                uuid: uuid,
+                creationDate: date,
+                size: size,
+                type: classifySnapshot(name: name, explicitType: string(
+                    raw,
+                    keys: ["SnapshotType", "Type", "Role"]
+                ), diskutilSource: true),
+                source: .diskutil
+            ))
+        }
+        return ParsedSnapshots(snapshots: snapshots, isPartial: isPartial)
+    }
+
+    static func parseTMUtilSnapshots(_ data: Data) -> ParsedSnapshots {
+        guard let output = String(data: data, encoding: .utf8) else {
+            return ParsedSnapshots(snapshots: [], isPartial: !data.isEmpty)
+        }
+        var snapshots: [SnapshotCandidate] = []
+        var isPartial = false
+        for rawLine in output.components(separatedBy: .newlines) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty else { continue }
+            if line.hasPrefix("Snapshots for ") { continue }
+            guard line.hasPrefix("com.apple.") else {
+                isPartial = true
+                continue
+            }
+            snapshots.append(SnapshotCandidate(
+                name: line,
+                uuid: nil,
+                creationDate: dateFromSnapshotName(line),
+                size: nil,
+                type: classifySnapshot(name: line, explicitType: nil, diskutilSource: false),
+                source: .tmutil
+            ))
+        }
+        return ParsedSnapshots(snapshots: snapshots, isPartial: isPartial)
+    }
+}
+
+// MARK: - Snapshot Deduplication and Report Construction
+
+extension APFSStorageAnalyzer {
+    static func deduplicate(_ candidates: [SnapshotCandidate]) -> [SnapshotCandidate] {
+        var unique: [SnapshotCandidate] = []
+        for candidate in candidates {
+            if let index = unique.firstIndex(where: { sameSnapshot($0, candidate) }) {
+                unique[index] = merge(unique[index], candidate)
+            } else {
+                unique.append(candidate)
+            }
+        }
+        return unique.sorted {
+            if $0.creationDate != $1.creationDate {
+                return ($0.creationDate ?? .distantPast) > ($1.creationDate ?? .distantPast)
+            }
+            return ($0.name ?? $0.uuid ?? "") < ($1.name ?? $1.uuid ?? "")
+        }
+    }
+
+    static func makeSnapshots(_ candidates: [SnapshotCandidate]) -> [APFSSnapshotInformation] {
+        candidates.compactMap { candidate in
+            guard let identifier = candidate.uuid ?? candidate.name else { return nil }
+            return APFSSnapshotInformation(
+                identifier: identifier,
+                name: candidate.name,
+                uuid: candidate.uuid,
+                creationDate: candidate.creationDate,
+                size: candidate.size,
+                sizeKnowledge: candidate.size == nil ? .unavailable : .reportedBySystem,
+                type: candidate.type,
+                source: candidate.source,
+                storageRelationship: candidate.size == nil
+                    ? .sizeUnavailable
+                    : .sharedNonAdditive
+            )
+        }
+    }
+}
+
+private extension APFSStorageAnalyzer {
+    static func report(
+        statistics: VolumeCapacityStatistics,
+        metadata: DiskInfoMetadata,
+        snapshots: [APFSSnapshotInformation],
+        state: APFSAnalysisState,
+        wasCancelled: Bool,
+        issues: [APFSStorageIssue]
+    ) -> APFSStorageReport {
+        let total = statistics.totalCapacity ?? metadata.totalCapacity
+        let available = statistics.availableCapacity ?? metadata.availableCapacity
+        let used: Int64?
+        if let total, let available {
+            used = max(0, total - min(total, available))
+        } else {
+            used = statistics.usedCapacity
+        }
+        let filesystemType = metadata.filesystemType ?? statistics.filesystemDescription
+        let filesystemKind = metadata.filesystemKind == .unknown
+            ? classifyFilesystem(filesystemType)
+            : metadata.filesystemKind
+        let relationship = filesystemKind == .nonAPFS
+            ? APFSDataVolumeRelationship.notApplicable
+            : metadata.dataVolumeRelationship
+        let volume = APFSVolumeInformation(
+            name: metadata.name ?? statistics.volumeName,
+            volumeIdentifier: metadata.volumeIdentifier,
+            volumeUUID: metadata.volumeUUID ?? statistics.volumeIdentifier,
+            containerIdentifier: metadata.containerIdentifier,
+            volumeGroupIdentifier: metadata.volumeGroupIdentifier,
+            filesystemType: filesystemType,
+            filesystemKind: filesystemKind,
+            mountPoint: metadata.mountPoint ?? statistics.mountPoint,
+            dataVolumeRelationship: relationship,
+            capacity: APFSVolumeCapacity(
+                totalCapacity: total,
+                availableCapacity: available,
+                usedCapacity: used,
+                availableCapacityForImportantUsage: statistics.availableCapacityForImportantUsage,
+                availableCapacityForOpportunisticUsage: statistics.availableCapacityForOpportunisticUsage,
+                purgeableEstimate: statistics.purgeableEstimate,
+                purgeableEstimateKnowledge: statistics.purgeableEstimate == nil
+                    ? .unavailable
+                    : .estimated
+            )
+        )
+        return APFSStorageReport(
+            volume: volume,
+            snapshots: snapshots,
+            state: state,
+            accountingRelationship: .volumeMetadataAndSnapshotsAreNonAdditiveToFilesystemTrees,
+            wasCancelled: wasCancelled,
+            issues: uniqueIssues(issues).sorted {
+                ($0.source ?? "", $0.kind.rawValue, $0.message)
+                    < ($1.source ?? "", $1.kind.rawValue, $1.message)
+            }
+        )
+    }
+
+    static func volumeIssues(_ input: [VolumeStatisticsReadIssue]) -> [APFSStorageIssue] {
+        input.map {
+            APFSStorageIssue(
+                kind: .volumeStatisticsUnavailable,
+                message: $0.message,
+                source: "foundation-volume-statistics"
+            )
+        }
+    }
+
+    static func uniqueIssues(_ issues: [APFSStorageIssue]) -> [APFSStorageIssue] {
+        var seen: Set<APFSStorageIssue> = []
+        return issues.filter { seen.insert($0).inserted }
+    }
+
+    static func commandIssue(
+        _ result: APFSCommandResult,
+        source: String
+    ) -> APFSStorageIssue? {
+        if result.launchError != nil {
+            return APFSStorageIssue(
+                kind: .commandUnavailable,
+                message: "The required read-only system inspection command could not be launched.",
+                source: source
+            )
+        }
+        guard result.terminationStatus != 0 else { return nil }
+        let stderr = String(data: result.stderr, encoding: .utf8)?.lowercased() ?? ""
+        let isPermissionFailure = stderr.contains("permission denied")
+            || stderr.contains("not permitted")
+            || stderr.contains("authorization")
+        return APFSStorageIssue(
+            kind: isPermissionFailure ? .permissionDenied : .commandFailed,
+            message: isPermissionFailure
+                ? "The system denied access to this read-only storage metadata."
+                : "A read-only system storage inspection command failed with status \(result.terminationStatus).",
+            source: source
+        )
+    }
+
+    static func cancelledIssue(source: String) -> APFSStorageIssue {
+        APFSStorageIssue(
+            kind: .cancelled,
+            message: "APFS storage inspection was cancelled.",
+            source: source
+        )
+    }
+
+    static func propertyListDictionary(_ data: Data) -> [String: Any]? {
+        guard !data.isEmpty,
+              let value = try? PropertyListSerialization.propertyList(
+                from: data,
+                options: [],
+                format: nil
+              ) else {
+            return nil
+        }
+        return value as? [String: Any]
+    }
+
+    static func string(_ dictionary: [String: Any], keys: [String]) -> String? {
+        for key in keys {
+            if let value = dictionary[key] as? String,
+               !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return value
+            }
+        }
+        return nil
+    }
+
+    static func stringArray(_ value: Any?) -> [String] {
+        if let values = value as? [String] { return values }
+        if let value = value as? String { return [value] }
+        return []
+    }
+
+    static func nonnegativeInteger(
+        _ dictionary: [String: Any],
+        keys: [String]
+    ) -> Int64? {
+        for key in keys {
+            let number: Int64?
+            if let value = dictionary[key] as? NSNumber {
+                number = value.int64Value
+            } else if let value = dictionary[key] as? Int64 {
+                number = value
+            } else if let value = dictionary[key] as? Int {
+                number = Int64(value)
+            } else {
+                number = nil
+            }
+            if let number, number >= 0 { return number }
+        }
+        return nil
+    }
+
+    static func dateValue(_ dictionary: [String: Any], keys: [String]) -> Date? {
+        for key in keys {
+            if let date = dictionary[key] as? Date { return date }
+            if let string = dictionary[key] as? String,
+               let date = parseDateString(string) {
+                return date
+            }
+        }
+        return nil
+    }
+
+    static func parseDateString(_ value: String) -> Date? {
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = iso.date(from: value) { return date }
+        iso.formatOptions = [.withInternetDateTime]
+        return iso.date(from: value)
+    }
+
+    static func dateFromSnapshotName(_ name: String) -> Date? {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+        for component in name.components(separatedBy: ".") {
+            if let date = formatter.date(from: component) { return date }
+        }
+        return nil
+    }
+
+    static func classifyFilesystem(_ value: String?) -> APFSFilesystemKind {
+        guard let normalized = value?.lowercased() else { return .unknown }
+        return normalized.contains("apfs") ? .apfs : .nonAPFS
+    }
+
+    static func dataRelationship(
+        filesystemKind: APFSFilesystemKind,
+        roles: [String],
+        hasVolumeGroup: Bool
+    ) -> APFSDataVolumeRelationship {
+        guard filesystemKind != .nonAPFS else { return .notApplicable }
+        let normalized = roles.map { $0.lowercased() }
+        if normalized.contains(where: { $0 == "data" }) { return .dataVolume }
+        if normalized.contains(where: { $0 == "system" }) { return .systemVolume }
+        if hasVolumeGroup { return .volumeGroupMember }
+        return .unknown
+    }
+
+    static func classifySnapshot(
+        name: String?,
+        explicitType: String?,
+        diskutilSource: Bool
+    ) -> APFSSnapshotType {
+        let evidence = [name, explicitType]
+            .compactMap { $0?.lowercased() }
+            .joined(separator: " ")
+        if evidence.contains("timemachine") || evidence.contains("time machine") {
+            return .timeMachine
+        }
+        if evidence.contains("com.apple.os.update")
+            || evidence.contains("software update")
+            || evidence.contains("system update") {
+            return .operatingSystemUpdate
+        }
+        return diskutilSource ? .otherAPFS : .unknown
+    }
+
+    static func sameSnapshot(_ lhs: SnapshotCandidate, _ rhs: SnapshotCandidate) -> Bool {
+        if let leftUUID = lhs.uuid?.lowercased(),
+           let rightUUID = rhs.uuid?.lowercased(),
+           leftUUID == rightUUID {
+            return true
+        }
+        if let leftName = lhs.name, let rightName = rhs.name, leftName == rightName {
+            return true
+        }
+        if let leftDate = lhs.creationDate, let rightDate = rhs.creationDate,
+           leftDate == rightDate,
+           lhs.type != .unknown, rhs.type != .unknown,
+           lhs.type == rhs.type {
+            return true
+        }
+        return false
+    }
+
+    static func merge(_ lhs: SnapshotCandidate, _ rhs: SnapshotCandidate) -> SnapshotCandidate {
+        let source: APFSSnapshotSource = lhs.source == rhs.source
+            ? lhs.source
+            : .tmutilAndDiskutil
+        let type: APFSSnapshotType
+        if lhs.type == .unknown {
+            type = rhs.type
+        } else if rhs.type == .unknown || lhs.type == rhs.type {
+            type = lhs.type
+        } else {
+            type = lhs.source == .diskutil ? lhs.type : rhs.type
+        }
+        return SnapshotCandidate(
+            name: lhs.name ?? rhs.name,
+            uuid: lhs.uuid ?? rhs.uuid,
+            creationDate: lhs.creationDate ?? rhs.creationDate,
+            size: lhs.size ?? rhs.size,
+            type: type,
+            source: source
+        )
+    }
+}
+
+private final class APFSProcessCancellationState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var process: Process?
+    private var cancelled = false
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+
+    func register(_ process: Process) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !cancelled else { return false }
+        self.process = process
+        return true
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        let running = process?.isRunning == true ? process : nil
+        lock.unlock()
+        running?.terminate()
+    }
+
+    func terminateIfCancelled() {
+        lock.lock()
+        let running = cancelled && process?.isRunning == true ? process : nil
+        lock.unlock()
+        running?.terminate()
+    }
+}

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/ApplicationSupportAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/ApplicationSupportAnalyzer.swift
@@ -1,0 +1,249 @@
+import AppKit
+import Foundation
+
+/// Read-only analysis of the current user's `~/Library/Application Support`.
+///
+/// The analyzer deliberately delegates all filesystem traversal and byte
+/// accounting to `FileTreeScanner`. Its role is limited to Application
+/// Support-specific ordering, conservative application attribution, and
+/// explanatory metadata for a future storage UI.
+struct ApplicationSupportAnalyzer: Sendable {
+    struct ApplicationIdentity: Hashable, Sendable {
+        let bundleIdentifier: String
+        let displayName: String
+    }
+
+    typealias AttributionProvider = @Sendable (String) -> ApplicationIdentity?
+
+    enum MetadataKey {
+        static let directChildCount = "applicationSupport.directChildCount"
+        static let largeAllocatedSizeThreshold = "applicationSupport.largeAllocatedSizeThreshold"
+        static let virtualDiskImageCount = "applicationSupport.virtualDiskImageCount"
+    }
+
+    static let storageCategoryIdentifier = "application-support"
+    static let defaultLargeAllocatedSizeThreshold: Int64 = 1_073_741_824
+
+    static var currentUserApplicationSupportURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+    }
+
+    private static let virtualDiskImageExtensions: Set<String> = [
+        "img", "qcow2", "raw", "sparsebundle", "vmdk",
+    ]
+
+    private let applicationSupportURL: URL
+    private let scanner: FileTreeScanner
+    private let largeAllocatedSizeThreshold: Int64
+    private let attributionProvider: AttributionProvider
+
+    init(
+        applicationSupportURL: URL = ApplicationSupportAnalyzer.currentUserApplicationSupportURL,
+        scanner: FileTreeScanner = FileTreeScanner(),
+        largeAllocatedSizeThreshold: Int64 = ApplicationSupportAnalyzer.defaultLargeAllocatedSizeThreshold
+    ) {
+        self.init(
+            applicationSupportURL: applicationSupportURL,
+            scanner: scanner,
+            largeAllocatedSizeThreshold: largeAllocatedSizeThreshold,
+            attributionProvider: { directoryName in
+                ApplicationSupportAnalyzer.workspaceAttribution(for: directoryName)
+            }
+        )
+    }
+
+    init(
+        applicationSupportURL: URL,
+        scanner: FileTreeScanner = FileTreeScanner(),
+        largeAllocatedSizeThreshold: Int64 = ApplicationSupportAnalyzer.defaultLargeAllocatedSizeThreshold,
+        attributionProvider: @escaping AttributionProvider
+    ) {
+        self.applicationSupportURL = applicationSupportURL
+        self.scanner = scanner
+        self.largeAllocatedSizeThreshold = max(largeAllocatedSizeThreshold, 1)
+        self.attributionProvider = attributionProvider
+    }
+
+    /// Returns the scanner's native result model. Immediate Application
+    /// Support children are ordered by allocated size, while every descendant
+    /// remains available for later drill-down.
+    func analyze() async -> StorageAnalysisResult {
+        let scannedResult = await scanner.scan(root: applicationSupportURL)
+        let threshold = largeAllocatedSizeThreshold
+        let attributionProvider = attributionProvider
+
+        return await Task.detached(priority: .utility) {
+            Self.enrich(
+                scannedResult,
+                largeAllocatedSizeThreshold: threshold,
+                attributionProvider: attributionProvider
+            )
+        }.value
+    }
+}
+
+// MARK: - Result Enrichment
+
+private extension ApplicationSupportAnalyzer {
+    static func enrich(
+        _ result: StorageAnalysisResult,
+        largeAllocatedSizeThreshold: Int64,
+        attributionProvider: AttributionProvider
+    ) -> StorageAnalysisResult {
+        let entries = result.root.children
+            .map {
+                enrichEntry(
+                    $0,
+                    largeAllocatedSizeThreshold: largeAllocatedSizeThreshold,
+                    attributionProvider: attributionProvider
+                )
+            }
+            .sorted(by: allocatedSizeDescending)
+
+        var rootAttributes = result.root.metadata.attributes
+        rootAttributes[MetadataKey.directChildCount] = String(entries.count)
+
+        let rootMetadata = StorageAnalysisMetadata(
+            owningApplicationIdentifier: result.root.metadata.owningApplicationIdentifier,
+            owningApplicationName: result.root.metadata.owningApplicationName,
+            storageCategoryIdentifier: storageCategoryIdentifier,
+            safetyClassificationIdentifier: result.root.metadata.safetyClassificationIdentifier,
+            confidence: result.root.metadata.confidence,
+            isUnusuallyLarge: result.root.metadata.isUnusuallyLarge,
+            explanation: "Storage in the current user's Application Support directory.",
+            attributes: rootAttributes
+        )
+
+        let root = copy(result.root, children: entries, metadata: rootMetadata)
+        return StorageAnalysisResult(
+            root: root,
+            startedAt: result.startedAt,
+            completedAt: result.completedAt,
+            rootDeviceIdentifier: result.rootDeviceIdentifier,
+            wasCancelled: result.wasCancelled,
+            issues: result.issues
+        )
+    }
+
+    static func enrichEntry(
+        _ node: StorageNode,
+        largeAllocatedSizeThreshold: Int64,
+        attributionProvider: AttributionProvider
+    ) -> StorageNode {
+        let attribution = node.itemType == .directory ? attributionProvider(node.name) : nil
+        let virtualDiskImageCount = countVirtualDiskImages(in: node)
+        var attributes = node.metadata.attributes
+        attributes[MetadataKey.directChildCount] = String(node.children.count)
+        attributes[MetadataKey.largeAllocatedSizeThreshold] = String(largeAllocatedSizeThreshold)
+        attributes[MetadataKey.virtualDiskImageCount] = String(virtualDiskImageCount)
+
+        let explanation: String
+        if let attribution {
+            explanation = "Storage used by \(attribution.displayName) in Application Support."
+        } else {
+            explanation = "Application Support storage; the owning application has not been identified."
+        }
+
+        let metadata = StorageAnalysisMetadata(
+            owningApplicationIdentifier: attribution?.bundleIdentifier,
+            owningApplicationName: attribution?.displayName,
+            storageCategoryIdentifier: storageCategoryIdentifier,
+            safetyClassificationIdentifier: node.metadata.safetyClassificationIdentifier,
+            confidence: attribution == nil ? nil : 1,
+            isUnusuallyLarge: node.allocatedSize >= largeAllocatedSizeThreshold,
+            explanation: explanation,
+            attributes: attributes
+        )
+
+        return copy(node, children: node.children, metadata: metadata)
+    }
+
+    static func copy(
+        _ node: StorageNode,
+        children: [StorageNode],
+        metadata: StorageAnalysisMetadata
+    ) -> StorageNode {
+        StorageNode(
+            name: node.name,
+            absolutePath: node.absolutePath,
+            logicalSize: node.logicalSize,
+            allocatedSize: node.allocatedSize,
+            ownLogicalSize: node.ownLogicalSize,
+            ownAllocatedSize: node.ownAllocatedSize,
+            itemType: node.itemType,
+            children: children,
+            accessibility: node.accessibility,
+            scanIssues: node.scanIssues,
+            isHidden: node.isHidden,
+            isSymbolicLink: node.isSymbolicLink,
+            isCountedInParentTotals: node.isCountedInParentTotals,
+            metadata: metadata
+        )
+    }
+
+    static func allocatedSizeDescending(_ left: StorageNode, _ right: StorageNode) -> Bool {
+        if left.allocatedSize != right.allocatedSize {
+            return left.allocatedSize > right.allocatedSize
+        }
+        if left.logicalSize != right.logicalSize {
+            return left.logicalSize > right.logicalSize
+        }
+        return left.absolutePath < right.absolutePath
+    }
+
+    static func countVirtualDiskImages(in root: StorageNode) -> Int {
+        var count = 0
+        var pending = [root]
+        while let node = pending.popLast() {
+            let pathExtension = URL(fileURLWithPath: node.absolutePath).pathExtension.lowercased()
+            if virtualDiskImageExtensions.contains(pathExtension) {
+                count += 1
+            }
+            pending.append(contentsOf: node.children)
+        }
+        return count
+    }
+}
+
+// MARK: - Conservative Application Attribution
+
+private extension ApplicationSupportAnalyzer {
+    /// Only reverse-DNS-style directory names are considered. Launch Services
+    /// must resolve the exact identifier to an installed app, and the bundle
+    /// itself must report the same identifier. Plain vendor names such as
+    /// "Google" or product names such as "Code" remain unattributed unless a
+    /// future provider supplies an explicit, reliable relationship.
+    static func workspaceAttribution(for directoryName: String) -> ApplicationIdentity? {
+        guard isBundleIdentifier(directoryName),
+              let applicationURL = NSWorkspace.shared.urlForApplication(
+                withBundleIdentifier: directoryName
+              ),
+              let bundle = Bundle(url: applicationURL),
+              bundle.bundleIdentifier == directoryName else {
+            return nil
+        }
+
+        let displayName = (bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String)
+            ?? (bundle.object(forInfoDictionaryKey: "CFBundleName") as? String)
+            ?? applicationURL.deletingPathExtension().lastPathComponent
+
+        return ApplicationIdentity(
+            bundleIdentifier: directoryName,
+            displayName: displayName
+        )
+    }
+
+    static func isBundleIdentifier(_ value: String) -> Bool {
+        let components = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard components.count >= 2, components.allSatisfy({ !$0.isEmpty }) else {
+            return false
+        }
+
+        let allowedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-"))
+        return components.allSatisfy { component in
+            component.unicodeScalars.allSatisfy { allowedCharacters.contains($0) }
+        }
+    }
+}

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/ApplicationSupportAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/ApplicationSupportAnalyzer.swift
@@ -36,17 +36,20 @@ struct ApplicationSupportAnalyzer: Sendable {
 
     private let applicationSupportURL: URL
     private let scanner: FileTreeScanner
+    private let cache: StorageAnalysisCache?
     private let largeAllocatedSizeThreshold: Int64
     private let attributionProvider: AttributionProvider
 
     init(
         applicationSupportURL: URL = ApplicationSupportAnalyzer.currentUserApplicationSupportURL,
         scanner: FileTreeScanner = FileTreeScanner(),
+        cache: StorageAnalysisCache? = nil,
         largeAllocatedSizeThreshold: Int64 = ApplicationSupportAnalyzer.defaultLargeAllocatedSizeThreshold
     ) {
         self.init(
             applicationSupportURL: applicationSupportURL,
             scanner: scanner,
+            cache: cache,
             largeAllocatedSizeThreshold: largeAllocatedSizeThreshold,
             attributionProvider: { directoryName in
                 ApplicationSupportAnalyzer.workspaceAttribution(for: directoryName)
@@ -57,11 +60,13 @@ struct ApplicationSupportAnalyzer: Sendable {
     init(
         applicationSupportURL: URL,
         scanner: FileTreeScanner = FileTreeScanner(),
+        cache: StorageAnalysisCache? = nil,
         largeAllocatedSizeThreshold: Int64 = ApplicationSupportAnalyzer.defaultLargeAllocatedSizeThreshold,
         attributionProvider: @escaping AttributionProvider
     ) {
         self.applicationSupportURL = applicationSupportURL
         self.scanner = scanner
+        self.cache = cache
         self.largeAllocatedSizeThreshold = max(largeAllocatedSizeThreshold, 1)
         self.attributionProvider = attributionProvider
     }
@@ -70,7 +75,14 @@ struct ApplicationSupportAnalyzer: Sendable {
     /// Support children are ordered by allocated size, while every descendant
     /// remains available for later drill-down.
     func analyze() async -> StorageAnalysisResult {
-        let scannedResult = await scanner.scan(root: applicationSupportURL)
+        let scannedResult: StorageAnalysisResult
+        if let cached = cache?.get(path: applicationSupportURL.path) {
+            scannedResult = cached
+        } else {
+            let result = await scanner.scan(root: applicationSupportURL)
+            cache?.store(result, isFullSubtree: true)
+            scannedResult = result
+        }
         let threshold = largeAllocatedSizeThreshold
         let attributionProvider = attributionProvider
 

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/ApplicationsStorageAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/ApplicationsStorageAnalyzer.swift
@@ -1,0 +1,203 @@
+import Darwin
+import Foundation
+
+/// Explanatory categories for immediate children of the system-wide
+/// `/Applications` directory. Categories describe storage role only and have
+/// no uninstall, cleanup, or mutation meaning.
+enum ApplicationsStorageCategory: String, Codable, CaseIterable, Sendable {
+    case applicationBundle = "applications.bundle"
+    case utilityFolder = "applications.utilities"
+    case systemComponent = "applications.system"
+    case developerTool = "applications.developer"
+    case other = "applications.other"
+
+    var explanation: String {
+        switch self {
+        case .applicationBundle:
+            return "Installed macOS application bundle (.app)."
+        case .utilityFolder:
+            return "System and administrative utility applications."
+        case .systemComponent:
+            return "System-provided application components and helpers."
+        case .developerTool:
+            return "Developer IDEs, simulators, command line tools, and support apps."
+        case .other:
+            return "Other items located directly within /Applications."
+        }
+    }
+}
+
+/// Read-only storage analyzer for the canonical `/Applications` root on macOS.
+///
+/// `FileTreeScanner` owns filesystem traversal, allocated physical block
+/// accounting (`st_blocks * 512`), logical file size measurement (`st_size`),
+/// hard-link deduplication, volume-boundary protection, and error capture.
+///
+/// This analyzer validates root existence, enriches top-level application
+/// nodes with explanatory category metadata, and sorts children deterministically.
+struct ApplicationsStorageAnalyzer: Sendable {
+    enum MetadataKey {
+        static let directChildCount = "applications.directChildCount"
+        static let largeAllocatedSizeThreshold = "applications.largeAllocatedSizeThreshold"
+        static let storageScope = "applications.storageScope"
+        static let canonicalUserFacingPath = "applications.canonicalUserFacingPath"
+        static let packagesAggregated = "applications.packagesAggregated"
+        static let descendantEntriesMeasured = "applications.descendantEntriesMeasured"
+        static let descendantNodesAvoided = "applications.descendantNodesAvoided"
+    }
+
+    static let storageCategoryIdentifier = "applications"
+    static let defaultLargeAllocatedSizeThreshold: Int64 = 1_073_741_824 // 1 GB
+    static let defaultApplicationsURL = URL(fileURLWithPath: "/Applications", isDirectory: true)
+
+    private let applicationsURL: URL
+    private let scanner: FileTreeScanner
+    private let cache: StorageAnalysisCache?
+    private let largeAllocatedSizeThreshold: Int64
+
+    init(
+        applicationsURL: URL = ApplicationsStorageAnalyzer.defaultApplicationsURL,
+        scanner: FileTreeScanner = FileTreeScanner(configuration: .init(aggregateApplicationPackages: true)),
+        cache: StorageAnalysisCache? = nil,
+        largeAllocatedSizeThreshold: Int64 = ApplicationsStorageAnalyzer.defaultLargeAllocatedSizeThreshold
+    ) {
+        self.applicationsURL = applicationsURL
+        self.scanner = scanner
+        self.cache = cache
+        self.largeAllocatedSizeThreshold = max(largeAllocatedSizeThreshold, 1)
+    }
+
+    func analyze() async -> StorageAnalysisResult {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: applicationsURL.path, isDirectory: &isDirectory) else {
+            var missingMetadata = StorageAnalysisMetadata()
+            missingMetadata.storageCategoryIdentifier = Self.storageCategoryIdentifier
+            missingMetadata.attributes[MetadataKey.canonicalUserFacingPath] = "/Applications"
+
+            let missingNode = StorageNode(
+                name: applicationsURL.lastPathComponent.isEmpty ? "Applications" : applicationsURL.lastPathComponent,
+                absolutePath: applicationsURL.path,
+                logicalSize: 0,
+                allocatedSize: 0,
+                ownLogicalSize: 0,
+                ownAllocatedSize: 0,
+                itemType: .directory,
+                children: [],
+                accessibility: .accessible,
+                scanIssues: [],
+                isHidden: false,
+                isSymbolicLink: false,
+                isCountedInParentTotals: true,
+                metadata: missingMetadata
+            )
+            return StorageAnalysisResult(
+                root: missingNode,
+                startedAt: Date(),
+                completedAt: Date(),
+                rootDeviceIdentifier: nil,
+                wasCancelled: false,
+                issues: []
+            )
+        }
+
+        let scannedResult: StorageAnalysisResult
+        if let cached = cache?.get(path: applicationsURL.path) {
+            scannedResult = cached
+        } else {
+            let result = await scanner.scan(root: applicationsURL, aggregateApplicationPackages: true)
+            cache?.store(result, isFullSubtree: true)
+            scannedResult = result
+        }
+
+        let sortedChildren = scannedResult.root.children
+            .map { enrichChild($0) }
+            .sorted(by: childSortOrder)
+
+        var rootMetadata = scannedResult.root.metadata
+        rootMetadata.storageCategoryIdentifier = Self.storageCategoryIdentifier
+        rootMetadata.attributes[MetadataKey.directChildCount] = String(sortedChildren.count)
+        rootMetadata.attributes[MetadataKey.largeAllocatedSizeThreshold] = String(largeAllocatedSizeThreshold)
+        rootMetadata.attributes[MetadataKey.canonicalUserFacingPath] = "/Applications"
+        let appCount = sortedChildren.filter { $0.name.hasSuffix(".app") }.count
+        if appCount > 0 {
+            rootMetadata.attributes[MetadataKey.packagesAggregated] = String(appCount)
+        }
+        if let measured = scannedResult.root.metadata.attributes["fileTreeScanner.descendantEntriesMeasured"] {
+            rootMetadata.attributes[MetadataKey.descendantEntriesMeasured] = measured
+            rootMetadata.attributes[MetadataKey.descendantNodesAvoided] = measured
+        }
+
+        let enrichedRoot = StorageNode(
+            name: scannedResult.root.name,
+            absolutePath: scannedResult.root.absolutePath,
+            logicalSize: scannedResult.root.logicalSize,
+            allocatedSize: scannedResult.root.allocatedSize,
+            ownLogicalSize: scannedResult.root.ownLogicalSize,
+            ownAllocatedSize: scannedResult.root.ownAllocatedSize,
+            itemType: scannedResult.root.itemType,
+            children: sortedChildren,
+            accessibility: scannedResult.root.accessibility,
+            scanIssues: scannedResult.root.scanIssues,
+            isHidden: scannedResult.root.isHidden,
+            isSymbolicLink: scannedResult.root.isSymbolicLink,
+            isCountedInParentTotals: scannedResult.root.isCountedInParentTotals,
+            metadata: rootMetadata
+        )
+
+        return StorageAnalysisResult(
+            root: enrichedRoot,
+            startedAt: scannedResult.startedAt,
+            completedAt: scannedResult.completedAt,
+            rootDeviceIdentifier: scannedResult.rootDeviceIdentifier,
+            wasCancelled: scannedResult.wasCancelled,
+            issues: scannedResult.issues
+        )
+    }
+
+    private func enrichChild(_ node: StorageNode) -> StorageNode {
+        let category = categoryFor(name: node.name, path: node.absolutePath)
+        var metadata = node.metadata
+        metadata.storageCategoryIdentifier = category.rawValue
+        metadata.explanation = category.explanation
+
+        return StorageNode(
+            name: node.name,
+            absolutePath: node.absolutePath,
+            logicalSize: node.logicalSize,
+            allocatedSize: node.allocatedSize,
+            ownLogicalSize: node.ownLogicalSize,
+            ownAllocatedSize: node.ownAllocatedSize,
+            itemType: node.itemType,
+            children: node.children,
+            accessibility: node.accessibility,
+            scanIssues: node.scanIssues,
+            isHidden: node.isHidden,
+            isSymbolicLink: node.isSymbolicLink,
+            isCountedInParentTotals: node.isCountedInParentTotals,
+            metadata: metadata
+        )
+    }
+
+    private func categoryFor(name: String, path: String) -> ApplicationsStorageCategory {
+        if name.hasSuffix(".app") {
+            if name.contains("Xcode") || name.contains("Developer") {
+                return .developerTool
+            }
+            if name.contains("Safari") || name.contains("System") || name.contains("Finder") {
+                return .systemComponent
+            }
+            return .applicationBundle
+        }
+        if name == "Utilities" {
+            return .utilityFolder
+        }
+        return .other
+    }
+
+    private func childSortOrder(_ lhs: StorageNode, _ rhs: StorageNode) -> Bool {
+        if lhs.allocatedSize != rhs.allocatedSize {
+            return lhs.allocatedSize > rhs.allocatedSize
+        }
+        return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
+    }
+}

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/ContainersAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/ContainersAnalyzer.swift
@@ -36,17 +36,20 @@ struct ContainersAnalyzer: Sendable {
 
     private let containersURL: URL
     private let scanner: FileTreeScanner
+    private let cache: StorageAnalysisCache?
     private let largeAllocatedSizeThreshold: Int64
     private let attributionProvider: AttributionProvider
 
     init(
         containersURL: URL = ContainersAnalyzer.currentUserContainersURL,
         scanner: FileTreeScanner = FileTreeScanner(),
+        cache: StorageAnalysisCache? = nil,
         largeAllocatedSizeThreshold: Int64 = ContainersAnalyzer.defaultLargeAllocatedSizeThreshold
     ) {
         self.init(
             containersURL: containersURL,
             scanner: scanner,
+            cache: cache,
             largeAllocatedSizeThreshold: largeAllocatedSizeThreshold,
             attributionProvider: { bundleIdentifier in
                 ContainersAnalyzer.workspaceAttribution(for: bundleIdentifier)
@@ -57,11 +60,13 @@ struct ContainersAnalyzer: Sendable {
     init(
         containersURL: URL,
         scanner: FileTreeScanner = FileTreeScanner(),
+        cache: StorageAnalysisCache? = nil,
         largeAllocatedSizeThreshold: Int64 = ContainersAnalyzer.defaultLargeAllocatedSizeThreshold,
         attributionProvider: @escaping AttributionProvider
     ) {
         self.containersURL = containersURL
         self.scanner = scanner
+        self.cache = cache
         self.largeAllocatedSizeThreshold = max(largeAllocatedSizeThreshold, 1)
         self.attributionProvider = attributionProvider
     }
@@ -70,7 +75,14 @@ struct ContainersAnalyzer: Sendable {
     /// are ordered by allocated bytes; their complete children remain intact
     /// for future inspection of Data, Library, Documents, and other paths.
     func analyze() async -> StorageAnalysisResult {
-        let scannedResult = await scanner.scan(root: containersURL)
+        let scannedResult: StorageAnalysisResult
+        if let cached = cache?.get(path: containersURL.path) {
+            scannedResult = cached
+        } else {
+            let result = await scanner.scan(root: containersURL)
+            cache?.store(result, isFullSubtree: true)
+            scannedResult = result
+        }
         let threshold = largeAllocatedSizeThreshold
         let attributionProvider = attributionProvider
 

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/ContainersAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/ContainersAnalyzer.swift
@@ -1,0 +1,269 @@
+import AppKit
+import Foundation
+
+/// Read-only analysis of the current user's `~/Library/Containers`.
+///
+/// Filesystem traversal and byte accounting remain the responsibility of
+/// `FileTreeScanner`. This analyzer adds container-specific bundle metadata,
+/// verified application attribution, and largest-first presentation ordering.
+struct ContainersAnalyzer: Sendable {
+    struct ApplicationIdentity: Hashable, Sendable {
+        let bundleIdentifier: String
+        let displayName: String
+    }
+
+    typealias AttributionProvider = @Sendable (String) -> ApplicationIdentity?
+
+    enum MetadataKey {
+        static let directChildCount = "containers.directChildCount"
+        static let largeAllocatedSizeThreshold = "containers.largeAllocatedSizeThreshold"
+        static let virtualDiskImageCount = "containers.virtualDiskImageCount"
+        static let bundleIdentifierSource = "containers.bundleIdentifierSource"
+    }
+
+    static let storageCategoryIdentifier = "containers"
+    static let defaultLargeAllocatedSizeThreshold: Int64 = 1_073_741_824
+
+    static var currentUserContainersURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Containers", isDirectory: true)
+    }
+
+    private static let virtualDiskImageExtensions: Set<String> = [
+        "img", "qcow2", "raw", "sparsebundle", "vmdk",
+    ]
+
+    private let containersURL: URL
+    private let scanner: FileTreeScanner
+    private let largeAllocatedSizeThreshold: Int64
+    private let attributionProvider: AttributionProvider
+
+    init(
+        containersURL: URL = ContainersAnalyzer.currentUserContainersURL,
+        scanner: FileTreeScanner = FileTreeScanner(),
+        largeAllocatedSizeThreshold: Int64 = ContainersAnalyzer.defaultLargeAllocatedSizeThreshold
+    ) {
+        self.init(
+            containersURL: containersURL,
+            scanner: scanner,
+            largeAllocatedSizeThreshold: largeAllocatedSizeThreshold,
+            attributionProvider: { bundleIdentifier in
+                ContainersAnalyzer.workspaceAttribution(for: bundleIdentifier)
+            }
+        )
+    }
+
+    init(
+        containersURL: URL,
+        scanner: FileTreeScanner = FileTreeScanner(),
+        largeAllocatedSizeThreshold: Int64 = ContainersAnalyzer.defaultLargeAllocatedSizeThreshold,
+        attributionProvider: @escaping AttributionProvider
+    ) {
+        self.containersURL = containersURL
+        self.scanner = scanner
+        self.largeAllocatedSizeThreshold = max(largeAllocatedSizeThreshold, 1)
+        self.attributionProvider = attributionProvider
+    }
+
+    /// Returns the scanner's native hierarchical result. Immediate containers
+    /// are ordered by allocated bytes; their complete children remain intact
+    /// for future inspection of Data, Library, Documents, and other paths.
+    func analyze() async -> StorageAnalysisResult {
+        let scannedResult = await scanner.scan(root: containersURL)
+        let threshold = largeAllocatedSizeThreshold
+        let attributionProvider = attributionProvider
+
+        return await Task.detached(priority: .utility) {
+            Self.enrich(
+                scannedResult,
+                largeAllocatedSizeThreshold: threshold,
+                attributionProvider: attributionProvider
+            )
+        }.value
+    }
+}
+
+// MARK: - Result Enrichment
+
+private extension ContainersAnalyzer {
+    static func enrich(
+        _ result: StorageAnalysisResult,
+        largeAllocatedSizeThreshold: Int64,
+        attributionProvider: AttributionProvider
+    ) -> StorageAnalysisResult {
+        let containers = result.root.children
+            .map {
+                enrichContainer(
+                    $0,
+                    largeAllocatedSizeThreshold: largeAllocatedSizeThreshold,
+                    attributionProvider: attributionProvider
+                )
+            }
+            .sorted(by: allocatedSizeDescending)
+
+        var rootAttributes = result.root.metadata.attributes
+        rootAttributes[MetadataKey.directChildCount] = String(containers.count)
+
+        let rootMetadata = StorageAnalysisMetadata(
+            bundleIdentifier: result.root.metadata.bundleIdentifier,
+            owningApplicationIdentifier: result.root.metadata.owningApplicationIdentifier,
+            owningApplicationName: result.root.metadata.owningApplicationName,
+            storageCategoryIdentifier: storageCategoryIdentifier,
+            safetyClassificationIdentifier: result.root.metadata.safetyClassificationIdentifier,
+            confidence: result.root.metadata.confidence,
+            isUnusuallyLarge: result.root.metadata.isUnusuallyLarge,
+            explanation: "Sandboxed application storage in the current user's Containers directory.",
+            attributes: rootAttributes
+        )
+
+        let root = copy(result.root, children: containers, metadata: rootMetadata)
+        return StorageAnalysisResult(
+            root: root,
+            startedAt: result.startedAt,
+            completedAt: result.completedAt,
+            rootDeviceIdentifier: result.rootDeviceIdentifier,
+            wasCancelled: result.wasCancelled,
+            issues: result.issues
+        )
+    }
+
+    static func enrichContainer(
+        _ node: StorageNode,
+        largeAllocatedSizeThreshold: Int64,
+        attributionProvider: AttributionProvider
+    ) -> StorageNode {
+        let bundleIdentifier = bundleIdentifierCandidate(for: node)
+        let proposedAttribution = bundleIdentifier.flatMap(attributionProvider)
+        let attribution: ApplicationIdentity?
+        if proposedAttribution?.bundleIdentifier == bundleIdentifier {
+            attribution = proposedAttribution
+        } else {
+            attribution = nil
+        }
+
+        let virtualDiskImageCount = countVirtualDiskImages(in: node)
+        var attributes = node.metadata.attributes
+        attributes[MetadataKey.directChildCount] = String(node.children.count)
+        attributes[MetadataKey.largeAllocatedSizeThreshold] = String(largeAllocatedSizeThreshold)
+        attributes[MetadataKey.virtualDiskImageCount] = String(virtualDiskImageCount)
+        if bundleIdentifier != nil {
+            attributes[MetadataKey.bundleIdentifierSource] = "directory-name"
+        }
+
+        let explanation: String
+        if let attribution {
+            explanation = "Sandboxed application data used by \(attribution.displayName)."
+        } else if let bundleIdentifier {
+            explanation = "Sandboxed application data for \(bundleIdentifier); the installed application owner is unknown."
+        } else {
+            explanation = "Sandboxed application data; the bundle identifier and owner are unknown."
+        }
+
+        let metadata = StorageAnalysisMetadata(
+            bundleIdentifier: bundleIdentifier,
+            owningApplicationIdentifier: attribution?.bundleIdentifier,
+            owningApplicationName: attribution?.displayName,
+            storageCategoryIdentifier: storageCategoryIdentifier,
+            safetyClassificationIdentifier: node.metadata.safetyClassificationIdentifier,
+            confidence: attribution == nil ? nil : 1,
+            isUnusuallyLarge: node.allocatedSize >= largeAllocatedSizeThreshold,
+            explanation: explanation,
+            attributes: attributes
+        )
+
+        return copy(node, children: node.children, metadata: metadata)
+    }
+
+    static func bundleIdentifierCandidate(for node: StorageNode) -> String? {
+        guard node.itemType == .directory || node.itemType == .volumeBoundary,
+              isBundleIdentifier(node.name) else {
+            return nil
+        }
+        return node.name
+    }
+
+    static func copy(
+        _ node: StorageNode,
+        children: [StorageNode],
+        metadata: StorageAnalysisMetadata
+    ) -> StorageNode {
+        StorageNode(
+            name: node.name,
+            absolutePath: node.absolutePath,
+            logicalSize: node.logicalSize,
+            allocatedSize: node.allocatedSize,
+            ownLogicalSize: node.ownLogicalSize,
+            ownAllocatedSize: node.ownAllocatedSize,
+            itemType: node.itemType,
+            children: children,
+            accessibility: node.accessibility,
+            scanIssues: node.scanIssues,
+            isHidden: node.isHidden,
+            isSymbolicLink: node.isSymbolicLink,
+            isCountedInParentTotals: node.isCountedInParentTotals,
+            metadata: metadata
+        )
+    }
+
+    static func allocatedSizeDescending(_ left: StorageNode, _ right: StorageNode) -> Bool {
+        if left.allocatedSize != right.allocatedSize {
+            return left.allocatedSize > right.allocatedSize
+        }
+        if left.logicalSize != right.logicalSize {
+            return left.logicalSize > right.logicalSize
+        }
+        return left.absolutePath < right.absolutePath
+    }
+
+    static func countVirtualDiskImages(in root: StorageNode) -> Int {
+        var count = 0
+        var pending = [root]
+        while let node = pending.popLast() {
+            let pathExtension = URL(fileURLWithPath: node.absolutePath).pathExtension.lowercased()
+            if virtualDiskImageExtensions.contains(pathExtension) {
+                count += 1
+            }
+            pending.append(contentsOf: node.children)
+        }
+        return count
+    }
+}
+
+// MARK: - Conservative Bundle Attribution
+
+private extension ContainersAnalyzer {
+    /// Launch Services must resolve the exact container directory identifier,
+    /// and the resulting app bundle must report that same identifier. A valid
+    /// directory name alone is retained as a candidate but never proves owner.
+    static func workspaceAttribution(for bundleIdentifier: String) -> ApplicationIdentity? {
+        guard let applicationURL = NSWorkspace.shared.urlForApplication(
+                withBundleIdentifier: bundleIdentifier
+              ),
+              let bundle = Bundle(url: applicationURL),
+              bundle.bundleIdentifier == bundleIdentifier else {
+            return nil
+        }
+
+        let displayName = (bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String)
+            ?? (bundle.object(forInfoDictionaryKey: "CFBundleName") as? String)
+            ?? applicationURL.deletingPathExtension().lastPathComponent
+
+        return ApplicationIdentity(
+            bundleIdentifier: bundleIdentifier,
+            displayName: displayName
+        )
+    }
+
+    static func isBundleIdentifier(_ value: String) -> Bool {
+        let components = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard components.count >= 2, components.allSatisfy({ !$0.isEmpty }) else {
+            return false
+        }
+
+        let allowedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-"))
+        return components.allSatisfy { component in
+            component.unicodeScalars.allSatisfy { allowedCharacters.contains($0) }
+        }
+    }
+}

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/CoverageExpansionAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/CoverageExpansionAnalyzer.swift
@@ -1,0 +1,408 @@
+import Darwin
+import Foundation
+
+/// Discovers and measures meaningful filesystem regions currently omitted from
+/// PureMac's specialized additive storage accounting without double-counting.
+///
+/// Stage A: Shallow Discovery enumerates immediate children cheaply and checks
+/// ownership, symlink status, device boundaries, and system-protected classification.
+/// Stage B: Targeted Recursive Measurement uses FileTreeScanner with bounded
+/// concurrency to safely measure only eligible, unowned candidates.
+struct CoverageExpansionAnalyzer: Sendable {
+    private let homeDirectoryURL: URL
+    private let dataVolumeURL: URL
+    private let scanner: FileTreeScanner
+    private let maxConcurrentDirectoryReads: Int
+    private let extraExcludedCanonicalPaths: [String]
+
+    private static let specializedLibraryNames: Set<String> = [
+        "Application Support",
+        "Containers",
+        "Group Containers",
+    ]
+
+    private static let standardDataVolumeRootsToExclude: Set<String> = [
+        "/Users",
+        "/Library",
+        "/private",
+        "/Applications",
+        "/opt",
+        "/usr",
+        "/usr/local",
+        "/System",
+        "/Volumes",
+        "/dev",
+        "/net",
+        "/home",
+        "/bin",
+        "/sbin",
+        "/etc",
+        "/var",
+        "/tmp",
+        "/.DocumentRevisions-V100",
+        "/.Spotlight-V100",
+        "/.fseventsd",
+        "/.Trashes",
+        "/.PKInstallSandboxManager",
+        "/.PKInstallSandboxManager-SystemSoftware",
+    ]
+
+    init(
+        homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+        dataVolumeURL: URL = URL(fileURLWithPath: "/System/Volumes/Data"),
+        scanner: FileTreeScanner = FileTreeScanner(),
+        maxConcurrentDirectoryReads: Int = 2,
+        extraExcludedCanonicalPaths: [String] = []
+    ) {
+        self.homeDirectoryURL = homeDirectoryURL.standardizedFileURL
+        self.dataVolumeURL = dataVolumeURL.standardizedFileURL
+        self.scanner = scanner
+        self.maxConcurrentDirectoryReads = max(1, min(maxConcurrentDirectoryReads, 4))
+        self.extraExcludedCanonicalPaths = extraExcludedCanonicalPaths
+    }
+
+    func analyze() async -> StorageCoverageExpansionReport {
+        guard !Task.isCancelled else {
+            return .empty
+        }
+
+        // STAGE A: Shallow Discovery
+        var discoveredCandidates: [StorageCoverageCandidate] = []
+        var shallowIssues: [StorageScanIssue] = []
+
+        let homeDevice = rootDeviceIdentifier(for: homeDirectoryURL.path)
+        let dataVolumeDevice = rootDeviceIdentifier(for: dataVolumeURL.path)
+
+        // 1. Discover ~/Library immediate children outside Application Support, Containers, Group Containers
+        let libraryURL = homeDirectoryURL.appendingPathComponent("Library", isDirectory: true)
+        let libraryCandidates = discoverChildren(
+            in: libraryURL.path,
+            scope: .userLibrary,
+            expectedDevice: homeDevice,
+            nameFilter: { !Self.specializedLibraryNames.contains($0) },
+            issues: &shallowIssues
+        )
+        discoveredCandidates.append(contentsOf: libraryCandidates)
+
+        // 2. Discover immediate hidden home entries (~/.cache, ~/.npm, etc.)
+        let hiddenHomeCandidates = discoverChildren(
+            in: homeDirectoryURL.path,
+            scope: .hiddenHome,
+            expectedDevice: homeDevice,
+            nameFilter: { name in
+                (name.hasPrefix(".") && name != "." && name != "..") || name == "Library"
+            },
+            issues: &shallowIssues
+        ).filter { candidate in
+            // Exclude ~/Library itself here as its children are discovered independently above
+            let norm = StoragePathNormalizer.normalize(candidate.originalPath)
+            let libraryNorm = StoragePathNormalizer.normalize(libraryURL.path)
+            return norm != libraryNorm
+        }
+        discoveredCandidates.append(contentsOf: hiddenHomeCandidates)
+
+        // 3. Discover top-level Data-volume roots not already owned
+        if FileManager.default.fileExists(atPath: dataVolumeURL.path) {
+            let dataVolumeCandidates = discoverChildren(
+                in: dataVolumeURL.path,
+                scope: .dataVolumeRoot,
+                expectedDevice: dataVolumeDevice,
+                nameFilter: { name in
+                    let childPath = self.dataVolumeURL.appendingPathComponent(name).path
+                    let normalized = StoragePathNormalizer.normalize(childPath)
+                    return !Self.standardDataVolumeRootsToExclude.contains(normalized)
+                        && !Self.standardDataVolumeRootsToExclude.contains(childPath)
+                },
+                issues: &shallowIssues
+            )
+            discoveredCandidates.append(contentsOf: dataVolumeCandidates)
+        }
+
+        if Task.isCancelled {
+            return StorageCoverageExpansionReport(
+                totalNewlyMeasuredBytes: 0,
+                measuredCandidateCount: 0,
+                excludedOverlapCount: 0,
+                inaccessibleCandidateCount: 0,
+                differentVolumeBoundaryCount: 0,
+                failedCandidateCount: 0,
+                candidates: discoveredCandidates.sorted { $0.normalizedPath < $1.normalizedPath },
+                largestDiscoveredRegions: [],
+                treeResults: [],
+                wasCancelled: true,
+                issues: shallowIssues
+            )
+        }
+
+        // STAGE B: Targeted Recursive Measurement of eligible candidates
+        let eligibleIndices = discoveredCandidates.indices.filter {
+            discoveredCandidates[$0].status == .eligible
+        }
+
+        var treeResults: [StorageAnalysisResult] = []
+        var finalCandidates = discoveredCandidates
+
+        await withTaskGroup(of: (Int, StorageAnalysisResult?).self) { group in
+            var iterator = eligibleIndices.makeIterator()
+            let initialBatch = min(maxConcurrentDirectoryReads, eligibleIndices.count)
+
+            for _ in 0..<initialBatch {
+                if let index = iterator.next() {
+                    let path = finalCandidates[index].originalPath
+                    group.addTask {
+                        let result = await scanner.scan(root: URL(fileURLWithPath: path))
+                        return (index, result)
+                    }
+                }
+            }
+
+            while let (index, result) = await group.next() {
+                if Task.isCancelled {
+                    finalCandidates[index] = updateCandidateStatus(finalCandidates[index], status: .cancelled)
+                } else if let result {
+                    if result.wasCancelled {
+                        finalCandidates[index] = updateCandidateStatus(finalCandidates[index], status: .cancelled)
+                    } else {
+                        finalCandidates[index] = StorageCoverageCandidate(
+                            originalPath: finalCandidates[index].originalPath,
+                            normalizedPath: finalCandidates[index].normalizedPath,
+                            name: finalCandidates[index].name,
+                            scope: finalCandidates[index].scope,
+                            status: .measured,
+                            allocatedBytes: max(result.root.allocatedSize, 0),
+                            logicalBytes: max(result.root.logicalSize, 0),
+                            issue: result.issues.first,
+                            exclusionReason: nil,
+                            contributesToExplainedBytes: true
+                        )
+                        treeResults.append(result)
+                    }
+                } else {
+                    finalCandidates[index] = updateCandidateStatus(finalCandidates[index], status: .failed)
+                }
+
+                if !Task.isCancelled, let nextIndex = iterator.next() {
+                    let path = finalCandidates[nextIndex].originalPath
+                    group.addTask {
+                        let result = await scanner.scan(root: URL(fileURLWithPath: path))
+                        return (nextIndex, result)
+                    }
+                }
+            }
+        }
+
+        finalCandidates.sort { $0.normalizedPath < $1.normalizedPath }
+
+        let measuredCandidates = finalCandidates.filter { $0.status == .measured }
+        let totalNewlyMeasuredBytes = measuredCandidates.reduce(Int64(0)) {
+            $0 + ($1.allocatedBytes ?? 0)
+        }
+
+        let largestRegions = measuredCandidates
+            .sorted { ($0.allocatedBytes ?? 0) > ($1.allocatedBytes ?? 0) }
+
+        return StorageCoverageExpansionReport(
+            totalNewlyMeasuredBytes: totalNewlyMeasuredBytes,
+            measuredCandidateCount: measuredCandidates.count,
+            excludedOverlapCount: finalCandidates.filter { $0.status == .excludedAlreadyAccounted || $0.status == .excludedNested }.count,
+            inaccessibleCandidateCount: finalCandidates.filter { $0.status == .inaccessible || $0.status == .excludedProtectedSystem }.count,
+            differentVolumeBoundaryCount: finalCandidates.filter { $0.status == .excludedDifferentVolume }.count,
+            failedCandidateCount: finalCandidates.filter { $0.status == .failed }.count,
+            candidates: finalCandidates,
+            largestDiscoveredRegions: largestRegions,
+            treeResults: treeResults,
+            wasCancelled: Task.isCancelled,
+            issues: shallowIssues + treeResults.flatMap(\.issues)
+        )
+    }
+
+    // MARK: - Shallow Discovery Helpers
+
+    private func discoverChildren(
+        in parentPath: String,
+        scope: StorageCoverageCandidateScope,
+        expectedDevice: dev_t?,
+        nameFilter: (String) -> Bool,
+        issues: inout [StorageScanIssue]
+    ) -> [StorageCoverageCandidate] {
+        guard let directory = opendir(parentPath) else {
+            let errorCode = Darwin.errno
+            if errorCode != 0 && errorCode != ENOENT {
+                issues.append(StorageScanIssue(
+                    path: parentPath,
+                    kind: errorCode == EACCES || errorCode == EPERM ? .permissionDenied : .unreadable,
+                    message: "Failed to open directory: \(parentPath)",
+                    posixErrorCode: errorCode
+                ))
+            }
+            return []
+        }
+        defer { closedir(directory) }
+
+        var candidates: [StorageCoverageCandidate] = []
+
+        while true {
+            Darwin.errno = 0
+            guard let entry = readdir(directory) else {
+                let errorCode = Darwin.errno
+                if errorCode != 0 {
+                    issues.append(StorageScanIssue(
+                        path: parentPath,
+                        kind: errorCode == EACCES || errorCode == EPERM ? .permissionDenied : .unreadable,
+                        message: "Failed reading directory entry in \(parentPath)",
+                        posixErrorCode: errorCode
+                    ))
+                }
+                break
+            }
+
+            var nameBuffer = entry.pointee.d_name
+            let capacity = MemoryLayout.size(ofValue: nameBuffer)
+            let name = withUnsafePointer(to: &nameBuffer) { pointer in
+                pointer.withMemoryRebound(to: CChar.self, capacity: capacity) {
+                    String(cString: $0)
+                }
+            }
+            guard name != ".", name != ".." else { continue }
+            guard nameFilter(name) else { continue }
+
+            let childPath = parentPath == "/" ? "/\(name)" : "\(parentPath)/\(name)"
+            let normalized = StoragePathNormalizer.normalize(childPath)
+
+            var statInfo = stat()
+            guard lstat(childPath, &statInfo) == 0 else {
+                let errorCode = Darwin.errno
+                let isPerm = errorCode == EACCES || errorCode == EPERM
+                let issue = StorageScanIssue(
+                    path: childPath,
+                    kind: isPerm ? .permissionDenied : .metadataUnavailable,
+                    message: "Cannot inspect metadata for \(childPath)",
+                    posixErrorCode: errorCode
+                )
+                issues.append(issue)
+                candidates.append(StorageCoverageCandidate(
+                    originalPath: childPath,
+                    normalizedPath: normalized,
+                    name: name,
+                    scope: scope,
+                    status: isPerm ? .inaccessible : .failed,
+                    allocatedBytes: nil,
+                    logicalBytes: nil,
+                    issue: issue,
+                    exclusionReason: isPerm ? "Permission denied." : "Metadata unavailable.",
+                    contributesToExplainedBytes: false
+                ))
+                continue
+            }
+
+            let mode = statInfo.st_mode
+            let isSymlink = (mode & S_IFMT) == S_IFLNK
+
+            if isSymlink {
+                candidates.append(StorageCoverageCandidate(
+                    originalPath: childPath,
+                    normalizedPath: normalized,
+                    name: name,
+                    scope: scope,
+                    status: .excludedSymlink,
+                    allocatedBytes: nil,
+                    logicalBytes: nil,
+                    issue: nil,
+                    exclusionReason: "Symbolic links are not followed.",
+                    contributesToExplainedBytes: false
+                ))
+                continue
+            }
+
+            if let expectedDevice, statInfo.st_dev != expectedDevice {
+                candidates.append(StorageCoverageCandidate(
+                    originalPath: childPath,
+                    normalizedPath: normalized,
+                    name: name,
+                    scope: scope,
+                    status: .excludedDifferentVolume,
+                    allocatedBytes: nil,
+                    logicalBytes: nil,
+                    issue: nil,
+                    exclusionReason: "Located on a different filesystem volume boundary.",
+                    contributesToExplainedBytes: false
+                ))
+                continue
+            }
+
+            if StoragePathNormalizer.isSystemProtectedLocation(normalized) {
+                candidates.append(StorageCoverageCandidate(
+                    originalPath: childPath,
+                    normalizedPath: normalized,
+                    name: name,
+                    scope: scope,
+                    status: .excludedProtectedSystem,
+                    allocatedBytes: nil,
+                    logicalBytes: nil,
+                    issue: nil,
+                    exclusionReason: "Protected system state; not traversed.",
+                    contributesToExplainedBytes: false
+                ))
+                continue
+            }
+
+            let isAlreadyAccounted = extraExcludedCanonicalPaths.contains { excluded in
+                StoragePathNormalizer.pathsOverlap(excluded, normalized)
+            }
+            if isAlreadyAccounted {
+                candidates.append(StorageCoverageCandidate(
+                    originalPath: childPath,
+                    normalizedPath: normalized,
+                    name: name,
+                    scope: scope,
+                    status: .excludedAlreadyAccounted,
+                    allocatedBytes: nil,
+                    logicalBytes: nil,
+                    issue: nil,
+                    exclusionReason: "Already accounted by specialized canonical root.",
+                    contributesToExplainedBytes: false
+                ))
+                continue
+            }
+
+            candidates.append(StorageCoverageCandidate(
+                originalPath: childPath,
+                normalizedPath: normalized,
+                name: name,
+                scope: scope,
+                status: .eligible,
+                allocatedBytes: nil,
+                logicalBytes: nil,
+                issue: nil,
+                exclusionReason: nil,
+                contributesToExplainedBytes: false
+            ))
+        }
+
+        return candidates
+    }
+
+    private func rootDeviceIdentifier(for path: String) -> dev_t? {
+        var statInfo = stat()
+        guard stat(path, &statInfo) == 0 else { return nil }
+        return statInfo.st_dev
+    }
+
+    private func updateCandidateStatus(
+        _ candidate: StorageCoverageCandidate,
+        status: StorageCoverageCandidateStatus
+    ) -> StorageCoverageCandidate {
+        StorageCoverageCandidate(
+            originalPath: candidate.originalPath,
+            normalizedPath: candidate.normalizedPath,
+            name: candidate.name,
+            scope: candidate.scope,
+            status: status,
+            allocatedBytes: candidate.allocatedBytes,
+            logicalBytes: candidate.logicalBytes,
+            issue: candidate.issue,
+            exclusionReason: candidate.exclusionReason,
+            contributesToExplainedBytes: candidate.contributesToExplainedBytes
+        )
+    }
+}

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/CoverageExpansionAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/CoverageExpansionAnalyzer.swift
@@ -12,6 +12,7 @@ struct CoverageExpansionAnalyzer: Sendable {
     private let homeDirectoryURL: URL
     private let dataVolumeURL: URL
     private let scanner: FileTreeScanner
+    private let cache: StorageAnalysisCache?
     private let maxConcurrentDirectoryReads: Int
     private let extraExcludedCanonicalPaths: [String]
 
@@ -51,13 +52,15 @@ struct CoverageExpansionAnalyzer: Sendable {
         homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
         dataVolumeURL: URL = URL(fileURLWithPath: "/System/Volumes/Data"),
         scanner: FileTreeScanner = FileTreeScanner(),
-        maxConcurrentDirectoryReads: Int = 2,
+        cache: StorageAnalysisCache? = nil,
+        maxConcurrentDirectoryReads: Int = 4,
         extraExcludedCanonicalPaths: [String] = []
     ) {
         self.homeDirectoryURL = homeDirectoryURL.standardizedFileURL
         self.dataVolumeURL = dataVolumeURL.standardizedFileURL
         self.scanner = scanner
-        self.maxConcurrentDirectoryReads = max(1, min(maxConcurrentDirectoryReads, 4))
+        self.cache = cache
+        self.maxConcurrentDirectoryReads = max(1, min(maxConcurrentDirectoryReads, 8))
         self.extraExcludedCanonicalPaths = extraExcludedCanonicalPaths
     }
 
@@ -142,6 +145,9 @@ struct CoverageExpansionAnalyzer: Sendable {
         var treeResults: [StorageAnalysisResult] = []
         var finalCandidates = discoveredCandidates
 
+        let scannerRef = scanner
+        let cacheRef = cache
+
         await withTaskGroup(of: (Int, StorageAnalysisResult?).self) { group in
             var iterator = eligibleIndices.makeIterator()
             let initialBatch = min(maxConcurrentDirectoryReads, eligibleIndices.count)
@@ -150,7 +156,11 @@ struct CoverageExpansionAnalyzer: Sendable {
                 if let index = iterator.next() {
                     let path = finalCandidates[index].originalPath
                     group.addTask {
-                        let result = await scanner.scan(root: URL(fileURLWithPath: path))
+                        if let cached = cacheRef?.get(path: path) {
+                            return (index, cached)
+                        }
+                        let result = await scannerRef.scan(root: URL(fileURLWithPath: path))
+                        cacheRef?.store(result, isFullSubtree: true)
                         return (index, result)
                     }
                 }
@@ -163,17 +173,35 @@ struct CoverageExpansionAnalyzer: Sendable {
                     if result.wasCancelled {
                         finalCandidates[index] = updateCandidateStatus(finalCandidates[index], status: .cancelled)
                     } else {
+                        let hasIssues = !result.issues.isEmpty
+                        let allocated = max(result.root.allocatedSize, 0)
+                        let logical = max(result.root.logicalSize, 0)
+
+                        let status: StorageCoverageCandidateStatus
+                        let contributes: Bool
+
+                        if !hasIssues {
+                            status = .measured
+                            contributes = true
+                        } else if allocated > 0 {
+                            status = .partiallyMeasured
+                            contributes = true
+                        } else {
+                            status = .inaccessible
+                            contributes = false
+                        }
+
                         finalCandidates[index] = StorageCoverageCandidate(
                             originalPath: finalCandidates[index].originalPath,
                             normalizedPath: finalCandidates[index].normalizedPath,
                             name: finalCandidates[index].name,
                             scope: finalCandidates[index].scope,
-                            status: .measured,
-                            allocatedBytes: max(result.root.allocatedSize, 0),
-                            logicalBytes: max(result.root.logicalSize, 0),
+                            status: status,
+                            allocatedBytes: allocated,
+                            logicalBytes: logical,
                             issue: result.issues.first,
-                            exclusionReason: nil,
-                            contributesToExplainedBytes: true
+                            exclusionReason: hasIssues ? "Partial scan; access restricted for some items." : nil,
+                            contributesToExplainedBytes: contributes
                         )
                         treeResults.append(result)
                     }
@@ -193,7 +221,7 @@ struct CoverageExpansionAnalyzer: Sendable {
 
         finalCandidates.sort { $0.normalizedPath < $1.normalizedPath }
 
-        let measuredCandidates = finalCandidates.filter { $0.status == .measured }
+        let measuredCandidates = finalCandidates.filter { $0.status.isMeasuredOrPartial && $0.contributesToExplainedBytes }
         let totalNewlyMeasuredBytes = measuredCandidates.reduce(Int64(0)) {
             $0 + ($1.allocatedBytes ?? 0)
         }
@@ -204,8 +232,17 @@ struct CoverageExpansionAnalyzer: Sendable {
         return StorageCoverageExpansionReport(
             totalNewlyMeasuredBytes: totalNewlyMeasuredBytes,
             measuredCandidateCount: measuredCandidates.count,
-            excludedOverlapCount: finalCandidates.filter { $0.status == .excludedAlreadyAccounted || $0.status == .excludedNested }.count,
-            inaccessibleCandidateCount: finalCandidates.filter { $0.status == .inaccessible || $0.status == .excludedProtectedSystem }.count,
+            excludedOverlapCount: finalCandidates.filter {
+                $0.status == .excludedAlreadyAccounted
+                    || $0.status == .excludedNested
+                    || $0.status == .skippedAlreadyOwned
+                    || $0.status == .skippedUnsafeOverlap
+            }.count,
+            inaccessibleCandidateCount: finalCandidates.filter {
+                $0.status == .inaccessible
+                    || $0.status == .excludedProtectedSystem
+                    || $0.status == .partiallyMeasured
+            }.count,
             differentVolumeBoundaryCount: finalCandidates.filter { $0.status == .excludedDifferentVolume }.count,
             failedCandidateCount: finalCandidates.filter { $0.status == .failed }.count,
             candidates: finalCandidates,

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/DataVolumeHiddenStorageAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/DataVolumeHiddenStorageAnalyzer.swift
@@ -1,0 +1,322 @@
+import Darwin
+import Foundation
+
+/// Informational categories for hidden entries located directly on the
+/// writable macOS Data volume. These values describe attribution only.
+enum DataVolumeHiddenStorageCategory: String, Codable, CaseIterable, Sendable {
+    case adobeTemporaryStorage = "data-volume-hidden.adobe-temporary-storage"
+    case filesystemEvents = "data-volume-hidden.filesystem-events"
+    case spotlightIndex = "data-volume-hidden.spotlight-index"
+    case documentRevisions = "data-volume-hidden.document-revisions"
+    case temporaryItems = "data-volume-hidden.temporary-items"
+    case trashes = "data-volume-hidden.trashes"
+    case unknown = "data-volume-hidden.unknown"
+
+    var explanation: String {
+        switch self {
+        case .adobeTemporaryStorage:
+            return "Hidden temporary storage attributed by name to Adobe products; no cleanup behavior is implied."
+        case .filesystemEvents:
+            return "Filesystem event history maintained by macOS; this label does not imply cleanability."
+        case .spotlightIndex:
+            return "Spotlight search indexing data managed by macOS; this label does not imply cleanability."
+        case .documentRevisions:
+            return "Document revision and version storage managed by macOS; this label does not imply cleanability."
+        case .temporaryItems:
+            return "Hidden temporary-item storage managed by macOS and applications; no cleanup behavior is implied."
+        case .trashes:
+            return "Hidden per-volume Trash storage; this analyzer only attributes its size."
+        case .unknown:
+            return "Unclassified hidden storage located directly on the writable Data volume."
+        }
+    }
+}
+
+/// Informational management context, deliberately separate from cleanup
+/// safety or deletion eligibility.
+enum DataVolumeHiddenManagementKind: String, Codable, Sendable {
+    case systemManaged
+    case productAttributed
+    case systemAndApplicationManaged
+    case unknown
+}
+
+/// Completeness of the reported numeric subtree total. An incomplete total is
+/// a known lower bound and never an estimate of unreadable descendants.
+enum DataVolumeHiddenSizeKnowledge: String, Codable, Sendable {
+    case complete
+    case incompleteDueToInaccessibility
+    case incompleteDueToCancellation
+    case excludedDifferentVolume
+}
+
+/// Read-only attribution of hidden entries located immediately below
+/// `/System/Volumes/Data`.
+///
+/// The root is enumerated once. `FileTreeScanner` recursively traverses only
+/// selected hidden children while preserving a shared inode-accounting context
+/// across those children.
+struct DataVolumeHiddenStorageAnalyzer: Sendable {
+    enum MetadataKey {
+        static let directChildCount = "dataVolumeHidden.directChildCount"
+        static let largeAllocatedSizeThreshold = "dataVolumeHidden.largeAllocatedSizeThreshold"
+        static let virtualDiskImageCount = "dataVolumeHidden.virtualDiskImageCount"
+        static let virtualDiskFormat = "dataVolumeHidden.virtualDiskFormat"
+        static let virtualDiskSparseState = "dataVolumeHidden.virtualDiskSparseState"
+        static let managementKind = "dataVolumeHidden.managementKind"
+        static let sizeKnowledge = "dataVolumeHidden.sizeKnowledge"
+        static let scanScope = "dataVolumeHidden.scanScope"
+        static let canonicalDataVolumePath = "dataVolumeHidden.canonicalDataVolumePath"
+    }
+
+    static let storageCategoryIdentifier = "data-volume-hidden-storage"
+    static let defaultLargeAllocatedSizeThreshold: Int64 = 1_073_741_824
+    static let defaultDataVolumeURL = URL(
+        fileURLWithPath: "/System/Volumes/Data",
+        isDirectory: true
+    )
+
+    private enum VirtualDiskFormat: String {
+        case raw
+        case img
+        case qcow2
+        case vmdk
+        case sparseBundle = "sparsebundle"
+    }
+
+    private enum SparseState: String {
+        case sparse
+        case notSparse = "not-sparse"
+        case unknown
+    }
+
+    private let dataVolumeURL: URL
+    private let scanner: FileTreeScanner
+    private let largeAllocatedSizeThreshold: Int64
+
+    init(
+        dataVolumeURL: URL = DataVolumeHiddenStorageAnalyzer.defaultDataVolumeURL,
+        scanner: FileTreeScanner = FileTreeScanner(),
+        largeAllocatedSizeThreshold: Int64 = DataVolumeHiddenStorageAnalyzer.defaultLargeAllocatedSizeThreshold
+    ) {
+        self.dataVolumeURL = dataVolumeURL
+        self.scanner = scanner
+        self.largeAllocatedSizeThreshold = max(largeAllocatedSizeThreshold, 1)
+    }
+
+    func analyze() async -> StorageAnalysisResult {
+        let scannedResult = await scanner.scanSelectedImmediateChildren(
+            root: dataVolumeURL,
+            including: { $0.isHidden }
+        )
+        let threshold = largeAllocatedSizeThreshold
+
+        return await Task.detached(priority: .utility) {
+            Self.enrich(
+                scannedResult,
+                largeAllocatedSizeThreshold: threshold
+            )
+        }.value
+    }
+}
+
+// Internal so volume-boundary behavior can be verified without creating a
+// privileged test mount.
+extension DataVolumeHiddenStorageAnalyzer {
+    static func enrich(
+        _ result: StorageAnalysisResult,
+        largeAllocatedSizeThreshold: Int64
+    ) -> StorageAnalysisResult {
+        var root = result.root
+        var issues = result.issues
+
+        if root.itemType != .directory, root.itemType != .unknown {
+            let issue = StorageScanIssue(
+                path: root.absolutePath,
+                kind: .notDirectory,
+                message: "Data-volume hidden storage analysis requires a directory root.",
+                posixErrorCode: ENOTDIR
+            )
+            var rootIssues = root.scanIssues
+            if !rootIssues.contains(issue) { rootIssues.append(issue) }
+            if !issues.contains(issue) { issues.append(issue) }
+            root = copy(
+                root,
+                children: root.children,
+                accessibility: .inaccessible,
+                scanIssues: rootIssues,
+                metadata: root.metadata
+            )
+        }
+
+        root = enrichTreeMetadata(in: root)
+        let entries = root.children
+            .map {
+                enrichImmediateHiddenEntry(
+                    $0,
+                    largeAllocatedSizeThreshold: largeAllocatedSizeThreshold
+                )
+            }
+            .sorted(by: allocatedSizeDescending)
+
+        var rootMetadata = root.metadata
+        rootMetadata.storageCategoryIdentifier = storageCategoryIdentifier
+        rootMetadata.explanation = "Hidden top-level storage on the writable macOS Data volume."
+        rootMetadata.attributes[MetadataKey.directChildCount] = String(entries.count)
+        rootMetadata.attributes[MetadataKey.scanScope] = "selected-hidden-immediate-children-only"
+        rootMetadata.attributes[MetadataKey.canonicalDataVolumePath] = root.absolutePath
+
+        root = copy(root, children: entries, metadata: rootMetadata)
+        return StorageAnalysisResult(
+            root: root,
+            startedAt: result.startedAt,
+            completedAt: result.completedAt,
+            rootDeviceIdentifier: result.rootDeviceIdentifier,
+            wasCancelled: result.wasCancelled,
+            issues: issues.sorted(by: issueSort)
+        )
+    }
+}
+
+// MARK: - Metadata Enrichment
+
+private extension DataVolumeHiddenStorageAnalyzer {
+    static func enrichImmediateHiddenEntry(
+        _ node: StorageNode,
+        largeAllocatedSizeThreshold: Int64
+    ) -> StorageNode {
+        let category = category(for: node.name)
+        var metadata = node.metadata
+        metadata.storageCategoryIdentifier = category.rawValue
+        metadata.isUnusuallyLarge = node.allocatedSize >= largeAllocatedSizeThreshold
+        metadata.explanation = category.explanation
+        metadata.attributes[MetadataKey.directChildCount] = String(node.children.count)
+        metadata.attributes[MetadataKey.largeAllocatedSizeThreshold] = String(largeAllocatedSizeThreshold)
+        metadata.attributes[MetadataKey.virtualDiskImageCount] = String(countVirtualDiskImages(in: node))
+        metadata.attributes[MetadataKey.managementKind] = managementKind(for: category).rawValue
+        return copy(node, children: node.children, metadata: metadata)
+    }
+
+    static func enrichTreeMetadata(in node: StorageNode) -> StorageNode {
+        let children = node.children.map(enrichTreeMetadata)
+        var metadata = node.metadata
+        metadata.attributes[MetadataKey.sizeKnowledge] = sizeKnowledge(for: node.accessibility).rawValue
+
+        if let format = virtualDiskFormat(for: node) {
+            metadata.attributes[MetadataKey.virtualDiskFormat] = format.rawValue
+            metadata.attributes[MetadataKey.virtualDiskSparseState] = sparseState(for: node).rawValue
+        }
+
+        return copy(node, children: children, metadata: metadata)
+    }
+
+    static func category(for name: String) -> DataVolumeHiddenStorageCategory {
+        switch name {
+        case ".adobeTemp": return .adobeTemporaryStorage
+        case ".fseventsd": return .filesystemEvents
+        case ".Spotlight-V100": return .spotlightIndex
+        case ".DocumentRevisions-V100": return .documentRevisions
+        case ".TemporaryItems": return .temporaryItems
+        case ".Trashes": return .trashes
+        default: return .unknown
+        }
+    }
+
+    static func managementKind(
+        for category: DataVolumeHiddenStorageCategory
+    ) -> DataVolumeHiddenManagementKind {
+        switch category {
+        case .adobeTemporaryStorage:
+            return .productAttributed
+        case .filesystemEvents, .spotlightIndex, .documentRevisions:
+            return .systemManaged
+        case .temporaryItems, .trashes:
+            return .systemAndApplicationManaged
+        case .unknown:
+            return .unknown
+        }
+    }
+
+    static func sizeKnowledge(
+        for accessibility: StorageAccessibility
+    ) -> DataVolumeHiddenSizeKnowledge {
+        switch accessibility {
+        case .accessible: return .complete
+        case .partiallyAccessible, .inaccessible: return .incompleteDueToInaccessibility
+        case .cancelled: return .incompleteDueToCancellation
+        case .skippedDifferentVolume: return .excludedDifferentVolume
+        }
+    }
+
+    private static func virtualDiskFormat(for node: StorageNode) -> VirtualDiskFormat? {
+        guard !node.isSymbolicLink,
+              node.itemType == .regularFile || node.itemType == .directory else {
+            return nil
+        }
+
+        switch URL(fileURLWithPath: node.absolutePath).pathExtension.lowercased() {
+        case "raw": return .raw
+        case "img": return .img
+        case "qcow2": return .qcow2
+        case "vmdk": return .vmdk
+        case "sparsebundle": return .sparseBundle
+        default: return nil
+        }
+    }
+
+    private static func sparseState(for node: StorageNode) -> SparseState {
+        guard node.itemType == .regularFile else { return .unknown }
+        return node.ownLogicalSize > node.ownAllocatedSize ? .sparse : .notSparse
+    }
+
+    static func countVirtualDiskImages(in root: StorageNode) -> Int {
+        var count = 0
+        var pending = [root]
+        while let node = pending.popLast() {
+            if virtualDiskFormat(for: node) != nil { count += 1 }
+            pending.append(contentsOf: node.children)
+        }
+        return count
+    }
+
+    static func allocatedSizeDescending(_ left: StorageNode, _ right: StorageNode) -> Bool {
+        if left.allocatedSize != right.allocatedSize {
+            return left.allocatedSize > right.allocatedSize
+        }
+        if left.logicalSize != right.logicalSize {
+            return left.logicalSize > right.logicalSize
+        }
+        return left.absolutePath < right.absolutePath
+    }
+
+    static func copy(
+        _ node: StorageNode,
+        children: [StorageNode],
+        accessibility: StorageAccessibility? = nil,
+        scanIssues: [StorageScanIssue]? = nil,
+        metadata: StorageAnalysisMetadata
+    ) -> StorageNode {
+        StorageNode(
+            name: node.name,
+            absolutePath: node.absolutePath,
+            logicalSize: node.logicalSize,
+            allocatedSize: node.allocatedSize,
+            ownLogicalSize: node.ownLogicalSize,
+            ownAllocatedSize: node.ownAllocatedSize,
+            itemType: node.itemType,
+            children: children,
+            accessibility: accessibility ?? node.accessibility,
+            scanIssues: scanIssues ?? node.scanIssues,
+            isHidden: node.isHidden,
+            isSymbolicLink: node.isSymbolicLink,
+            isCountedInParentTotals: node.isCountedInParentTotals,
+            metadata: metadata
+        )
+    }
+
+    static func issueSort(_ left: StorageScanIssue, _ right: StorageScanIssue) -> Bool {
+        if left.path != right.path { return left.path < right.path }
+        if left.kind != right.kind { return left.kind.rawValue < right.kind.rawValue }
+        return left.message < right.message
+    }
+}

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/DataVolumeInternalGapAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/DataVolumeInternalGapAnalyzer.swift
@@ -1,0 +1,393 @@
+import Foundation
+
+/// Read-only analyzer that deconstructs and investigates the Data-volume internal
+/// accounting gap between APFS physical allocation and filesystem attributed blocks.
+struct DataVolumeInternalGapAnalyzer: Sendable {
+
+    func analyze(
+        reconciliationReport: StorageReconciliationReport,
+        dataVolumePhysicalInUse: Int64?
+    ) -> DataVolumeInternalGapReport {
+        guard !Task.isCancelled else {
+            return .empty
+        }
+
+        let filesystemAttributed = reconciliationReport.explainedAllocatedBytes
+        let internalGap: Int64?
+        if let dataVolumePhysicalInUse {
+            internalGap = max(0, dataVolumePhysicalInUse - filesystemAttributed)
+        } else {
+            internalGap = nil
+        }
+
+        // 1. Allocation vs Logical Size Diagnostic
+        let allocationDeltaSummary = evaluateAllocationDelta(from: reconciliationReport)
+
+        // 2. Protected Storage Aggregation into Families
+        let protectedSummary = aggregateProtectedStorage(from: reconciliationReport)
+
+        // 3. Build Waterfall Items with Strict Tiers
+        let waterfallItems = buildWaterfall(
+            reconciliationReport: reconciliationReport,
+            internalGap: internalGap,
+            allocationDelta: allocationDeltaSummary,
+            protectedSummary: protectedSummary
+        )
+
+        // 4. Calculate Non-Additive Evidenced Bytes
+        let nonAdditiveEvidenced = waterfallItems
+            .filter { $0.tier != .measuredAdditive && $0.category != .unresolvedResidual }
+            .compactMap(\.reportedBytes)
+            .reduce(Int64(0), +)
+
+        // 5. Human-Readable Interpretation
+        let interpretation = buildInterpretation(
+            dataVolumePhysicalInUse: dataVolumePhysicalInUse,
+            filesystemAttributed: filesystemAttributed,
+            internalGap: internalGap,
+            allocationDelta: allocationDeltaSummary,
+            protectedSummary: protectedSummary,
+            purgeableBytes: reconciliationReport.purgeableEstimateBytes
+        )
+
+        return DataVolumeInternalGapReport(
+            dataVolumePhysicalInUseBytes: dataVolumePhysicalInUse,
+            filesystemAttributedBytes: filesystemAttributed,
+            internalPhysicalGapBytes: internalGap,
+            allocationDeltaSummary: allocationDeltaSummary,
+            waterfallItems: waterfallItems,
+            protectedSummary: protectedSummary,
+            additiveExplainedPortionBytes: 0, // Invariant: categories 2-5 never reduce residual
+            nonAdditiveEvidencedPortionBytes: nonAdditiveEvidenced,
+            unresolvedResidualGapBytes: internalGap,
+            humanReadableInterpretation: interpretation,
+            wasCancelled: reconciliationReport.wasCancelled,
+            issues: []
+        )
+    }
+
+    // MARK: - Allocation vs Logical Diagnostic
+
+    private func evaluateAllocationDelta(
+        from report: StorageReconciliationReport
+    ) -> DataVolumeAllocationDeltaSummary {
+        var totalLogical: Int64 = 0
+        var totalAllocated: Int64 = 0
+        var sparseObserved = false
+        var paddingObserved = false
+
+        let results = report.analyzerResults
+
+        // Accumulate from specialized roots
+        let roots: [StorageNode?] = [
+            results.userHomeStorage?.result.root,
+            results.applicationSupport?.root,
+            results.containers?.root,
+            results.groupContainers?.root,
+            results.systemLibrary?.root,
+            results.privateStorage?.root,
+            results.dataVolumeHiddenStorage?.root,
+            results.developerSystemStorage?.opt.result.root,
+            results.developerSystemStorage?.usrLocal.result.root
+        ]
+
+        for root in roots.compactMap({ $0 }) {
+            totalLogical += root.logicalSize
+            totalAllocated += root.allocatedSize
+            if root.logicalSize > root.allocatedSize {
+                sparseObserved = true
+            }
+            if root.allocatedSize > root.logicalSize {
+                paddingObserved = true
+            }
+        }
+
+        // Coverage expansion candidates
+        if let expansion = results.coverageExpansion {
+            for candidate in expansion.candidates where candidate.status.isMeasuredOrPartial {
+                if let alloc = candidate.allocatedBytes {
+                    totalAllocated += alloc
+                }
+                if let log = candidate.logicalBytes {
+                    totalLogical += log
+                }
+            }
+        }
+
+        let delta = totalAllocated - totalLogical
+        let deltaStr = formatBytes(abs(delta))
+        let explanation: String
+        if delta >= 0 {
+            explanation = "Filesystem allocated blocks exceed logical file sizes by \(deltaStr) across measured trees due to filesystem allocation block granularity (4 KB alignment)."
+        } else {
+            explanation = "Logical file sizes exceed physical allocated blocks by \(deltaStr) across measured trees due to sparse files and APFS compression."
+        }
+
+        return DataVolumeAllocationDeltaSummary(
+            totalMeasuredLogicalBytes: totalLogical,
+            totalMeasuredAllocatedBytes: totalAllocated,
+            deltaBytes: delta,
+            sparseFilesObserved: sparseObserved,
+            blockPaddingObserved: paddingObserved,
+            explanation: explanation
+        )
+    }
+
+    // MARK: - Protected Storage Aggregation
+
+    private func aggregateProtectedStorage(
+        from report: StorageReconciliationReport
+    ) -> DataVolumeProtectedStorageSummary {
+        let allIssues = report.coverageDiagnostic.measurementIssues.groups.flatMap { group in
+            group.representativePaths.map { path in
+                (path: path, source: group.source, error: group.posixErrorCode)
+            }
+        }
+
+        var spotlightCount = 0
+        var documentRevisionsCount = 0
+        var fseventsdCount = 0
+        var privateVarDbCount = 0
+        var tccPrivacyCount = 0
+        var installSandboxCount = 0
+        var otherProtectedCount = 0
+
+        for issue in allIssues {
+            let p = issue.path.lowercased()
+            if p.contains(".spotlight-v100") || p.contains("corespotlight") {
+                spotlightCount += 1
+            } else if p.contains(".documentrevisions-v100") {
+                documentRevisionsCount += 1
+            } else if p.contains(".fseventsd") {
+                fseventsdCount += 1
+            } else if p.contains("/private/var/db") || p.contains("/private/var/folders") || p.contains("/private/var/root") {
+                privateVarDbCount += 1
+            } else if p.contains("tcc") || p.contains("safari") || p.contains("identityservices") || p.contains("homekit") {
+                tccPrivacyCount += 1
+            } else if p.contains(".pkinstallsandboxmanager") {
+                installSandboxCount += 1
+            } else {
+                otherProtectedCount += 1
+            }
+        }
+
+        var families: [DataVolumeProtectedFamily] = []
+
+        if spotlightCount > 0 || FileManager.default.fileExists(atPath: "/System/Volumes/Data/.Spotlight-V100") {
+            families.append(DataVolumeProtectedFamily(
+                id: "spotlight",
+                name: "Spotlight Metadata & Indexes",
+                pathPattern: "/System/Volumes/Data/.Spotlight-V100",
+                issueCount: max(spotlightCount, 1),
+                knownLowerBoundBytes: nil,
+                explanation: "macOS CoreSpotlight index databases and metadata search store."
+            ))
+        }
+
+        if documentRevisionsCount > 0 || FileManager.default.fileExists(atPath: "/System/Volumes/Data/.DocumentRevisions-V100") {
+            families.append(DataVolumeProtectedFamily(
+                id: "document_revisions",
+                name: "Document Versions & Revisions",
+                pathPattern: "/System/Volumes/Data/.DocumentRevisions-V100",
+                issueCount: max(documentRevisionsCount, 1),
+                knownLowerBoundBytes: nil,
+                explanation: "macOS auto-save document generation database and revision chunk storage."
+            ))
+        }
+
+        if fseventsdCount > 0 || FileManager.default.fileExists(atPath: "/System/Volumes/Data/.fseventsd") {
+            families.append(DataVolumeProtectedFamily(
+                id: "fseventsd",
+                name: "Filesystem Events Journal",
+                pathPattern: "/System/Volumes/Data/.fseventsd",
+                issueCount: max(fseventsdCount, 1),
+                knownLowerBoundBytes: nil,
+                explanation: "Kernel filesystem events log and stream tracking journal."
+            ))
+        }
+
+        if privateVarDbCount > 0 {
+            families.append(DataVolumeProtectedFamily(
+                id: "private_var_db",
+                name: "Private / System State Databases",
+                pathPattern: "/private/var/db, /private/var/folders",
+                issueCount: privateVarDbCount,
+                knownLowerBoundBytes: nil,
+                explanation: "System daemon configuration databases, diagnostic logs, and dynamic system state."
+            ))
+        }
+
+        if tccPrivacyCount > 0 {
+            families.append(DataVolumeProtectedFamily(
+                id: "tcc_privacy",
+                name: "TCC & User Privacy Locations",
+                pathPattern: "~/Library/Safari, com.apple.TCC",
+                issueCount: tccPrivacyCount,
+                knownLowerBoundBytes: nil,
+                explanation: "User data locations restricted by macOS Transparency, Consent, and Control (TCC)."
+            ))
+        }
+
+        if installSandboxCount > 0 {
+            families.append(DataVolumeProtectedFamily(
+                id: "install_sandbox",
+                name: "Package Installation Sandboxes",
+                pathPattern: "/System/Volumes/Data/.PKInstallSandboxManager*",
+                issueCount: installSandboxCount,
+                knownLowerBoundBytes: nil,
+                explanation: "Staged macOS installer assets and system software installation sandboxes."
+            ))
+        }
+
+        let totalIssues = report.coverageDiagnostic.measurementIssues.totalIssueCount
+        let lowerBound = report.inaccessibleKnownLowerBoundBytes
+        let unreadablePaths = report.unreadablePathCount
+
+        return DataVolumeProtectedStorageSummary(
+            families: families,
+            totalProtectedIssueCount: totalIssues,
+            inaccessiblePathCount: unreadablePaths,
+            knownLowerBoundBytes: lowerBound,
+            explanation: "\(families.count) protected system storage families recorded across the Data volume."
+        )
+    }
+
+    // MARK: - Waterfall Assembly
+
+    private func buildWaterfall(
+        reconciliationReport: StorageReconciliationReport,
+        internalGap: Int64?,
+        allocationDelta: DataVolumeAllocationDeltaSummary,
+        protectedSummary: DataVolumeProtectedStorageSummary
+    ) -> [DataVolumeGapWaterfallItem] {
+        var items: [DataVolumeGapWaterfallItem] = []
+
+        // 1. Allocation vs Logical Delta
+        let delta = allocationDelta.deltaBytes
+        items.append(DataVolumeGapWaterfallItem(
+            id: "allocation_delta",
+            title: "Allocation Block vs Logical Size Delta",
+            category: .filesystemAllocationDelta,
+            tier: .measuredNonAdditive,
+            reportedBytes: abs(delta),
+            explanation: allocationDelta.explanation,
+            badgeText: "Diagnostic"
+        ))
+
+        // 2. Purgeable Capacity Estimate
+        if let purgeable = reconciliationReport.purgeableEstimateBytes, purgeable > 0 {
+            items.append(DataVolumeGapWaterfallItem(
+                id: "purgeable_estimate",
+                title: "Purgeable Capacity Estimate",
+                category: .purgeableEstimate,
+                tier: .estimatedOSReported,
+                reportedBytes: purgeable,
+                explanation: "macOS opportunistic reclaim estimate derived from volumeAvailableCapacityForImportantUsage. May overlap cache files on disk.",
+                badgeText: "Estimate"
+            ))
+        }
+
+        // 3. APFS Snapshots & Extents
+        let snapshots = reconciliationReport.analyzerResults.apfsStorage?.snapshots ?? []
+        let snapshotBytes = snapshots.compactMap(\.size).reduce(Int64(0), +)
+        if !snapshots.isEmpty || snapshotBytes > 0 {
+            items.append(DataVolumeGapWaterfallItem(
+                id: "apfs_snapshots",
+                title: "APFS Snapshots (\(snapshots.count))",
+                category: .apfsSnapshots,
+                tier: .measuredNonAdditive,
+                reportedBytes: snapshotBytes > 0 ? snapshotBytes : nil,
+                explanation: "APFS copy-on-write snapshots share extents with live filesystem data and are non-additive.",
+                badgeText: "Non-additive"
+            ))
+        }
+
+        // 4. APFS Clones & Shared Extents
+        items.append(DataVolumeGapWaterfallItem(
+            id: "clone_shared_extents",
+            title: "APFS File Clones & Shared Extents",
+            category: .cloneSharedExtents,
+            tier: .presenceOnly,
+            reportedBytes: nil,
+            explanation: "APFS clonefile copy-on-write extents are shared between files. Exclusive physical allocation is not exposed by macOS userland APIs.",
+            badgeText: "Presence-only"
+        ))
+
+        // 5. Protected System Storage
+        items.append(DataVolumeGapWaterfallItem(
+            id: "protected_storage",
+            title: "macOS Protected Storage (\(protectedSummary.families.count) families)",
+            category: .protectedStorage,
+            tier: .unknownProtected,
+            reportedBytes: nil, // Strictly no fabricated bytes
+            explanation: "Restricted system locations including Spotlight (.Spotlight-V100), Document Versions (.DocumentRevisions-V100), and system databases.",
+            badgeText: "Protected"
+        ))
+
+        // 6. APFS Filesystem Metadata & Structural Overhead
+        items.append(DataVolumeGapWaterfallItem(
+            id: "apfs_metadata",
+            title: "APFS Filesystem Metadata & Structure Overhead",
+            category: .apfsFilesystemMetadata,
+            tier: .presenceOnly,
+            reportedBytes: nil,
+            explanation: "APFS object map, 2M+ file inode records, directory B-Trees, extent allocation bitmaps, and checkpoint log structures.",
+            badgeText: "Presence-only"
+        ))
+
+        // 7. Unresolved Residual Physical Accounting Gap
+        if let internalGap {
+            items.append(DataVolumeGapWaterfallItem(
+                id: "unresolved_residual",
+                title: "Unresolved Data-Volume Physical Gap",
+                category: .unresolvedResidual,
+                tier: .unknownProtected,
+                reportedBytes: internalGap,
+                explanation: "Remaining difference between Data volume physical allocation and directory tree sum after accounting for all evidenced factors.",
+                badgeText: "Unresolved"
+            ))
+        }
+
+        return items
+    }
+
+    // MARK: - Human Readable Interpretation
+
+    private func buildInterpretation(
+        dataVolumePhysicalInUse: Int64?,
+        filesystemAttributed: Int64,
+        internalGap: Int64?,
+        allocationDelta: DataVolumeAllocationDeltaSummary,
+        protectedSummary: DataVolumeProtectedStorageSummary,
+        purgeableBytes: Int64?
+    ) -> String {
+        guard let inUse = dataVolumePhysicalInUse, let gap = internalGap else {
+            return "Data volume physical allocation information is currently unavailable."
+        }
+
+        let inUseStr = formatBytes(inUse)
+        let attributedStr = formatBytes(filesystemAttributed)
+        let gapStr = formatBytes(gap)
+
+        var parts: [String] = [
+            "macOS reports \(inUseStr) physically allocated on the Data volume, while PureMac attributes \(attributedStr) to accessible directory trees, resulting in an internal gap of \(gapStr)."
+        ]
+
+        if let purgeable = purgeableBytes, purgeable > 0 {
+            let purgeableStr = formatBytes(purgeable)
+            parts.append("macOS estimates \(purgeableStr) of purgeable cache data.")
+        }
+
+        if !protectedSummary.families.isEmpty {
+            parts.append("\(protectedSummary.families.count) protected system areas (including Spotlight and Document Versions) deny read access.")
+        }
+
+        parts.append("Because APFS metadata, shared extents, and purgeable files are non-additive, the \(gapStr) residual remains unreduced and must not be treated as junk.")
+        return parts.joined(separator: " ")
+    }
+
+    private func formatBytes(_ bytes: Int64?) -> String {
+        guard let bytes else { return "Unknown" }
+        return ByteCountFormatter.string(fromByteCount: max(bytes, 0), countStyle: .file)
+    }
+}

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/DeveloperSystemStorageAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/DeveloperSystemStorageAnalyzer.swift
@@ -1,0 +1,475 @@
+import Darwin
+import Foundation
+
+/// Canonical developer and third-party locations analyzed by this report.
+enum DeveloperSystemCanonicalRoot: String, Codable, CaseIterable, Sendable {
+    case opt = "/opt"
+    case usrLocal = "/usr/local"
+}
+
+/// Availability of one configured canonical-root analysis.
+enum DeveloperSystemRootState: String, Codable, Sendable {
+    case present
+    case missing
+    case inaccessible
+    case invalid
+    case partiallyReadable
+    case cancelled
+}
+
+/// Explanatory storage attribution only. These categories do not express
+/// cleanup safety or deletion eligibility.
+enum DeveloperSystemStorageCategory: String, Codable, CaseIterable, Sendable {
+    case developerToolStorage
+    case packageManagerStorage
+    case thirdPartyStorage
+    case executableStorage
+    case libraryStorage
+    case sharedResourceStorage
+    case unknown
+
+    var explanation: String {
+        switch self {
+        case .developerToolStorage:
+            return "Developer tools, runtimes, SDKs, and related local storage."
+        case .packageManagerStorage:
+            return "Package-manager installations and data; this label does not imply cleanability."
+        case .thirdPartyStorage:
+            return "Third-party software and data stored outside the macOS system directories."
+        case .executableStorage:
+            return "Locally installed command-line executables and symbolic links."
+        case .libraryStorage:
+            return "Third-party and locally installed libraries."
+        case .sharedResourceStorage:
+            return "Shared resources installed by third-party software and developer tools."
+        case .unknown:
+            return "Unclassified storage retained for inspection without guessed attribution."
+        }
+    }
+}
+
+/// Whether a numeric subtree total is complete. An incomplete total is a
+/// known lower bound and never treats unreadable descendants as known zero.
+enum DeveloperSystemSizeKnowledge: String, Codable, Sendable {
+    case complete
+    case knownLowerBound
+    case unavailable
+    case incompleteDueToCancellation
+    case excludedDifferentVolume
+}
+
+struct DeveloperSystemRootAnalysis: Hashable, Codable, Sendable {
+    let canonicalRoot: DeveloperSystemCanonicalRoot
+    let configuredPath: String
+    let state: DeveloperSystemRootState
+    let result: StorageAnalysisResult
+}
+
+/// Separate canonical trees plus non-additive, cross-root unique totals.
+struct DeveloperSystemStorageReport: Hashable, Codable, Sendable {
+    let opt: DeveloperSystemRootAnalysis
+    let usrLocal: DeveloperSystemRootAnalysis
+    let combinedUniqueLogicalSize: Int64
+    let combinedUniqueAllocatedSize: Int64
+    let combinedSizeKnowledge: DeveloperSystemSizeKnowledge
+    let wasCancelled: Bool
+    let issues: [StorageScanIssue]
+}
+
+/// Read-only filesystem attribution for `/opt` and `/usr/local`.
+///
+/// `FileTreeScanner` owns traversal, byte accounting, hard-link identity,
+/// cancellation, symlink safety, and mounted-filesystem boundaries. This
+/// analyzer keeps the two canonical results separate and adds only lightweight
+/// path-name metadata.
+struct DeveloperSystemStorageAnalyzer: Sendable {
+    enum MetadataKey {
+        static let canonicalRoot = "developerSystem.canonicalRoot"
+        static let configuredPath = "developerSystem.configuredPath"
+        static let rootState = "developerSystem.rootState"
+        static let directChildCount = "developerSystem.directChildCount"
+        static let largeAllocatedSizeThreshold = "developerSystem.largeAllocatedSizeThreshold"
+        static let virtualDiskImageCount = "developerSystem.virtualDiskImageCount"
+        static let virtualDiskFormat = "developerSystem.virtualDiskFormat"
+        static let virtualDiskSparseState = "developerSystem.virtualDiskSparseState"
+        static let sizeKnowledge = "developerSystem.sizeKnowledge"
+        static let accountingScope = "developerSystem.accountingScope"
+    }
+
+    static let defaultOptURL = URL(fileURLWithPath: "/opt", isDirectory: true)
+    static let defaultUsrLocalURL = URL(fileURLWithPath: "/usr/local", isDirectory: true)
+    static let defaultLargeAllocatedSizeThreshold: Int64 = 1_073_741_824
+
+    private enum VirtualDiskFormat: String {
+        case raw
+        case img
+        case qcow2
+        case vmdk
+        case sparseBundle = "sparsebundle"
+    }
+
+    private enum SparseState: String {
+        case sparse
+        case notSparse = "not-sparse"
+        case unknown
+    }
+
+    private let optURL: URL
+    private let usrLocalURL: URL
+    private let scanner: FileTreeScanner
+    private let largeAllocatedSizeThreshold: Int64
+
+    init(
+        optURL: URL = DeveloperSystemStorageAnalyzer.defaultOptURL,
+        usrLocalURL: URL = DeveloperSystemStorageAnalyzer.defaultUsrLocalURL,
+        scanner: FileTreeScanner = FileTreeScanner(),
+        largeAllocatedSizeThreshold: Int64 = DeveloperSystemStorageAnalyzer.defaultLargeAllocatedSizeThreshold
+    ) {
+        self.optURL = optURL
+        self.usrLocalURL = usrLocalURL
+        self.scanner = scanner
+        self.largeAllocatedSizeThreshold = max(largeAllocatedSizeThreshold, 1)
+    }
+
+    func analyze() async -> DeveloperSystemStorageReport {
+        let scan = await scanner.scanIndependentRoots([optURL, usrLocalURL])
+        let optResult = scan.results[0]
+        let usrLocalResult = scan.results[1]
+        let threshold = largeAllocatedSizeThreshold
+
+        return await Task.detached(priority: .utility) {
+            Self.makeReport(
+                optResult: optResult,
+                usrLocalResult: usrLocalResult,
+                combinedUniqueLogicalSize: scan.combinedUniqueLogicalSize,
+                combinedUniqueAllocatedSize: scan.combinedUniqueAllocatedSize,
+                largeAllocatedSizeThreshold: threshold
+            )
+        }.value
+    }
+}
+
+// Internal so tests can verify enrichment and filesystem-boundary behavior
+// without requiring privileged mounts or access to the real canonical roots.
+extension DeveloperSystemStorageAnalyzer {
+    static func makeReport(
+        optResult: StorageAnalysisResult,
+        usrLocalResult: StorageAnalysisResult,
+        combinedUniqueLogicalSize: Int64,
+        combinedUniqueAllocatedSize: Int64,
+        largeAllocatedSizeThreshold: Int64
+    ) -> DeveloperSystemStorageReport {
+        let opt = enrichRoot(
+            optResult,
+            canonicalRoot: .opt,
+            largeAllocatedSizeThreshold: largeAllocatedSizeThreshold
+        )
+        let usrLocal = enrichRoot(
+            usrLocalResult,
+            canonicalRoot: .usrLocal,
+            largeAllocatedSizeThreshold: largeAllocatedSizeThreshold
+        )
+        let allIssues = (opt.result.issues + usrLocal.result.issues)
+            .uniqued()
+            .sorted(by: issueSort)
+        let wasCancelled = opt.result.wasCancelled || usrLocal.result.wasCancelled
+
+        return DeveloperSystemStorageReport(
+            opt: opt,
+            usrLocal: usrLocal,
+            combinedUniqueLogicalSize: combinedUniqueLogicalSize,
+            combinedUniqueAllocatedSize: combinedUniqueAllocatedSize,
+            combinedSizeKnowledge: combinedKnowledge(
+                opt: opt,
+                usrLocal: usrLocal,
+                wasCancelled: wasCancelled
+            ),
+            wasCancelled: wasCancelled,
+            issues: allIssues
+        )
+    }
+}
+
+// MARK: - Root and Attribution Enrichment
+
+private extension DeveloperSystemStorageAnalyzer {
+    static func enrichRoot(
+        _ input: StorageAnalysisResult,
+        canonicalRoot: DeveloperSystemCanonicalRoot,
+        largeAllocatedSizeThreshold: Int64
+    ) -> DeveloperSystemRootAnalysis {
+        var root = input.root
+        var issues = input.issues
+
+        if root.itemType != .directory, root.itemType != .unknown {
+            let issue = StorageScanIssue(
+                path: root.absolutePath,
+                kind: .notDirectory,
+                message: "Developer system storage analysis requires a directory root.",
+                posixErrorCode: ENOTDIR
+            )
+            var rootIssues = root.scanIssues
+            if !rootIssues.contains(issue) { rootIssues.append(issue) }
+            if !issues.contains(issue) { issues.append(issue) }
+            root = copy(
+                root,
+                children: root.children,
+                accessibility: .inaccessible,
+                scanIssues: rootIssues,
+                metadata: root.metadata
+            )
+        }
+
+        root = enrichTreeMetadata(in: root)
+        let children = root.children
+            .map {
+                enrichImmediateChild(
+                    $0,
+                    canonicalRoot: canonicalRoot,
+                    largeAllocatedSizeThreshold: largeAllocatedSizeThreshold
+                )
+            }
+            .sorted(by: allocatedSizeDescending)
+
+        let state = rootState(for: root, result: input)
+        let rootCategory: DeveloperSystemStorageCategory = canonicalRoot == .opt
+            ? .thirdPartyStorage
+            : .developerToolStorage
+        var metadata = root.metadata
+        metadata.storageCategoryIdentifier = rootCategory.rawValue
+        metadata.explanation = rootCategory.explanation
+        metadata.attributes[MetadataKey.canonicalRoot] = canonicalRoot.rawValue
+        metadata.attributes[MetadataKey.configuredPath] = root.absolutePath
+        metadata.attributes[MetadataKey.rootState] = state.rawValue
+        metadata.attributes[MetadataKey.directChildCount] = String(children.count)
+        metadata.attributes[MetadataKey.accountingScope] = "standalone-canonical-root"
+        metadata.attributes[MetadataKey.sizeKnowledge] = rootSizeKnowledge(
+            for: state
+        ).rawValue
+        root = copy(root, children: children, metadata: metadata)
+
+        let result = StorageAnalysisResult(
+            root: root,
+            startedAt: input.startedAt,
+            completedAt: input.completedAt,
+            rootDeviceIdentifier: input.rootDeviceIdentifier,
+            wasCancelled: input.wasCancelled,
+            issues: issues.sorted(by: issueSort)
+        )
+        return DeveloperSystemRootAnalysis(
+            canonicalRoot: canonicalRoot,
+            configuredPath: root.absolutePath,
+            state: state,
+            result: result
+        )
+    }
+
+    static func enrichImmediateChild(
+        _ node: StorageNode,
+        canonicalRoot: DeveloperSystemCanonicalRoot,
+        largeAllocatedSizeThreshold: Int64
+    ) -> StorageNode {
+        let category = category(for: node.name, under: canonicalRoot)
+        var metadata = node.metadata
+        metadata.storageCategoryIdentifier = category.rawValue
+        metadata.explanation = explanation(
+            for: category,
+            name: node.name,
+            canonicalRoot: canonicalRoot
+        )
+        metadata.isUnusuallyLarge = node.allocatedSize >= largeAllocatedSizeThreshold
+        metadata.attributes[MetadataKey.directChildCount] = String(node.children.count)
+        metadata.attributes[MetadataKey.largeAllocatedSizeThreshold] = String(
+            largeAllocatedSizeThreshold
+        )
+        metadata.attributes[MetadataKey.virtualDiskImageCount] = String(
+            countVirtualDiskImages(in: node)
+        )
+        return copy(node, children: node.children, metadata: metadata)
+    }
+
+    static func enrichTreeMetadata(in node: StorageNode) -> StorageNode {
+        let children = node.children.map(enrichTreeMetadata)
+        var metadata = node.metadata
+        metadata.attributes[MetadataKey.sizeKnowledge] = sizeKnowledge(for: node).rawValue
+
+        if let format = virtualDiskFormat(for: node) {
+            metadata.attributes[MetadataKey.virtualDiskFormat] = format.rawValue
+            metadata.attributes[MetadataKey.virtualDiskSparseState] = sparseState(for: node).rawValue
+        }
+
+        return copy(node, children: children, metadata: metadata)
+    }
+
+    static func category(
+        for name: String,
+        under canonicalRoot: DeveloperSystemCanonicalRoot
+    ) -> DeveloperSystemStorageCategory {
+        switch (canonicalRoot, name) {
+        case (.opt, "homebrew"),
+             (.usrLocal, "Homebrew"),
+             (.usrLocal, "Cellar"),
+             (.usrLocal, "Caskroom"):
+            return .packageManagerStorage
+        case (.usrLocal, "bin"):
+            return .executableStorage
+        case (.usrLocal, "lib"):
+            return .libraryStorage
+        case (.usrLocal, "share"):
+            return .sharedResourceStorage
+        default:
+            return .unknown
+        }
+    }
+
+    static func explanation(
+        for category: DeveloperSystemStorageCategory,
+        name: String,
+        canonicalRoot: DeveloperSystemCanonicalRoot
+    ) -> String {
+        switch (canonicalRoot, name) {
+        case (.opt, "homebrew"):
+            return "Homebrew installation and package storage under /opt; no cleanup behavior is implied."
+        case (.usrLocal, "Homebrew"):
+            return "Homebrew installation and repository storage under /usr/local; no cleanup behavior is implied."
+        case (.usrLocal, "Cellar"):
+            return "Installed Homebrew formula versions; no cleanup behavior is implied."
+        case (.usrLocal, "Caskroom"):
+            return "Homebrew Cask installation storage; no cleanup behavior is implied."
+        default:
+            return category.explanation
+        }
+    }
+
+    static func rootState(
+        for root: StorageNode,
+        result: StorageAnalysisResult
+    ) -> DeveloperSystemRootState {
+        if result.wasCancelled || root.accessibility == .cancelled { return .cancelled }
+        if root.itemType != .directory, root.itemType != .unknown { return .invalid }
+        if root.itemType == .unknown,
+           root.scanIssues.contains(where: { $0.posixErrorCode == ENOENT }) {
+            return .missing
+        }
+
+        switch root.accessibility {
+        case .accessible: return .present
+        case .partiallyAccessible, .skippedDifferentVolume: return .partiallyReadable
+        case .inaccessible: return .inaccessible
+        case .cancelled: return .cancelled
+        }
+    }
+
+    static func sizeKnowledge(for node: StorageNode) -> DeveloperSystemSizeKnowledge {
+        switch node.accessibility {
+        case .accessible: return .complete
+        case .partiallyAccessible, .inaccessible: return .knownLowerBound
+        case .cancelled: return .incompleteDueToCancellation
+        case .skippedDifferentVolume: return .excludedDifferentVolume
+        }
+    }
+
+    static func combinedKnowledge(
+        opt: DeveloperSystemRootAnalysis,
+        usrLocal: DeveloperSystemRootAnalysis,
+        wasCancelled: Bool
+    ) -> DeveloperSystemSizeKnowledge {
+        if wasCancelled { return .incompleteDueToCancellation }
+        let states = [opt.state, usrLocal.state]
+        if states.contains(.inaccessible) || states.contains(.partiallyReadable) {
+            return .knownLowerBound
+        }
+        if states.contains(.invalid) { return .unavailable }
+        return .complete
+    }
+
+    static func rootSizeKnowledge(
+        for state: DeveloperSystemRootState
+    ) -> DeveloperSystemSizeKnowledge {
+        switch state {
+        case .present, .missing: return .complete
+        case .inaccessible, .partiallyReadable: return .knownLowerBound
+        case .invalid: return .unavailable
+        case .cancelled: return .incompleteDueToCancellation
+        }
+    }
+
+    private static func virtualDiskFormat(for node: StorageNode) -> VirtualDiskFormat? {
+        guard !node.isSymbolicLink,
+              node.itemType == .regularFile || node.itemType == .directory else {
+            return nil
+        }
+
+        switch URL(fileURLWithPath: node.absolutePath).pathExtension.lowercased() {
+        case "raw": return .raw
+        case "img": return .img
+        case "qcow2": return .qcow2
+        case "vmdk": return .vmdk
+        case "sparsebundle": return .sparseBundle
+        default: return nil
+        }
+    }
+
+    private static func sparseState(for node: StorageNode) -> SparseState {
+        guard node.itemType == .regularFile else { return .unknown }
+        return node.ownLogicalSize > node.ownAllocatedSize ? .sparse : .notSparse
+    }
+
+    static func countVirtualDiskImages(in root: StorageNode) -> Int {
+        var count = 0
+        var pending = [root]
+        while let node = pending.popLast() {
+            if virtualDiskFormat(for: node) != nil { count += 1 }
+            pending.append(contentsOf: node.children)
+        }
+        return count
+    }
+
+    static func allocatedSizeDescending(_ left: StorageNode, _ right: StorageNode) -> Bool {
+        if left.allocatedSize != right.allocatedSize {
+            return left.allocatedSize > right.allocatedSize
+        }
+        if left.logicalSize != right.logicalSize {
+            return left.logicalSize > right.logicalSize
+        }
+        return left.absolutePath < right.absolutePath
+    }
+
+    static func copy(
+        _ node: StorageNode,
+        children: [StorageNode],
+        accessibility: StorageAccessibility? = nil,
+        scanIssues: [StorageScanIssue]? = nil,
+        metadata: StorageAnalysisMetadata
+    ) -> StorageNode {
+        StorageNode(
+            name: node.name,
+            absolutePath: node.absolutePath,
+            logicalSize: node.logicalSize,
+            allocatedSize: node.allocatedSize,
+            ownLogicalSize: node.ownLogicalSize,
+            ownAllocatedSize: node.ownAllocatedSize,
+            itemType: node.itemType,
+            children: children,
+            accessibility: accessibility ?? node.accessibility,
+            scanIssues: scanIssues ?? node.scanIssues,
+            isHidden: node.isHidden,
+            isSymbolicLink: node.isSymbolicLink,
+            isCountedInParentTotals: node.isCountedInParentTotals,
+            metadata: metadata
+        )
+    }
+
+    static func issueSort(_ left: StorageScanIssue, _ right: StorageScanIssue) -> Bool {
+        if left.path != right.path { return left.path < right.path }
+        if left.kind != right.kind { return left.kind.rawValue < right.kind.rawValue }
+        return left.message < right.message
+    }
+}
+
+private extension Array where Element: Hashable {
+    func uniqued() -> [Element] {
+        var seen: Set<Element> = []
+        return filter { seen.insert($0).inserted }
+    }
+}

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/DeveloperSystemStorageAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/DeveloperSystemStorageAnalyzer.swift
@@ -117,17 +117,20 @@ struct DeveloperSystemStorageAnalyzer: Sendable {
     private let optURL: URL
     private let usrLocalURL: URL
     private let scanner: FileTreeScanner
+    private let cache: StorageAnalysisCache?
     private let largeAllocatedSizeThreshold: Int64
 
     init(
         optURL: URL = DeveloperSystemStorageAnalyzer.defaultOptURL,
         usrLocalURL: URL = DeveloperSystemStorageAnalyzer.defaultUsrLocalURL,
         scanner: FileTreeScanner = FileTreeScanner(),
+        cache: StorageAnalysisCache? = nil,
         largeAllocatedSizeThreshold: Int64 = DeveloperSystemStorageAnalyzer.defaultLargeAllocatedSizeThreshold
     ) {
         self.optURL = optURL
         self.usrLocalURL = usrLocalURL
         self.scanner = scanner
+        self.cache = cache
         self.largeAllocatedSizeThreshold = max(largeAllocatedSizeThreshold, 1)
     }
 
@@ -135,6 +138,8 @@ struct DeveloperSystemStorageAnalyzer: Sendable {
         let scan = await scanner.scanIndependentRoots([optURL, usrLocalURL])
         let optResult = scan.results[0]
         let usrLocalResult = scan.results[1]
+        cache?.store(optResult, isFullSubtree: true)
+        cache?.store(usrLocalResult, isFullSubtree: true)
         let threshold = largeAllocatedSizeThreshold
 
         return await Task.detached(priority: .utility) {

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/DockerStorageAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/DockerStorageAnalyzer.swift
@@ -50,10 +50,12 @@ struct DockerStorageAnalyzer: Sendable {
     private let scanner: FileTreeScanner
     private let executableLocator: ExecutableLocator
     private let commandRunner: CommandRunner
+    private let cache: StorageAnalysisCache?
 
     init(
         hostStorageRoots: [URL] = DockerStorageAnalyzer.currentUserHostStorageRoots,
         scanner: FileTreeScanner = FileTreeScanner(),
+        cache: StorageAnalysisCache? = nil,
         executableLocator: @escaping ExecutableLocator = {
             DockerStorageAnalyzer.discoverDockerExecutable()
         },
@@ -63,6 +65,7 @@ struct DockerStorageAnalyzer: Sendable {
     ) {
         self.hostStorageRoots = hostStorageRoots
         self.scanner = scanner
+        self.cache = cache
         self.executableLocator = executableLocator
         self.commandRunner = commandRunner
     }
@@ -73,7 +76,13 @@ struct DockerStorageAnalyzer: Sendable {
 
         for root in roots {
             guard !Task.isCancelled else { break }
-            hostResults.append(await scanner.scan(root: root))
+            if let cached = cache?.get(path: root.path) {
+                hostResults.append(cached)
+            } else {
+                let result = await scanner.scan(root: root)
+                cache?.store(result, isFullSubtree: true)
+                hostResults.append(result)
+            }
         }
 
         let hostFootprint = await Task.detached(priority: .utility) {

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/DockerStorageAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/DockerStorageAnalyzer.swift
@@ -1,0 +1,834 @@
+import Darwin
+import Foundation
+
+struct DockerCommandRequest: Equatable, Sendable {
+    let executableURL: URL
+    let arguments: [String]
+}
+
+struct DockerCommandResult: Equatable, Sendable {
+    let terminationStatus: Int32
+    let stdout: String
+    let stderr: String
+    let launchError: String?
+    let wasCancelled: Bool
+}
+
+/// Read-only analysis of Docker's host-side files and runtime-reported usage.
+///
+/// Host storage is scanned with `FileTreeScanner`. Runtime accounting is kept
+/// as a separate, non-additive view obtained from structured Docker CLI
+/// inspection commands. This analyzer has no dependency on `CleaningEngine`.
+struct DockerStorageAnalyzer: Sendable {
+    typealias ExecutableLocator = @Sendable () -> URL?
+    typealias CommandRunner = @Sendable (DockerCommandRequest) async -> DockerCommandResult
+
+    static let contextInspectionArguments = ["context", "inspect", "--format", "json"]
+    static let runtimeAccountingArguments = ["system", "df", "--format", "json"]
+
+    static var currentUserHostStorageRoots: [URL] {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let library = home.appendingPathComponent("Library", isDirectory: true)
+        return [
+            library
+                .appendingPathComponent("Containers", isDirectory: true)
+                .appendingPathComponent("com.docker.docker", isDirectory: true),
+            library
+                .appendingPathComponent("Group Containers", isDirectory: true)
+                .appendingPathComponent("group.com.docker", isDirectory: true),
+            library
+                .appendingPathComponent("Application Support", isDirectory: true)
+                .appendingPathComponent("Docker Desktop", isDirectory: true),
+            library
+                .appendingPathComponent("Application Support", isDirectory: true)
+                .appendingPathComponent("com.docker.docker", isDirectory: true),
+            home.appendingPathComponent(".docker", isDirectory: true),
+        ]
+    }
+
+    private let hostStorageRoots: [URL]
+    private let scanner: FileTreeScanner
+    private let executableLocator: ExecutableLocator
+    private let commandRunner: CommandRunner
+
+    init(
+        hostStorageRoots: [URL] = DockerStorageAnalyzer.currentUserHostStorageRoots,
+        scanner: FileTreeScanner = FileTreeScanner(),
+        executableLocator: @escaping ExecutableLocator = {
+            DockerStorageAnalyzer.discoverDockerExecutable()
+        },
+        commandRunner: @escaping CommandRunner = { request in
+            await DockerStorageAnalyzer.runReadOnlyCommand(request)
+        }
+    ) {
+        self.hostStorageRoots = hostStorageRoots
+        self.scanner = scanner
+        self.executableLocator = executableLocator
+        self.commandRunner = commandRunner
+    }
+
+    func analyze() async -> DockerStorageReport {
+        let roots = Self.existingNonOverlappingRoots(hostStorageRoots)
+        var hostResults: [StorageAnalysisResult] = []
+
+        for root in roots {
+            guard !Task.isCancelled else { break }
+            hostResults.append(await scanner.scan(root: root))
+        }
+
+        let hostFootprint = await Task.detached(priority: .utility) {
+            Self.makeHostFootprint(from: hostResults)
+        }.value
+        let virtualDisks = await Task.detached(priority: .utility) {
+            Self.findVirtualDisks(in: hostResults)
+        }.value
+        var issues = Self.filesystemIssues(from: hostResults)
+
+        guard !Task.isCancelled,
+              !hostResults.contains(where: \.wasCancelled) else {
+            issues.append(.init(
+                kind: .cancelled,
+                message: "Docker storage analysis was cancelled.",
+                path: nil
+            ))
+            return Self.report(
+                hostFootprint: hostFootprint,
+                virtualDisks: virtualDisks,
+                runtimeStatus: .cancelled,
+                runtimeAccounting: nil,
+                dockerExecutablePath: nil,
+                wasCancelled: true,
+                issues: issues
+            )
+        }
+
+        guard let executableURL = executableLocator() else {
+            issues.append(.init(
+                kind: .executableNotFound,
+                message: "Docker CLI was not found in a supported application or executable path.",
+                path: nil
+            ))
+            return Self.report(
+                hostFootprint: hostFootprint,
+                virtualDisks: virtualDisks,
+                runtimeStatus: .notInstalled,
+                runtimeAccounting: nil,
+                dockerExecutablePath: nil,
+                wasCancelled: false,
+                issues: issues
+            )
+        }
+
+        let contextCommandResult = await commandRunner(DockerCommandRequest(
+            executableURL: executableURL,
+            arguments: Self.contextInspectionArguments
+        ))
+
+        if Task.isCancelled || contextCommandResult.wasCancelled {
+            issues.append(.init(
+                kind: .cancelled,
+                message: "Docker context inspection was cancelled.",
+                path: nil
+            ))
+            return Self.report(
+                hostFootprint: hostFootprint,
+                virtualDisks: virtualDisks,
+                runtimeStatus: .cancelled,
+                runtimeAccounting: nil,
+                dockerExecutablePath: executableURL.path,
+                wasCancelled: true,
+                issues: issues
+            )
+        }
+
+        let contextInspection = Self.inspectRuntimeContext(contextCommandResult)
+        if let issue = contextInspection.issue {
+            issues.append(issue)
+        }
+
+        let commandResult = await commandRunner(DockerCommandRequest(
+            executableURL: executableURL,
+            arguments: Self.runtimeAccountingArguments
+        ))
+
+        if Task.isCancelled || commandResult.wasCancelled {
+            issues.append(.init(
+                kind: .cancelled,
+                message: "Docker runtime accounting was cancelled.",
+                path: nil
+            ))
+            return Self.report(
+                hostFootprint: hostFootprint,
+                virtualDisks: virtualDisks,
+                runtimeStatus: .cancelled,
+                runtimeAccounting: nil,
+                dockerExecutablePath: executableURL.path,
+                runtimeContext: contextInspection.context,
+                wasCancelled: true,
+                issues: issues
+            )
+        }
+
+        guard commandResult.launchError == nil, commandResult.terminationStatus == 0 else {
+            let detail = Self.commandFailureDetail(commandResult)
+            let daemonUnavailable = Self.indicatesUnavailableDaemon(detail)
+            issues.append(.init(
+                kind: daemonUnavailable ? .daemonUnavailable : .commandFailed,
+                message: detail,
+                path: nil
+            ))
+            return Self.report(
+                hostFootprint: hostFootprint,
+                virtualDisks: virtualDisks,
+                runtimeStatus: daemonUnavailable ? .installedDaemonUnavailable : .commandFailed,
+                runtimeAccounting: nil,
+                dockerExecutablePath: executableURL.path,
+                runtimeContext: contextInspection.context,
+                wasCancelled: false,
+                issues: issues
+            )
+        }
+
+        let parsed = Self.parseRuntimeAccounting(commandResult.stdout)
+        if parsed.isPartial {
+            issues.append(.init(
+                kind: .malformedRuntimeOutput,
+                message: "Docker returned incomplete or malformed structured storage accounting.",
+                path: nil
+            ))
+        }
+
+        return Self.report(
+            hostFootprint: hostFootprint,
+            virtualDisks: virtualDisks,
+            runtimeStatus: parsed.isPartial ? .partiallyReadable : .installedAndReachable,
+            runtimeAccounting: parsed.accounting,
+            dockerExecutablePath: executableURL.path,
+            runtimeContext: contextInspection.context,
+            wasCancelled: false,
+            issues: issues
+        )
+    }
+}
+
+// MARK: - Active Context Inspection
+
+private extension DockerStorageAnalyzer {
+    struct ContextInspectionResult {
+        let context: DockerRuntimeContext
+        let issue: DockerStorageIssue?
+    }
+
+    static func inspectRuntimeContext(
+        _ result: DockerCommandResult
+    ) -> ContextInspectionResult {
+        guard result.launchError == nil, result.terminationStatus == 0 else {
+            let detail = contextFailureDetail(result)
+            return ContextInspectionResult(
+                context: .unknown,
+                issue: DockerStorageIssue(
+                    kind: .contextInspectionFailed,
+                    message: detail,
+                    path: nil
+                )
+            )
+        }
+
+        guard let object = contextObject(from: result.stdout) else {
+            return ContextInspectionResult(
+                context: .unknown,
+                issue: DockerStorageIssue(
+                    kind: .contextInspectionFailed,
+                    message: "Docker returned malformed structured context information.",
+                    path: nil
+                )
+            )
+        }
+
+        let name = nonemptyString(caseInsensitiveValue(named: "Name", in: object))
+        let endpoints = caseInsensitiveValue(named: "Endpoints", in: object) as? [String: Any]
+        let dockerEndpoint = endpoints.flatMap { dictionary in
+            dictionary.first { $0.key.caseInsensitiveCompare("docker") == .orderedSame }?.value
+                as? [String: Any]
+        }
+        let rawEndpoint = dockerEndpoint.flatMap {
+            nonemptyString(caseInsensitiveValue(named: "Host", in: $0))
+        }
+        let location = rawEndpoint.map(runtimeLocation(for:)) ?? .unknown
+        let context = DockerRuntimeContext(
+            name: name,
+            sanitizedEndpoint: rawEndpoint.flatMap(sanitizeEndpoint),
+            location: location
+        )
+
+        guard location == .unknown else {
+            return ContextInspectionResult(context: context, issue: nil)
+        }
+        return ContextInspectionResult(
+            context: context,
+            issue: DockerStorageIssue(
+                kind: .runtimeLocationUnknown,
+                message: rawEndpoint == nil
+                    ? "The active Docker context did not provide a Docker endpoint."
+                    : "The active Docker endpoint could not be reliably classified as local or remote.",
+                path: nil
+            )
+        )
+    }
+
+    static func contextObject(from output: String) -> [String: Any]? {
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let data = trimmed.data(using: .utf8), !data.isEmpty,
+              let value = try? JSONSerialization.jsonObject(with: data) else {
+            return nil
+        }
+        if let object = value as? [String: Any] { return object }
+        if let objects = value as? [[String: Any]], objects.count == 1 {
+            return objects[0]
+        }
+        return nil
+    }
+
+    static func caseInsensitiveValue(
+        named name: String,
+        in dictionary: [String: Any]
+    ) -> Any? {
+        dictionary.first { $0.key.caseInsensitiveCompare(name) == .orderedSame }?.value
+    }
+
+    static func nonemptyString(_ value: Any?) -> String? {
+        guard let value = value as? String else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : String(trimmed.prefix(512))
+    }
+
+    static func runtimeLocation(for endpoint: String) -> DockerRuntimeLocation {
+        guard let components = URLComponents(string: endpoint),
+              let scheme = components.scheme?.lowercased() else {
+            return .unknown
+        }
+
+        switch scheme {
+        case "unix":
+            let host = components.host?.lowercased()
+            guard (host == nil || host == "" || host == "localhost"),
+                  components.path.hasPrefix("/") else {
+                return .unknown
+            }
+            return .local
+        case "ssh":
+            return .remote
+        case "tcp", "http", "https":
+            guard let host = components.host, !host.isEmpty else { return .unknown }
+            return isLoopbackHost(host) ? .unknown : .remote
+        default:
+            return .unknown
+        }
+    }
+
+    static func isLoopbackHost(_ host: String) -> Bool {
+        let normalized = host.lowercased()
+        return normalized == "localhost"
+            || normalized == "127.0.0.1"
+            || normalized == "::1"
+            || normalized.hasPrefix("127.")
+    }
+
+    static func sanitizeEndpoint(_ endpoint: String) -> String? {
+        guard let components = URLComponents(string: endpoint),
+              let scheme = components.scheme?.lowercased() else {
+            return "<unrecognized endpoint>"
+        }
+
+        if scheme == "unix" {
+            guard components.path.hasPrefix("/") else { return "unix://<redacted>" }
+            return "unix://\(sanitizeUnixSocketPath(components.path))"
+        }
+
+        guard let host = components.host, !host.isEmpty else {
+            return "\(scheme)://<redacted>"
+        }
+        let displayedHost = host.contains(":") ? "[\(host)]" : host
+        let port = components.port.map { ":\($0)" } ?? ""
+        return "\(scheme)://\(displayedHost)\(port)"
+    }
+
+    static func sanitizeUnixSocketPath(_ path: String) -> String {
+        let homePath = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
+        if path == homePath { return "~" }
+        if path.hasPrefix(homePath + "/") {
+            return "~/" + path.dropFirst(homePath.count + 1)
+        }
+
+        let components = path.split(separator: "/", omittingEmptySubsequences: true)
+        if components.count >= 2, components[0] == "Users" {
+            return "/Users/<redacted>/" + components.dropFirst(2).joined(separator: "/")
+        }
+        return path
+    }
+
+    static func relationship(
+        for location: DockerRuntimeLocation
+    ) -> DockerHostRuntimeRelationship {
+        switch location {
+        case .local: return .localRuntimeMayExplainHostFootprint
+        case .remote: return .remoteRuntimeNotRelatedToHostFootprint
+        case .unknown: return .unknownRelationship
+        }
+    }
+
+    static func contextFailureDetail(_ result: DockerCommandResult) -> String {
+        if result.launchError != nil {
+            return "Docker context inspection could not be launched."
+        }
+        return "Docker context inspection failed with exit status \(result.terminationStatus)."
+    }
+}
+
+// MARK: - Host Footprint
+
+private extension DockerStorageAnalyzer {
+    static func existingNonOverlappingRoots(_ candidates: [URL]) -> [URL] {
+        let uniquePaths = Set(candidates.map { $0.standardizedFileURL.path })
+        let existingPaths = uniquePaths.filter(pathExistsWithoutFollowingLinks)
+        let orderedPaths = existingPaths.sorted {
+            let leftDepth = $0.split(separator: "/").count
+            let rightDepth = $1.split(separator: "/").count
+            if leftDepth != rightDepth { return leftDepth < rightDepth }
+            return $0 < $1
+        }
+
+        var retained: [String] = []
+        for path in orderedPaths {
+            guard !retained.contains(where: { path == $0 || path.hasPrefix($0 + "/") }) else {
+                continue
+            }
+            retained.append(path)
+        }
+        return retained.sorted().map { URL(fileURLWithPath: $0) }
+    }
+
+    static func pathExistsWithoutFollowingLinks(_ path: String) -> Bool {
+        var metadata = stat()
+        return lstat(path, &metadata) == 0
+    }
+
+    static func makeHostFootprint(
+        from results: [StorageAnalysisResult]
+    ) -> DockerHostFootprint {
+        DockerHostFootprint(
+            locations: results.sorted { $0.root.absolutePath < $1.root.absolutePath },
+            logicalSize: results.reduce(0) { $0 + $1.root.logicalSize },
+            allocatedSize: results.reduce(0) { $0 + $1.root.allocatedSize }
+        )
+    }
+
+    static func filesystemIssues(
+        from results: [StorageAnalysisResult]
+    ) -> [DockerStorageIssue] {
+        results.flatMap(\.issues).map {
+            DockerStorageIssue(
+                kind: .filesystem,
+                message: $0.message,
+                path: $0.path
+            )
+        }
+    }
+
+    static func findVirtualDisks(
+        in results: [StorageAnalysisResult]
+    ) -> [DockerVirtualDisk] {
+        var disks: [DockerVirtualDisk] = []
+        var pending = results.map(\.root)
+
+        while let node = pending.popLast() {
+            if !node.isSymbolicLink,
+               let format = virtualDiskFormat(for: node) {
+                disks.append(DockerVirtualDisk(
+                    storageNode: node,
+                    format: format,
+                    sparseState: sparseState(for: node)
+                ))
+            }
+            pending.append(contentsOf: node.children)
+        }
+
+        return disks.sorted {
+            if $0.allocatedSize != $1.allocatedSize {
+                return $0.allocatedSize > $1.allocatedSize
+            }
+            if $0.logicalSize != $1.logicalSize {
+                return $0.logicalSize > $1.logicalSize
+            }
+            return $0.absolutePath < $1.absolutePath
+        }
+    }
+
+    static func virtualDiskFormat(for node: StorageNode) -> DockerVirtualDiskFormat? {
+        guard node.itemType == .regularFile || node.itemType == .directory else {
+            return nil
+        }
+
+        switch URL(fileURLWithPath: node.absolutePath).pathExtension.lowercased() {
+        case "raw": return .raw
+        case "img": return .img
+        case "qcow2": return .qcow2
+        case "vmdk": return .vmdk
+        case "sparsebundle": return .sparseBundle
+        default: return node.name.localizedCaseInsensitiveCompare("Docker.raw") == .orderedSame
+            ? .raw
+            : nil
+        }
+    }
+
+    static func sparseState(for node: StorageNode) -> DockerSparseState {
+        guard node.itemType == .regularFile else { return .unknown }
+        return node.logicalSize > node.allocatedSize ? .sparse : .notSparse
+    }
+}
+
+// MARK: - Runtime Parsing
+
+private extension DockerStorageAnalyzer {
+    struct RuntimeParseResult {
+        let accounting: DockerRuntimeAccounting?
+        let isPartial: Bool
+    }
+
+    struct ReclaimableValue {
+        let bytes: Int64?
+        let percentage: Double?
+    }
+
+    static func parseRuntimeAccounting(_ output: String) -> RuntimeParseResult {
+        let decoded = decodeJSONObjects(output)
+        var usages: [DockerRuntimeStorageCategory: DockerRuntimeStorageUsage] = [:]
+        var hadMalformedEntry = decoded.malformedCount > 0
+
+        for object in decoded.objects {
+            guard let usage = runtimeUsage(from: object) else {
+                hadMalformedEntry = true
+                continue
+            }
+            if usages[usage.category] != nil {
+                hadMalformedEntry = true
+            } else {
+                usages[usage.category] = usage
+            }
+        }
+
+        guard !usages.isEmpty else {
+            return RuntimeParseResult(accounting: nil, isPartial: true)
+        }
+
+        let accounting = DockerRuntimeAccounting(
+            images: usages[.images],
+            containers: usages[.containers],
+            localVolumes: usages[.localVolumes],
+            buildCache: usages[.buildCache]
+        )
+        return RuntimeParseResult(
+            accounting: accounting,
+            isPartial: hadMalformedEntry || !accounting.isComplete
+        )
+    }
+
+    static func decodeJSONObjects(
+        _ output: String
+    ) -> (objects: [[String: Any]], malformedCount: Int) {
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return ([], 1) }
+
+        if let data = trimmed.data(using: .utf8),
+           let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] {
+            return (array, 0)
+        }
+        if let data = trimmed.data(using: .utf8),
+           let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            return ([object], 0)
+        }
+
+        var objects: [[String: Any]] = []
+        var malformedCount = 0
+        for line in trimmed.split(whereSeparator: \.isNewline) {
+            guard let data = String(line).data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                malformedCount += 1
+                continue
+            }
+            objects.append(object)
+        }
+        return (objects, malformedCount)
+    }
+
+    static func runtimeUsage(from object: [String: Any]) -> DockerRuntimeStorageUsage? {
+        let values = Dictionary(uniqueKeysWithValues: object.map { ($0.key.lowercased(), $0.value) })
+        guard let type = values["type"] as? String,
+              let category = runtimeCategory(type) else {
+            return nil
+        }
+
+        let reclaimable = parseReclaimable(values["reclaimable"])
+        return DockerRuntimeStorageUsage(
+            category: category,
+            totalBytes: parseByteValue(values["size"]),
+            reclaimableBytes: reclaimable.bytes,
+            reclaimablePercentage: reclaimable.percentage,
+            objectCount: parseInteger(values["totalcount"]),
+            activeCount: parseInteger(values["active"])
+        )
+    }
+
+    static func runtimeCategory(_ type: String) -> DockerRuntimeStorageCategory? {
+        switch type.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "images": return .images
+        case "containers": return .containers
+        case "local volumes", "volumes": return .localVolumes
+        case "build cache", "buildcache": return .buildCache
+        default: return nil
+        }
+    }
+
+    static func parseReclaimable(_ value: Any?) -> ReclaimableValue {
+        guard let value else { return ReclaimableValue(bytes: nil, percentage: nil) }
+        if let number = value as? NSNumber {
+            return ReclaimableValue(bytes: number.int64Value, percentage: nil)
+        }
+        guard let text = value as? String else {
+            return ReclaimableValue(bytes: nil, percentage: nil)
+        }
+
+        let byteText = text.split(separator: "(", maxSplits: 1).first.map(String.init) ?? text
+        let percentage: Double? = {
+            guard let open = text.firstIndex(of: "("),
+                  let close = text[open...].firstIndex(of: ")") else {
+                return nil
+            }
+            let raw = text[text.index(after: open)..<close]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .replacingOccurrences(of: "%", with: "")
+            return Double(raw)
+        }()
+        return ReclaimableValue(bytes: parseHumanBytes(byteText), percentage: percentage)
+    }
+
+    static func parseByteValue(_ value: Any?) -> Int64? {
+        if let number = value as? NSNumber { return number.int64Value }
+        if let text = value as? String { return parseHumanBytes(text) }
+        return nil
+    }
+
+    static func parseInteger(_ value: Any?) -> Int? {
+        if let number = value as? NSNumber { return number.intValue }
+        if let text = value as? String { return Int(text.trimmingCharacters(in: .whitespaces)) }
+        return nil
+    }
+
+    static func parseHumanBytes(_ value: String) -> Int64? {
+        let normalized = value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: " ", with: "")
+        guard !normalized.isEmpty else { return nil }
+
+        let units: [(suffix: String, multiplier: Double)] = [
+            ("PiB", 1_125_899_906_842_624),
+            ("TiB", 1_099_511_627_776),
+            ("GiB", 1_073_741_824),
+            ("MiB", 1_048_576),
+            ("KiB", 1_024),
+            ("PB", 1_000_000_000_000_000),
+            ("TB", 1_000_000_000_000),
+            ("GB", 1_000_000_000),
+            ("MB", 1_000_000),
+            ("kB", 1_000),
+            ("B", 1),
+        ]
+        for unit in units where normalized.lowercased().hasSuffix(unit.suffix.lowercased()) {
+            let numberText = String(normalized.dropLast(unit.suffix.count))
+            guard let number = Double(numberText), number >= 0 else { return nil }
+            let bytes = number * unit.multiplier
+            guard bytes <= Double(Int64.max) else { return nil }
+            return Int64(bytes)
+        }
+        return nil
+    }
+}
+
+// MARK: - Executable Discovery and Read-Only Process Execution
+
+extension DockerStorageAnalyzer {
+    static func discoverDockerExecutable(
+        fileManager: FileManager = .default,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL? {
+        var candidatePaths = [
+            "/usr/local/bin/docker",
+            "/opt/homebrew/bin/docker",
+            "/Applications/Docker.app/Contents/Resources/bin/docker",
+            "/Applications/OrbStack.app/Contents/MacOS/xbin/docker",
+        ]
+        if let path = environment["PATH"] {
+            candidatePaths.append(contentsOf: path.split(separator: ":").compactMap { directory in
+                guard directory.hasPrefix("/") else { return nil }
+                return URL(fileURLWithPath: String(directory), isDirectory: true)
+                    .appendingPathComponent("docker", isDirectory: false)
+                    .path
+            })
+        }
+
+        var visited = Set<String>()
+        for path in candidatePaths {
+            let standardizedPath = URL(fileURLWithPath: path).standardizedFileURL.path
+            guard visited.insert(standardizedPath).inserted,
+                  fileManager.isExecutableFile(atPath: standardizedPath) else {
+                continue
+            }
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: standardizedPath, isDirectory: &isDirectory),
+                  !isDirectory.boolValue else {
+                continue
+            }
+            return URL(fileURLWithPath: standardizedPath).resolvingSymlinksInPath()
+        }
+        return nil
+    }
+
+    static func runReadOnlyCommand(_ request: DockerCommandRequest) async -> DockerCommandResult {
+        let cancellation = DockerProcessCancellationState()
+        let worker = Task.detached(priority: .utility) {
+            let process = Process()
+            process.executableURL = request.executableURL
+            process.arguments = request.arguments
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+            process.standardOutput = stdoutPipe
+            process.standardError = stderrPipe
+
+            guard cancellation.register(process) else {
+                return DockerCommandResult(
+                    terminationStatus: -1,
+                    stdout: "",
+                    stderr: "",
+                    launchError: nil,
+                    wasCancelled: true
+                )
+            }
+
+            do {
+                try process.run()
+            } catch {
+                return DockerCommandResult(
+                    terminationStatus: -1,
+                    stdout: "",
+                    stderr: "",
+                    launchError: error.localizedDescription,
+                    wasCancelled: cancellation.isCancelled
+                )
+            }
+
+            cancellation.terminateIfCancelled()
+            let stdoutTask = Task.detached {
+                stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+            }
+            let stderrTask = Task.detached {
+                stderrPipe.fileHandleForReading.readDataToEndOfFile()
+            }
+            process.waitUntilExit()
+            let stdoutData = await stdoutTask.value
+            let stderrData = await stderrTask.value
+
+            return DockerCommandResult(
+                terminationStatus: process.terminationStatus,
+                stdout: String(data: stdoutData, encoding: .utf8) ?? "",
+                stderr: String(data: stderrData, encoding: .utf8) ?? "",
+                launchError: nil,
+                wasCancelled: cancellation.isCancelled
+            )
+        }
+
+        return await withTaskCancellationHandler {
+            await worker.value
+        } onCancel: {
+            cancellation.cancel()
+        }
+    }
+}
+
+private extension DockerStorageAnalyzer {
+    static func report(
+        hostFootprint: DockerHostFootprint,
+        virtualDisks: [DockerVirtualDisk],
+        runtimeStatus: DockerRuntimeStatus,
+        runtimeAccounting: DockerRuntimeAccounting?,
+        dockerExecutablePath: String?,
+        runtimeContext: DockerRuntimeContext = .unknown,
+        wasCancelled: Bool,
+        issues: [DockerStorageIssue]
+    ) -> DockerStorageReport {
+        DockerStorageReport(
+            hostFootprint: hostFootprint,
+            virtualDisks: virtualDisks,
+            runtimeStatus: runtimeStatus,
+            runtimeAccounting: runtimeAccounting,
+            dockerExecutablePath: dockerExecutablePath,
+            runtimeContext: runtimeContext,
+            hostRuntimeRelationship: relationship(for: runtimeContext.location),
+            accountingRelationship: .runtimeBreakdownIsNonAdditiveToHostFootprint,
+            wasCancelled: wasCancelled,
+            issues: issues
+        )
+    }
+
+    static func commandFailureDetail(_ result: DockerCommandResult) -> String {
+        let candidate = result.launchError ?? (result.stderr.isEmpty ? result.stdout : result.stderr)
+        let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            return "Docker storage inspection failed with exit status \(result.terminationStatus)."
+        }
+        return String(trimmed.prefix(1_024))
+    }
+
+    static func indicatesUnavailableDaemon(_ detail: String) -> Bool {
+        let normalized = detail.lowercased()
+        return normalized.contains("cannot connect")
+            || normalized.contains("daemon is not running")
+            || normalized.contains("is the docker daemon running")
+            || normalized.contains("connection refused")
+            || normalized.contains("dial unix")
+    }
+}
+
+private final class DockerProcessCancellationState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var process: Process?
+    private var cancelled = false
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+
+    func register(_ process: Process) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !cancelled else { return false }
+        self.process = process
+        return true
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        let runningProcess = process?.isRunning == true ? process : nil
+        lock.unlock()
+        runningProcess?.terminate()
+    }
+
+    func terminateIfCancelled() {
+        lock.lock()
+        let runningProcess = cancelled && process?.isRunning == true ? process : nil
+        lock.unlock()
+        runningProcess?.terminate()
+    }
+}

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/GroupContainersAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/GroupContainersAnalyzer.swift
@@ -33,17 +33,20 @@ struct GroupContainersAnalyzer: Sendable {
 
     private let groupContainersURL: URL
     private let scanner: FileTreeScanner
+    private let cache: StorageAnalysisCache?
     private let largeAllocatedSizeThreshold: Int64
     private let attributionProvider: AttributionProvider
 
     init(
         groupContainersURL: URL = GroupContainersAnalyzer.currentUserGroupContainersURL,
         scanner: FileTreeScanner = FileTreeScanner(),
+        cache: StorageAnalysisCache? = nil,
         largeAllocatedSizeThreshold: Int64 = GroupContainersAnalyzer.defaultLargeAllocatedSizeThreshold
     ) {
         self.init(
             groupContainersURL: groupContainersURL,
             scanner: scanner,
+            cache: cache,
             largeAllocatedSizeThreshold: largeAllocatedSizeThreshold,
             attributionProvider: { _ in [] }
         )
@@ -52,11 +55,13 @@ struct GroupContainersAnalyzer: Sendable {
     init(
         groupContainersURL: URL,
         scanner: FileTreeScanner = FileTreeScanner(),
+        cache: StorageAnalysisCache? = nil,
         largeAllocatedSizeThreshold: Int64 = GroupContainersAnalyzer.defaultLargeAllocatedSizeThreshold,
         attributionProvider: @escaping AttributionProvider
     ) {
         self.groupContainersURL = groupContainersURL
         self.scanner = scanner
+        self.cache = cache
         self.largeAllocatedSizeThreshold = max(largeAllocatedSizeThreshold, 1)
         self.attributionProvider = attributionProvider
     }
@@ -65,7 +70,14 @@ struct GroupContainersAnalyzer: Sendable {
     /// Containers ordered for storage inspection. No cleanup semantics or
     /// filesystem mutation are introduced by this analyzer.
     func analyze() async -> StorageAnalysisResult {
-        let scannedResult = await scanner.scan(root: groupContainersURL)
+        let scannedResult: StorageAnalysisResult
+        if let cached = cache?.get(path: groupContainersURL.path) {
+            scannedResult = cached
+        } else {
+            let result = await scanner.scan(root: groupContainersURL)
+            cache?.store(result, isFullSubtree: true)
+            scannedResult = result
+        }
         let threshold = largeAllocatedSizeThreshold
         let attributionProvider = attributionProvider
 

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/GroupContainersAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/GroupContainersAnalyzer.swift
@@ -1,0 +1,285 @@
+import Foundation
+
+/// Read-only analysis of the current user's `~/Library/Group Containers`.
+///
+/// `FileTreeScanner` remains responsible for traversal, byte accounting,
+/// volume boundaries, links, errors, and cancellation. This analyzer only
+/// adds shared-container metadata and presentation ordering to that tree.
+struct GroupContainersAnalyzer: Sendable {
+    /// Supplies relationships established by a reliable source, such as a
+    /// future entitlement index. Directory-name similarity is not evidence.
+    typealias AttributionProvider = @Sendable (String) -> [StorageApplicationOwner]
+
+    enum MetadataKey {
+        static let directChildCount = "groupContainers.directChildCount"
+        static let groupIdentifierSource = "groupContainers.identifierSource"
+        static let largeAllocatedSizeThreshold = "groupContainers.largeAllocatedSizeThreshold"
+        static let ownerCount = "groupContainers.ownerCount"
+        static let virtualDiskImageCount = "groupContainers.virtualDiskImageCount"
+    }
+
+    static let storageCategoryIdentifier = "group-containers"
+    static let defaultLargeAllocatedSizeThreshold: Int64 = 1_073_741_824
+
+    static var currentUserGroupContainersURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Group Containers", isDirectory: true)
+    }
+
+    private static let virtualDiskImageExtensions: Set<String> = [
+        "img", "qcow2", "raw", "sparsebundle", "vmdk",
+    ]
+
+    private let groupContainersURL: URL
+    private let scanner: FileTreeScanner
+    private let largeAllocatedSizeThreshold: Int64
+    private let attributionProvider: AttributionProvider
+
+    init(
+        groupContainersURL: URL = GroupContainersAnalyzer.currentUserGroupContainersURL,
+        scanner: FileTreeScanner = FileTreeScanner(),
+        largeAllocatedSizeThreshold: Int64 = GroupContainersAnalyzer.defaultLargeAllocatedSizeThreshold
+    ) {
+        self.init(
+            groupContainersURL: groupContainersURL,
+            scanner: scanner,
+            largeAllocatedSizeThreshold: largeAllocatedSizeThreshold,
+            attributionProvider: { _ in [] }
+        )
+    }
+
+    init(
+        groupContainersURL: URL,
+        scanner: FileTreeScanner = FileTreeScanner(),
+        largeAllocatedSizeThreshold: Int64 = GroupContainersAnalyzer.defaultLargeAllocatedSizeThreshold,
+        attributionProvider: @escaping AttributionProvider
+    ) {
+        self.groupContainersURL = groupContainersURL
+        self.scanner = scanner
+        self.largeAllocatedSizeThreshold = max(largeAllocatedSizeThreshold, 1)
+        self.attributionProvider = attributionProvider
+    }
+
+    /// Returns the scanner's complete hierarchy with immediate Group
+    /// Containers ordered for storage inspection. No cleanup semantics or
+    /// filesystem mutation are introduced by this analyzer.
+    func analyze() async -> StorageAnalysisResult {
+        let scannedResult = await scanner.scan(root: groupContainersURL)
+        let threshold = largeAllocatedSizeThreshold
+        let attributionProvider = attributionProvider
+
+        return await Task.detached(priority: .utility) {
+            Self.enrich(
+                scannedResult,
+                largeAllocatedSizeThreshold: threshold,
+                attributionProvider: attributionProvider
+            )
+        }.value
+    }
+}
+
+// MARK: - Result Enrichment
+
+private extension GroupContainersAnalyzer {
+    static func enrich(
+        _ result: StorageAnalysisResult,
+        largeAllocatedSizeThreshold: Int64,
+        attributionProvider: AttributionProvider
+    ) -> StorageAnalysisResult {
+        let groupContainers = result.root.children
+            .map {
+                enrichGroupContainer(
+                    $0,
+                    largeAllocatedSizeThreshold: largeAllocatedSizeThreshold,
+                    attributionProvider: attributionProvider
+                )
+            }
+            .sorted(by: allocatedSizeDescending)
+
+        var rootAttributes = result.root.metadata.attributes
+        rootAttributes[MetadataKey.directChildCount] = String(groupContainers.count)
+
+        let rootMetadata = StorageAnalysisMetadata(
+            bundleIdentifier: result.root.metadata.bundleIdentifier,
+            groupContainerIdentifier: result.root.metadata.groupContainerIdentifier,
+            owningApplicationIdentifier: result.root.metadata.owningApplicationIdentifier,
+            owningApplicationName: result.root.metadata.owningApplicationName,
+            owningApplications: result.root.metadata.owningApplications,
+            storageCategoryIdentifier: storageCategoryIdentifier,
+            safetyClassificationIdentifier: result.root.metadata.safetyClassificationIdentifier,
+            confidence: result.root.metadata.confidence,
+            isUnusuallyLarge: result.root.metadata.isUnusuallyLarge,
+            explanation: "Shared application data in the current user's Group Containers directory.",
+            attributes: rootAttributes
+        )
+
+        let root = copy(result.root, children: groupContainers, metadata: rootMetadata)
+        return StorageAnalysisResult(
+            root: root,
+            startedAt: result.startedAt,
+            completedAt: result.completedAt,
+            rootDeviceIdentifier: result.rootDeviceIdentifier,
+            wasCancelled: result.wasCancelled,
+            issues: result.issues
+        )
+    }
+
+    static func enrichGroupContainer(
+        _ node: StorageNode,
+        largeAllocatedSizeThreshold: Int64,
+        attributionProvider: AttributionProvider
+    ) -> StorageNode {
+        let identifier = groupContainerIdentifierCandidate(for: node)
+        let owners = identifier
+            .map(attributionProvider)
+            .map(normalizedOwners) ?? []
+        let virtualDiskImageCount = countVirtualDiskImages(in: node)
+
+        var attributes = node.metadata.attributes
+        attributes[MetadataKey.directChildCount] = String(node.children.count)
+        attributes[MetadataKey.largeAllocatedSizeThreshold] = String(largeAllocatedSizeThreshold)
+        attributes[MetadataKey.ownerCount] = String(owners.count)
+        attributes[MetadataKey.virtualDiskImageCount] = String(virtualDiskImageCount)
+        if let identifier {
+            attributes[MetadataKey.groupIdentifierSource] = identifierSource(identifier)
+        }
+
+        let explanation: String
+        if !owners.isEmpty {
+            let ownerNames = owners.map { $0.displayName ?? $0.bundleIdentifier }
+            explanation = "Shared application data used by \(ownerNames.joined(separator: ", "))."
+        } else if let identifier {
+            explanation = "Shared application data for \(identifier); application ownership is unresolved."
+        } else {
+            explanation = "Shared application data; the container identifier and application ownership are unresolved."
+        }
+
+        let metadata = StorageAnalysisMetadata(
+            bundleIdentifier: nil,
+            groupContainerIdentifier: identifier,
+            owningApplicationIdentifier: nil,
+            owningApplicationName: nil,
+            owningApplications: owners.isEmpty ? nil : owners,
+            storageCategoryIdentifier: storageCategoryIdentifier,
+            safetyClassificationIdentifier: node.metadata.safetyClassificationIdentifier,
+            confidence: owners.isEmpty ? nil : 1,
+            isUnusuallyLarge: node.allocatedSize >= largeAllocatedSizeThreshold,
+            explanation: explanation,
+            attributes: attributes
+        )
+
+        return copy(node, children: node.children, metadata: metadata)
+    }
+
+    static func normalizedOwners(
+        _ owners: [StorageApplicationOwner]
+    ) -> [StorageApplicationOwner] {
+        var ownersByIdentifier: [String: StorageApplicationOwner] = [:]
+        for owner in owners where isEntitlementIdentifier(owner.bundleIdentifier) {
+            if ownersByIdentifier[owner.bundleIdentifier] == nil {
+                ownersByIdentifier[owner.bundleIdentifier] = owner
+            }
+        }
+        return ownersByIdentifier.values.sorted {
+            if $0.bundleIdentifier != $1.bundleIdentifier {
+                return $0.bundleIdentifier < $1.bundleIdentifier
+            }
+            return ($0.displayName ?? "") < ($1.displayName ?? "")
+        }
+    }
+
+    static func groupContainerIdentifierCandidate(for node: StorageNode) -> String? {
+        guard node.itemType == .directory || node.itemType == .volumeBoundary,
+              isEntitlementIdentifier(node.name) else {
+            return nil
+        }
+        return node.name
+    }
+
+    static func copy(
+        _ node: StorageNode,
+        children: [StorageNode],
+        metadata: StorageAnalysisMetadata
+    ) -> StorageNode {
+        StorageNode(
+            name: node.name,
+            absolutePath: node.absolutePath,
+            logicalSize: node.logicalSize,
+            allocatedSize: node.allocatedSize,
+            ownLogicalSize: node.ownLogicalSize,
+            ownAllocatedSize: node.ownAllocatedSize,
+            itemType: node.itemType,
+            children: children,
+            accessibility: node.accessibility,
+            scanIssues: node.scanIssues,
+            isHidden: node.isHidden,
+            isSymbolicLink: node.isSymbolicLink,
+            isCountedInParentTotals: node.isCountedInParentTotals,
+            metadata: metadata
+        )
+    }
+
+    static func allocatedSizeDescending(_ left: StorageNode, _ right: StorageNode) -> Bool {
+        if left.allocatedSize != right.allocatedSize {
+            return left.allocatedSize > right.allocatedSize
+        }
+        if left.logicalSize != right.logicalSize {
+            return left.logicalSize > right.logicalSize
+        }
+        return left.absolutePath < right.absolutePath
+    }
+
+    static func countVirtualDiskImages(in root: StorageNode) -> Int {
+        var count = 0
+        var pending = [root]
+        while let node = pending.popLast() {
+            let pathExtension = URL(fileURLWithPath: node.absolutePath).pathExtension.lowercased()
+            if virtualDiskImageExtensions.contains(pathExtension) {
+                count += 1
+            }
+            pending.append(contentsOf: node.children)
+        }
+        return count
+    }
+}
+
+// MARK: - Identifier Recognition
+
+private extension GroupContainersAnalyzer {
+    static func isEntitlementIdentifier(_ value: String) -> Bool {
+        let components = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard components.count >= 2, components.allSatisfy({ !$0.isEmpty }) else {
+            return false
+        }
+
+        let allowedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-"))
+        guard components.allSatisfy({ component in
+            component.unicodeScalars.allSatisfy { allowedCharacters.contains($0) }
+        }) else {
+            return false
+        }
+
+        if components[0] == "group" {
+            return components.count >= 3
+        }
+        return true
+    }
+
+    static func identifierSource(_ identifier: String) -> String {
+        let firstComponent = identifier.split(separator: ".", omittingEmptySubsequences: false)[0]
+        if firstComponent == "group" {
+            return "group-prefix-directory-name"
+        }
+        if isAppleTeamIdentifier(firstComponent) {
+            return "team-id-prefix-directory-name"
+        }
+        return "entitlement-style-directory-name"
+    }
+
+    static func isAppleTeamIdentifier(_ component: Substring) -> Bool {
+        guard component.count == 10 else { return false }
+        let allowedCharacters = CharacterSet.uppercaseLetters.union(.decimalDigits)
+        return component.unicodeScalars.allSatisfy { allowedCharacters.contains($0) }
+    }
+}

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/PrivateStorageAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/PrivateStorageAnalyzer.swift
@@ -112,20 +112,30 @@ struct PrivateStorageAnalyzer: Sendable {
 
     private let privateURL: URL
     private let scanner: FileTreeScanner
+    private let cache: StorageAnalysisCache?
     private let largeAllocatedSizeThreshold: Int64
 
     init(
         privateURL: URL = PrivateStorageAnalyzer.defaultPrivateURL,
         scanner: FileTreeScanner = FileTreeScanner(),
+        cache: StorageAnalysisCache? = nil,
         largeAllocatedSizeThreshold: Int64 = PrivateStorageAnalyzer.defaultLargeAllocatedSizeThreshold
     ) {
         self.privateURL = privateURL
         self.scanner = scanner
+        self.cache = cache
         self.largeAllocatedSizeThreshold = max(largeAllocatedSizeThreshold, 1)
     }
 
     func analyze() async -> StorageAnalysisResult {
-        let scannedResult = await scanner.scan(root: privateURL)
+        let scannedResult: StorageAnalysisResult
+        if let cached = cache?.get(path: privateURL.path) {
+            scannedResult = cached
+        } else {
+            let result = await scanner.scan(root: privateURL)
+            cache?.store(result, isFullSubtree: true)
+            scannedResult = result
+        }
         let threshold = largeAllocatedSizeThreshold
 
         return await Task.detached(priority: .utility) {

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/PrivateStorageAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/PrivateStorageAnalyzer.swift
@@ -1,0 +1,400 @@
+import Darwin
+import Foundation
+
+/// Explanatory categories for `/private` and the immediate children of
+/// `/private/var`. These labels describe storage purpose only and have no
+/// cleanup or deletion meaning.
+enum PrivateStorageCategory: String, Codable, CaseIterable, Sendable {
+    case variableState = "private.var"
+    case temporary = "private.tmp"
+    case configuration = "private.etc"
+    case otherTopLevel = "private.other"
+    case varFolders = "private.var.folders"
+    case varVirtualMemory = "private.var.vm"
+    case varDatabases = "private.var.db"
+    case varLogs = "private.var.log"
+    case varTemporary = "private.var.tmp"
+    case varRuntime = "private.var.run"
+    case varRoot = "private.var.root"
+    case varProtected = "private.var.protected"
+    case varAudit = "private.var.audit"
+    case otherVarChild = "private.var.other"
+
+    var explanation: String {
+        switch self {
+        case .variableState:
+            return "Persistent and temporary state managed by macOS, services, and applications."
+        case .temporary:
+            return "System-wide temporary storage; this label does not imply that its contents are currently disposable."
+        case .configuration:
+            return "System-wide configuration and service settings."
+        case .otherTopLevel:
+            return "Other storage directly inside /private."
+        case .varFolders:
+            return "Per-user and per-process caches, temporary files, application state, and other macOS-managed data."
+        case .varVirtualMemory:
+            return "Protected system-managed virtual-memory and swap-related storage."
+        case .varDatabases:
+            return "Protected databases and state maintained by macOS and system-wide services."
+        case .varLogs:
+            return "System and service logs represented for storage attribution only."
+        case .varTemporary:
+            return "Temporary files used by system services and applications; no cleanup behavior is implied."
+        case .varRuntime:
+            return "Runtime state used by system services and background processes."
+        case .varRoot:
+            return "Protected state belonging to the system administrator account."
+        case .varProtected:
+            return "Protected system and application state governed by macOS access controls."
+        case .varAudit:
+            return "Protected security and audit records maintained by macOS."
+        case .otherVarChild:
+            return "Other system or application state directly inside /private/var."
+        }
+    }
+}
+
+/// Informational handling context for a private-storage node. This is
+/// deliberately separate from cleanup safety classifications.
+enum PrivateStorageManagementKind: String, Codable, Sendable {
+    case systemManaged
+    case protectedSystemState
+    case temporaryStorage
+    case applicationAndSystemState
+    case systemConfiguration
+    case unclassified
+}
+
+/// Whether a numeric subtree total is complete. Incomplete totals are known
+/// lower bounds: unreadable descendants are never estimated or represented as
+/// known zero-byte storage.
+enum PrivateStorageSizeKnowledge: String, Codable, Sendable {
+    case complete
+    case incompleteDueToInaccessibility
+    case incompleteDueToCancellation
+    case excludedDifferentVolume
+}
+
+/// Read-only analysis of the canonical `/private` filesystem tree.
+///
+/// `FileTreeScanner` owns traversal, physical/logical accounting, hard-link
+/// deduplication, symlink handling, volume boundaries, and scan issues. This
+/// analyzer only enriches the resulting nodes for future storage explanation.
+struct PrivateStorageAnalyzer: Sendable {
+    enum MetadataKey {
+        static let directChildCount = "privateStorage.directChildCount"
+        static let largeAllocatedSizeThreshold = "privateStorage.largeAllocatedSizeThreshold"
+        static let virtualDiskImageCount = "privateStorage.virtualDiskImageCount"
+        static let virtualDiskFormat = "privateStorage.virtualDiskFormat"
+        static let virtualDiskSparseState = "privateStorage.virtualDiskSparseState"
+        static let managementKind = "privateStorage.managementKind"
+        static let sizeKnowledge = "privateStorage.sizeKnowledge"
+        static let canonicalUserFacingPath = "privateStorage.canonicalUserFacingPath"
+    }
+
+    static let storageCategoryIdentifier = "private-storage"
+    static let defaultLargeAllocatedSizeThreshold: Int64 = 1_073_741_824
+    static let defaultPrivateURL = URL(fileURLWithPath: "/private", isDirectory: true)
+
+    private enum VirtualDiskFormat: String {
+        case raw
+        case img
+        case qcow2
+        case vmdk
+        case sparseBundle = "sparsebundle"
+    }
+
+    private enum SparseState: String {
+        case sparse
+        case notSparse = "not-sparse"
+        case unknown
+    }
+
+    private let privateURL: URL
+    private let scanner: FileTreeScanner
+    private let largeAllocatedSizeThreshold: Int64
+
+    init(
+        privateURL: URL = PrivateStorageAnalyzer.defaultPrivateURL,
+        scanner: FileTreeScanner = FileTreeScanner(),
+        largeAllocatedSizeThreshold: Int64 = PrivateStorageAnalyzer.defaultLargeAllocatedSizeThreshold
+    ) {
+        self.privateURL = privateURL
+        self.scanner = scanner
+        self.largeAllocatedSizeThreshold = max(largeAllocatedSizeThreshold, 1)
+    }
+
+    func analyze() async -> StorageAnalysisResult {
+        let scannedResult = await scanner.scan(root: privateURL)
+        let threshold = largeAllocatedSizeThreshold
+
+        return await Task.detached(priority: .utility) {
+            Self.enrich(
+                scannedResult,
+                largeAllocatedSizeThreshold: threshold
+            )
+        }.value
+    }
+}
+
+// Internal for a volume-boundary regression test that must not create a
+// privileged test mount.
+extension PrivateStorageAnalyzer {
+    static func enrich(
+        _ result: StorageAnalysisResult,
+        largeAllocatedSizeThreshold: Int64
+    ) -> StorageAnalysisResult {
+        var root = result.root
+        var issues = result.issues
+
+        if root.itemType != .directory, root.itemType != .unknown {
+            let issue = StorageScanIssue(
+                path: root.absolutePath,
+                kind: .notDirectory,
+                message: "Private storage analysis requires a directory root.",
+                posixErrorCode: ENOTDIR
+            )
+            var rootIssues = root.scanIssues
+            if !rootIssues.contains(issue) { rootIssues.append(issue) }
+            if !issues.contains(issue) { issues.append(issue) }
+            root = copy(
+                root,
+                children: root.children,
+                accessibility: .inaccessible,
+                scanIssues: rootIssues,
+                metadata: root.metadata
+            )
+        }
+
+        root = enrichTreeMetadata(in: root)
+        let entries = root.children
+            .map {
+                enrichTopLevelChild(
+                    $0,
+                    largeAllocatedSizeThreshold: largeAllocatedSizeThreshold
+                )
+            }
+            .sorted(by: allocatedSizeDescending)
+
+        var rootMetadata = root.metadata
+        rootMetadata.storageCategoryIdentifier = storageCategoryIdentifier
+        rootMetadata.explanation = "Critical system and application storage in /private."
+        rootMetadata.attributes[MetadataKey.directChildCount] = String(entries.count)
+        rootMetadata.attributes[MetadataKey.canonicalUserFacingPath] = root.absolutePath
+        rootMetadata.attributes[MetadataKey.managementKind] = PrivateStorageManagementKind.systemManaged.rawValue
+
+        root = copy(root, children: entries, metadata: rootMetadata)
+        return StorageAnalysisResult(
+            root: root,
+            startedAt: result.startedAt,
+            completedAt: result.completedAt,
+            rootDeviceIdentifier: result.rootDeviceIdentifier,
+            wasCancelled: result.wasCancelled,
+            issues: issues.sorted(by: issueSort)
+        )
+    }
+}
+
+// MARK: - Category and Tree Enrichment
+
+private extension PrivateStorageAnalyzer {
+    static func enrichTopLevelChild(
+        _ node: StorageNode,
+        largeAllocatedSizeThreshold: Int64
+    ) -> StorageNode {
+        let category = topLevelCategory(for: node)
+        var children = node.children
+        if category == .variableState {
+            children = children
+                .map {
+                    enrichVarChild(
+                        $0,
+                        largeAllocatedSizeThreshold: largeAllocatedSizeThreshold
+                    )
+                }
+                .sorted(by: allocatedSizeDescending)
+        }
+
+        let withDrillDown = copy(node, children: children, metadata: node.metadata)
+        return addCategoryMetadata(
+            to: withDrillDown,
+            category: category,
+            managementKind: managementKind(for: category),
+            largeAllocatedSizeThreshold: largeAllocatedSizeThreshold
+        )
+    }
+
+    static func enrichVarChild(
+        _ node: StorageNode,
+        largeAllocatedSizeThreshold: Int64
+    ) -> StorageNode {
+        let category = varCategory(for: node)
+        return addCategoryMetadata(
+            to: node,
+            category: category,
+            managementKind: managementKind(for: category),
+            largeAllocatedSizeThreshold: largeAllocatedSizeThreshold
+        )
+    }
+
+    static func addCategoryMetadata(
+        to node: StorageNode,
+        category: PrivateStorageCategory,
+        managementKind: PrivateStorageManagementKind,
+        largeAllocatedSizeThreshold: Int64
+    ) -> StorageNode {
+        var metadata = node.metadata
+        metadata.storageCategoryIdentifier = category.rawValue
+        metadata.isUnusuallyLarge = node.allocatedSize >= largeAllocatedSizeThreshold
+        metadata.explanation = category.explanation
+        metadata.attributes[MetadataKey.directChildCount] = String(node.children.count)
+        metadata.attributes[MetadataKey.largeAllocatedSizeThreshold] = String(largeAllocatedSizeThreshold)
+        metadata.attributes[MetadataKey.virtualDiskImageCount] = String(countVirtualDiskImages(in: node))
+        metadata.attributes[MetadataKey.managementKind] = managementKind.rawValue
+        return copy(node, children: node.children, metadata: metadata)
+    }
+
+    static func enrichTreeMetadata(in node: StorageNode) -> StorageNode {
+        let children = node.children.map(enrichTreeMetadata)
+        var metadata = node.metadata
+        metadata.attributes[MetadataKey.sizeKnowledge] = sizeKnowledge(for: node.accessibility).rawValue
+
+        if let format = virtualDiskFormat(for: node) {
+            metadata.attributes[MetadataKey.virtualDiskFormat] = format.rawValue
+            metadata.attributes[MetadataKey.virtualDiskSparseState] = sparseState(for: node).rawValue
+        }
+
+        return copy(node, children: children, metadata: metadata)
+    }
+
+    static func topLevelCategory(for node: StorageNode) -> PrivateStorageCategory {
+        guard node.itemType == .directory || node.itemType == .volumeBoundary else {
+            return .otherTopLevel
+        }
+        switch node.name {
+        case "var": return .variableState
+        case "tmp": return .temporary
+        case "etc": return .configuration
+        default: return .otherTopLevel
+        }
+    }
+
+    static func varCategory(for node: StorageNode) -> PrivateStorageCategory {
+        guard node.itemType == .directory || node.itemType == .volumeBoundary else {
+            return .otherVarChild
+        }
+        switch node.name {
+        case "folders": return .varFolders
+        case "vm": return .varVirtualMemory
+        case "db": return .varDatabases
+        case "log": return .varLogs
+        case "tmp": return .varTemporary
+        case "run": return .varRuntime
+        case "root": return .varRoot
+        case "protected": return .varProtected
+        case "audit": return .varAudit
+        default: return .otherVarChild
+        }
+    }
+
+    static func managementKind(
+        for category: PrivateStorageCategory
+    ) -> PrivateStorageManagementKind {
+        switch category {
+        case .variableState, .varFolders:
+            return .applicationAndSystemState
+        case .temporary, .varTemporary:
+            return .temporaryStorage
+        case .configuration:
+            return .systemConfiguration
+        case .varVirtualMemory, .varDatabases, .varRoot, .varProtected, .varAudit:
+            return .protectedSystemState
+        case .varLogs, .varRuntime:
+            return .systemManaged
+        case .otherTopLevel, .otherVarChild:
+            return .unclassified
+        }
+    }
+
+    static func sizeKnowledge(
+        for accessibility: StorageAccessibility
+    ) -> PrivateStorageSizeKnowledge {
+        switch accessibility {
+        case .accessible: return .complete
+        case .partiallyAccessible, .inaccessible: return .incompleteDueToInaccessibility
+        case .cancelled: return .incompleteDueToCancellation
+        case .skippedDifferentVolume: return .excludedDifferentVolume
+        }
+    }
+
+    private static func virtualDiskFormat(for node: StorageNode) -> VirtualDiskFormat? {
+        guard !node.isSymbolicLink,
+              node.itemType == .regularFile || node.itemType == .directory else {
+            return nil
+        }
+        switch URL(fileURLWithPath: node.absolutePath).pathExtension.lowercased() {
+        case "raw": return .raw
+        case "img": return .img
+        case "qcow2": return .qcow2
+        case "vmdk": return .vmdk
+        case "sparsebundle": return .sparseBundle
+        default: return nil
+        }
+    }
+
+    private static func sparseState(for node: StorageNode) -> SparseState {
+        guard node.itemType == .regularFile else { return .unknown }
+        return node.ownLogicalSize > node.ownAllocatedSize ? .sparse : .notSparse
+    }
+
+    static func countVirtualDiskImages(in root: StorageNode) -> Int {
+        var count = 0
+        var pending = [root]
+        while let node = pending.popLast() {
+            if virtualDiskFormat(for: node) != nil { count += 1 }
+            pending.append(contentsOf: node.children)
+        }
+        return count
+    }
+
+    static func allocatedSizeDescending(_ left: StorageNode, _ right: StorageNode) -> Bool {
+        if left.allocatedSize != right.allocatedSize {
+            return left.allocatedSize > right.allocatedSize
+        }
+        if left.logicalSize != right.logicalSize {
+            return left.logicalSize > right.logicalSize
+        }
+        return left.absolutePath < right.absolutePath
+    }
+
+    static func copy(
+        _ node: StorageNode,
+        children: [StorageNode],
+        accessibility: StorageAccessibility? = nil,
+        scanIssues: [StorageScanIssue]? = nil,
+        metadata: StorageAnalysisMetadata
+    ) -> StorageNode {
+        StorageNode(
+            name: node.name,
+            absolutePath: node.absolutePath,
+            logicalSize: node.logicalSize,
+            allocatedSize: node.allocatedSize,
+            ownLogicalSize: node.ownLogicalSize,
+            ownAllocatedSize: node.ownAllocatedSize,
+            itemType: node.itemType,
+            children: children,
+            accessibility: accessibility ?? node.accessibility,
+            scanIssues: scanIssues ?? node.scanIssues,
+            isHidden: node.isHidden,
+            isSymbolicLink: node.isSymbolicLink,
+            isCountedInParentTotals: node.isCountedInParentTotals,
+            metadata: metadata
+        )
+    }
+
+    static func issueSort(_ left: StorageScanIssue, _ right: StorageScanIssue) -> Bool {
+        if left.path != right.path { return left.path < right.path }
+        if left.kind != right.kind { return left.kind.rawValue < right.kind.rawValue }
+        return left.message < right.message
+    }
+}

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/StorageAttributionAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/StorageAttributionAnalyzer.swift
@@ -1,0 +1,513 @@
+import Darwin
+import Foundation
+
+/// Read-only analyzer that attributes the composition of the writable Data volume
+/// and explains the remaining unexplained storage gap at the Data-volume / APFS level.
+struct StorageAttributionAnalyzer: Sendable {
+    static let defaultDataVolumeURL = URL(fileURLWithPath: "/System/Volumes/Data", isDirectory: true)
+    static let defaultVMDirectoryURL = URL(fileURLWithPath: "/private/var/vm", isDirectory: true)
+
+    private let dataVolumeURL: URL
+    private let vmDirectoryURL: URL
+
+    init(
+        dataVolumeURL: URL = StorageAttributionAnalyzer.defaultDataVolumeURL,
+        vmDirectoryURL: URL = StorageAttributionAnalyzer.defaultVMDirectoryURL
+    ) {
+        self.dataVolumeURL = dataVolumeURL.standardizedFileURL
+        self.vmDirectoryURL = vmDirectoryURL.standardizedFileURL
+    }
+
+    func analyze(
+        reconciliationReport: StorageReconciliationReport
+    ) async -> StorageUnexplainedAttributionReport {
+        guard !Task.isCancelled else {
+            return .empty
+        }
+
+        let volumeUsed = reconciliationReport.usedCapacityBytes
+        let explained = reconciliationReport.explainedAllocatedBytes
+        let unexplained = reconciliationReport.unexplainedBytes
+
+        // 1. Data-volume top-level root attribution
+        let dataVolumeRoots = inspectDataVolumeRoots(reconciliationReport: reconciliationReport)
+
+        // 2. System-managed storage inspection (VM, Swap, Sleep Image)
+        let vmInspection = inspectVirtualMemory()
+
+        // 3. APFS snapshots and purgeable info
+        let snapshots = reconciliationReport.analyzerResults.apfsStorage?.snapshots ?? []
+        let snapshotFootprint = snapshots.reduce(Int64(0)) { $0 + ($1.size ?? 0) }
+        let purgeable = reconciliationReport.purgeableEstimateBytes
+
+        // 4. Build attribution items
+        let attributionItems = buildAttributionItems(
+            reconciliationReport: reconciliationReport,
+            vmInspection: vmInspection,
+            dataVolumeRoots: dataVolumeRoots,
+            snapshotFootprint: snapshotFootprint > 0 ? snapshotFootprint : nil,
+            purgeableEstimate: purgeable,
+            unexplained: unexplained
+        )
+
+        // 5. Calculate residual truly unattributed storage
+        let residual = calculateResidual(
+            unexplained: unexplained,
+            attributionItems: attributionItems
+        )
+
+        return StorageUnexplainedAttributionReport(
+            volumeUsedBytes: volumeUsed,
+            explainedAllocatedBytes: explained,
+            unexplainedBytes: unexplained,
+            residualUnattributedBytes: residual,
+            dataVolumeRoots: dataVolumeRoots,
+            attributionItems: attributionItems,
+            vmFootprintBytes: vmInspection.totalVMBytes,
+            sleepImageBytes: vmInspection.sleepImageBytes,
+            snapshotFootprintBytes: snapshotFootprint > 0 ? snapshotFootprint : nil,
+            purgeableEstimateBytes: purgeable,
+            wasCancelled: reconciliationReport.wasCancelled || Task.isCancelled,
+            issues: []
+        )
+    }
+
+    // MARK: - Data-Volume Root Inspection
+
+    private func inspectDataVolumeRoots(
+        reconciliationReport: StorageReconciliationReport
+    ) -> [DataVolumeRootAttribution] {
+        let fileManager = FileManager.default
+        let dataVolumePath = dataVolumeURL.path
+
+        var dataVolumeDeviceID: dev_t = 0
+        var statBuf = stat()
+        if stat(dataVolumePath, &statBuf) == 0 {
+            dataVolumeDeviceID = statBuf.st_dev
+        }
+
+        guard let enumerator = try? fileManager.contentsOfDirectory(
+            at: dataVolumeURL,
+            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey, .fileSizeKey, .totalFileAllocatedSizeKey],
+            options: []
+        ) else {
+            return defaultStandardRoots(reconciliationReport: reconciliationReport)
+        }
+
+        var results: [DataVolumeRootAttribution] = []
+
+        for itemURL in enumerator {
+            let originalPath = itemURL.path
+            let name = itemURL.lastPathComponent
+            let normalizedPath = StoragePathNormalizer.normalize(originalPath)
+
+            var entryStat = stat()
+            let statResult = lstat(originalPath, &entryStat)
+            let isSymlink = statResult == 0 && ((entryStat.st_mode & S_IFMT) == S_IFLNK)
+            let isDifferentVolume = statResult == 0 && dataVolumeDeviceID != 0 && entryStat.st_dev != dataVolumeDeviceID
+
+            let isProtected = StoragePathNormalizer.isSystemProtectedLocation(originalPath)
+                || StoragePathNormalizer.isSystemProtectedLocation(normalizedPath)
+                || name == ".DocumentRevisions-V100"
+                || name == ".Spotlight-V100"
+                || name == ".fseventsd"
+                || name == ".PKInstallSandboxManager"
+                || name == ".PKInstallSandboxManager-SystemSoftware"
+
+            let matchingContributions = reconciliationReport.filesystemContributions.filter {
+                $0.normalizedPath == normalizedPath || StoragePathNormalizer.contains(parent: normalizedPath, child: $0.normalizedPath)
+            }
+            let uniqueBytes = matchingContributions
+                .filter { $0.relationship == .canonicalUnique || $0.relationship == .externalSpecializedUnique }
+                .reduce(Int64(0)) { $0 + $1.accountedAllocatedBytes }
+            let observedBytes = matchingContributions.reduce(Int64(0)) { $0 + $1.observedAllocatedBytes }
+
+            let (owner, stage) = identifyOwner(name: name, normalizedPath: normalizedPath)
+
+            let classification: DataVolumeRegionClassification
+            let explanation: String
+
+            if isSymlink {
+                classification = .intentionallyExcluded
+                explanation = "Symbolic link pointing to a system location; contents are not traversed to avoid duplication."
+            } else if isDifferentVolume {
+                classification = .separateVolumeOrMount
+                explanation = "Mount point or separate filesystem volume; isolated from Data-volume ledger."
+            } else if isProtected && uniqueBytes == 0 && observedBytes == 0 {
+                classification = .protectedUnreadable
+                explanation = "Protected macOS system directory governed by System Integrity Protection (SIP) and privacy controls."
+            } else if uniqueBytes > 0 {
+                if owner == .additionalCoverageGap {
+                    classification = .measuredByCoverageExpansion
+                    explanation = "Discovered and measured during the storage coverage expansion pass."
+                } else {
+                    classification = .ownedByExistingAnalyzer
+                    explanation = "Measured and accounted for by PureMac specialized storage analyzers."
+                }
+            } else if observedBytes > 0 {
+                classification = .partiallyMeasured
+                explanation = "Partially measured; some subpaths were excluded or owned by higher-level canonical roots."
+            } else if isProtected {
+                classification = .protectedUnreadable
+                explanation = "Protected macOS location with restricted filesystem access."
+            } else {
+                classification = .unknown
+                explanation = "Unattributed Data-volume root entry."
+            }
+
+            results.append(DataVolumeRootAttribution(
+                originalPath: originalPath,
+                normalizedPath: normalizedPath,
+                name: name,
+                classification: classification,
+                canonicalOwner: owner,
+                analyzerStage: stage,
+                allocatedBytes: uniqueBytes > 0 ? uniqueBytes : (observedBytes > 0 ? observedBytes : nil),
+                logicalBytes: nil,
+                isFilesystemAdditive: classification == .ownedByExistingAnalyzer || classification == .measuredByCoverageExpansion,
+                statusExplanation: explanation,
+                isProtectedSystem: isProtected
+            ))
+        }
+
+        // Add standard firmlinked top-level roots if they were not directly present in enumerator
+        let existingNormalized = Set(results.map(\.normalizedPath))
+        let standardEntries: [(name: String, path: String, owner: StorageCanonicalRoot, stage: StorageAnalyzerStage)] = [
+            ("Users", "/Users", .userHomeVisibleStorage, .userHomeStorage),
+            ("Library", "/Library", .systemLibrary, .systemLibrary),
+            ("private", "/private", .privateStorage, .privateStorage),
+            ("opt", "/opt", .opt, .developerSystemStorage),
+            ("usr/local", "/usr/local", .usrLocal, .developerSystemStorage),
+        ]
+
+        for entry in standardEntries where !existingNormalized.contains(entry.path) {
+            let matchingContributions = reconciliationReport.filesystemContributions.filter {
+                $0.normalizedPath == entry.path || StoragePathNormalizer.contains(parent: entry.path, child: $0.normalizedPath)
+            }
+            let uniqueBytes = matchingContributions
+                .filter { $0.relationship == .canonicalUnique || $0.relationship == .externalSpecializedUnique }
+                .reduce(Int64(0)) { $0 + $1.accountedAllocatedBytes }
+
+            results.append(DataVolumeRootAttribution(
+                originalPath: entry.path,
+                normalizedPath: entry.path,
+                name: entry.name,
+                classification: uniqueBytes > 0 ? .ownedByExistingAnalyzer : .unknown,
+                canonicalOwner: entry.owner,
+                analyzerStage: entry.stage,
+                allocatedBytes: uniqueBytes > 0 ? uniqueBytes : nil,
+                logicalBytes: nil,
+                isFilesystemAdditive: true,
+                statusExplanation: "Canonical macOS firmlink root on the writable Data volume.",
+                isProtectedSystem: false
+            ))
+        }
+
+        return results.sorted { ($0.allocatedBytes ?? 0) > ($1.allocatedBytes ?? 0) }
+    }
+
+    private func identifyOwner(
+        name: String,
+        normalizedPath: String
+    ) -> (StorageCanonicalRoot?, StorageAnalyzerStage?) {
+        switch normalizedPath {
+        case "/Users":
+            return (.userHomeVisibleStorage, .userHomeStorage)
+        case "/Library":
+            return (.systemLibrary, .systemLibrary)
+        case "/Library/Application Support":
+            return (.applicationSupport, .applicationSupport)
+        case "/private":
+            return (.privateStorage, .privateStorage)
+        case "/opt":
+            return (.opt, .developerSystemStorage)
+        case "/usr/local":
+            return (.usrLocal, .developerSystemStorage)
+        default:
+            break
+        }
+
+        if normalizedPath.hasPrefix("/System/Volumes/Data/.") || normalizedPath.hasPrefix("/.") {
+            return (.dataVolumeHiddenStorage, .dataVolumeHiddenStorage)
+        }
+        if normalizedPath.hasPrefix("/private") {
+            return (.privateStorage, .privateStorage)
+        }
+        if normalizedPath.hasPrefix("/Library") {
+            return (.systemLibrary, .systemLibrary)
+        }
+        if normalizedPath.hasPrefix("/Users") {
+            return (.userHomeVisibleStorage, .userHomeStorage)
+        }
+        return (.additionalCoverageGap, .coverageExpansion)
+    }
+
+    private func defaultStandardRoots(
+        reconciliationReport: StorageReconciliationReport
+    ) -> [DataVolumeRootAttribution] {
+        let standardEntries: [(name: String, path: String, owner: StorageCanonicalRoot, stage: StorageAnalyzerStage)] = [
+            ("Users", "/Users", .userHomeVisibleStorage, .userHomeStorage),
+            ("Library", "/Library", .systemLibrary, .systemLibrary),
+            ("private", "/private", .privateStorage, .privateStorage),
+            ("opt", "/opt", .opt, .developerSystemStorage),
+            ("usr/local", "/usr/local", .usrLocal, .developerSystemStorage),
+            ("Hidden Data Roots", "/System/Volumes/Data", .dataVolumeHiddenStorage, .dataVolumeHiddenStorage)
+        ]
+
+        return standardEntries.map { entry in
+            let matchingContributions = reconciliationReport.filesystemContributions.filter {
+                $0.normalizedPath == entry.path || StoragePathNormalizer.contains(parent: entry.path, child: $0.normalizedPath)
+            }
+            let uniqueBytes = matchingContributions
+                .filter { $0.relationship == .canonicalUnique || $0.relationship == .externalSpecializedUnique }
+                .reduce(Int64(0)) { $0 + $1.accountedAllocatedBytes }
+
+            return DataVolumeRootAttribution(
+                originalPath: entry.path,
+                normalizedPath: entry.path,
+                name: entry.name,
+                classification: uniqueBytes > 0 ? .ownedByExistingAnalyzer : .unknown,
+                canonicalOwner: entry.owner,
+                analyzerStage: entry.stage,
+                allocatedBytes: uniqueBytes > 0 ? uniqueBytes : nil,
+                logicalBytes: nil,
+                isFilesystemAdditive: true,
+                statusExplanation: "Canonical macOS root on Data volume.",
+                isProtectedSystem: false
+            )
+        }
+    }
+
+    // MARK: - System-Managed Storage Inspection (VM / Swap / Sleep Image)
+
+    private struct VMInspectionResult {
+        let totalVMBytes: Int64?
+        let swapBytes: Int64?
+        let sleepImageBytes: Int64?
+        let hasVMDirectory: Bool
+    }
+
+    private func inspectVirtualMemory() -> VMInspectionResult {
+        let vmPath = vmDirectoryURL.path
+        var totalBytes: Int64 = 0
+        var swapBytes: Int64 = 0
+        var sleepImageBytes: Int64 = 0
+        var foundEntries = false
+
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: vmDirectoryURL,
+            includingPropertiesForKeys: [.fileSizeKey, .totalFileAllocatedSizeKey],
+            options: []
+        ) else {
+            // Check direct stat of /private/var/vm/sleepimage if directory enumeration is restricted
+            let sleepImageURL = vmDirectoryURL.appendingPathComponent("sleepimage")
+            var sleepStat = stat()
+            if stat(sleepImageURL.path, &sleepStat) == 0 {
+                let bytes = Int64(sleepStat.st_blocks) * 512
+                return VMInspectionResult(
+                    totalVMBytes: bytes,
+                    swapBytes: nil,
+                    sleepImageBytes: bytes,
+                    hasVMDirectory: true
+                )
+            }
+            return VMInspectionResult(totalVMBytes: nil, swapBytes: nil, sleepImageBytes: nil, hasVMDirectory: false)
+        }
+
+        for item in entries {
+            foundEntries = true
+            let name = item.lastPathComponent
+            var itemStat = stat()
+            if lstat(item.path, &itemStat) == 0 {
+                let allocated = Int64(itemStat.st_blocks) * 512
+                totalBytes += allocated
+                if name.hasPrefix("swapfile") {
+                    swapBytes += allocated
+                } else if name == "sleepimage" {
+                    sleepImageBytes += allocated
+                }
+            }
+        }
+
+        return VMInspectionResult(
+            totalVMBytes: foundEntries ? totalBytes : nil,
+            swapBytes: swapBytes > 0 ? swapBytes : nil,
+            sleepImageBytes: sleepImageBytes > 0 ? sleepImageBytes : nil,
+            hasVMDirectory: true
+        )
+    }
+
+    // MARK: - Attribution Items Builder
+
+    private func buildAttributionItems(
+        reconciliationReport: StorageReconciliationReport,
+        vmInspection: VMInspectionResult,
+        dataVolumeRoots: [DataVolumeRootAttribution],
+        snapshotFootprint: Int64?,
+        purgeableEstimate: Int64?,
+        unexplained: Int64?
+    ) -> [StorageAttributionItem] {
+        var items: [StorageAttributionItem] = []
+
+        // Category 1: Measured Gaps (from Coverage Expansion)
+        if let coverageReport = reconciliationReport.analyzerResults.coverageExpansion {
+            for candidate in coverageReport.largestDiscoveredRegions where candidate.status == .measured {
+                items.append(StorageAttributionItem(
+                    id: "gap:\(candidate.normalizedPath)",
+                    category: .measuredGaps,
+                    name: candidate.name,
+                    path: candidate.normalizedPath,
+                    status: .measured,
+                    allocatedBytes: candidate.allocatedBytes,
+                    explanation: "Discovered and measured by storage coverage expansion (\(candidate.scope.rawValue)).",
+                    isFilesystemAdditive: true
+                ))
+            }
+        }
+
+        // Category 2: Protected System Storage
+        let protectedRoots = dataVolumeRoots.filter { $0.isProtectedSystem }
+        for root in protectedRoots {
+            items.append(StorageAttributionItem(
+                id: "protected:\(root.normalizedPath)",
+                category: .protectedSystemStorage,
+                name: root.name,
+                path: root.normalizedPath,
+                status: root.allocatedBytes != nil ? .partial : .protectedUnreadable,
+                allocatedBytes: root.allocatedBytes,
+                explanation: root.statusExplanation,
+                isFilesystemAdditive: root.isFilesystemAdditive
+            ))
+        }
+
+        // Add prominent protected system subdirectories if known
+        let protectedSubpaths: [(name: String, path: String, reason: String)] = [
+            ("Audit Logs", "/private/var/audit", "Protected macOS security audit logs (EACCES/SIP)."),
+            ("System Administrator State", "/private/var/root", "Protected root user state (EACCES/SIP)."),
+            ("System Databases", "/private/var/db", "Protected macOS system databases and metadata."),
+            ("Document Versions", "/System/Volumes/Data/.DocumentRevisions-V100", "macOS document revision history database."),
+            ("Spotlight Index", "/System/Volumes/Data/.Spotlight-V100", "System-wide search and indexing database."),
+            ("Filesystem Events", "/System/Volumes/Data/.fseventsd", "macOS filesystem change logs.")
+        ]
+        let existingItemPaths = Set(items.compactMap(\.path))
+        for subpath in protectedSubpaths where !existingItemPaths.contains(subpath.path) {
+            let matchingContributions = reconciliationReport.filesystemContributions.filter {
+                $0.normalizedPath == subpath.path || StoragePathNormalizer.contains(parent: subpath.path, child: $0.normalizedPath)
+            }
+            let uniqueBytes = matchingContributions
+                .filter { $0.relationship == .canonicalUnique || $0.relationship == .externalSpecializedUnique }
+                .reduce(Int64(0)) { $0 + $1.accountedAllocatedBytes }
+            let observedBytes = matchingContributions.reduce(Int64(0)) { $0 + $1.observedAllocatedBytes }
+
+            items.append(StorageAttributionItem(
+                id: "protected:\(subpath.path)",
+                category: .protectedSystemStorage,
+                name: subpath.name,
+                path: subpath.path,
+                status: uniqueBytes > 0 ? .partial : .protectedUnreadable,
+                allocatedBytes: uniqueBytes > 0 ? uniqueBytes : (observedBytes > 0 ? observedBytes : nil),
+                explanation: subpath.reason,
+                isFilesystemAdditive: uniqueBytes > 0
+            ))
+        }
+
+        // Category 3: System-Managed Storage (Virtual Memory, Sleep Image, Caches)
+        if let swapBytes = vmInspection.swapBytes {
+            items.append(StorageAttributionItem(
+                id: "system:var-vm-swap",
+                category: .systemManagedStorage,
+                name: "Virtual Memory Swap",
+                path: "/private/var/vm/swapfile*",
+                status: .measured,
+                allocatedBytes: swapBytes,
+                explanation: "Active macOS virtual memory swap files allocated on disk.",
+                isFilesystemAdditive: false
+            ))
+        }
+        if let sleepBytes = vmInspection.sleepImageBytes {
+            items.append(StorageAttributionItem(
+                id: "system:var-vm-sleepimage",
+                category: .systemManagedStorage,
+                name: "Sleep Image",
+                path: "/private/var/vm/sleepimage",
+                status: .measured,
+                allocatedBytes: sleepBytes,
+                explanation: "Hibernation image written by macOS when the Mac goes to sleep.",
+                isFilesystemAdditive: false
+            ))
+        }
+        if let totalVM = vmInspection.totalVMBytes, vmInspection.swapBytes == nil && vmInspection.sleepImageBytes == nil {
+            items.append(StorageAttributionItem(
+                id: "system:var-vm",
+                category: .systemManagedStorage,
+                name: "Virtual Memory (/private/var/vm)",
+                path: "/private/var/vm",
+                status: .measured,
+                allocatedBytes: totalVM,
+                explanation: "macOS virtual memory swap and sleep image directory.",
+                isFilesystemAdditive: false
+            ))
+        }
+
+        // Category 4: APFS & Non-Additive Factors
+        if let snapshotFootprint {
+            items.append(StorageAttributionItem(
+                id: "apfs:snapshots",
+                category: .apfsAndNonAdditive,
+                name: "APFS Local Snapshots",
+                path: nil,
+                status: .nonAdditive,
+                allocatedBytes: snapshotFootprint,
+                explanation: "Time Machine and OS update snapshots; copy-on-write data shares blocks with the live volume.",
+                isFilesystemAdditive: false
+            ))
+        }
+        if let purgeableEstimate {
+            items.append(StorageAttributionItem(
+                id: "apfs:purgeable",
+                category: .apfsAndNonAdditive,
+                name: "Purgeable Capacity",
+                path: nil,
+                status: .estimate,
+                allocatedBytes: purgeableEstimate,
+                explanation: "Estimated disk capacity that macOS can reclaim automatically when space is needed.",
+                isFilesystemAdditive: false
+            ))
+        }
+        items.append(StorageAttributionItem(
+            id: "apfs:shared-extents",
+            category: .apfsAndNonAdditive,
+            name: "APFS Shared Extents & Metadata",
+            path: nil,
+            status: .nonAdditive,
+            allocatedBytes: nil,
+            explanation: "APFS block cloning, extent sharing, and container filesystem metadata overhead.",
+            isFilesystemAdditive: false
+        ))
+
+        // Category 5: Still Unattributed
+        let residual = calculateResidual(unexplained: unexplained, attributionItems: items)
+        if let residual, residual > 0 {
+            items.append(StorageAttributionItem(
+                id: "unexplained:residual",
+                category: .stillUnattributed,
+                name: "Unattributed Residual",
+                path: nil,
+                status: .unknown,
+                allocatedBytes: residual,
+                explanation: "Remaining volume storage not yet attributed by measured or evidenced categories.",
+                isFilesystemAdditive: false
+            ))
+        }
+
+        return items
+    }
+
+    private func calculateResidual(
+        unexplained: Int64?,
+        attributionItems: [StorageAttributionItem]
+    ) -> Int64? {
+        guard let unexplained else { return nil }
+        return max(unexplained, 0)
+    }
+}

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/StorageAttributionAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/StorageAttributionAnalyzer.swift
@@ -173,6 +173,7 @@ struct StorageAttributionAnalyzer: Sendable {
         // Add standard firmlinked top-level roots if they were not directly present in enumerator
         let existingNormalized = Set(results.map(\.normalizedPath))
         let standardEntries: [(name: String, path: String, owner: StorageCanonicalRoot, stage: StorageAnalyzerStage)] = [
+            ("Applications", "/Applications", .applications, .applications),
             ("Users", "/Users", .userHomeVisibleStorage, .userHomeStorage),
             ("Library", "/Library", .systemLibrary, .systemLibrary),
             ("private", "/private", .privateStorage, .privateStorage),
@@ -211,6 +212,8 @@ struct StorageAttributionAnalyzer: Sendable {
         normalizedPath: String
     ) -> (StorageCanonicalRoot?, StorageAnalyzerStage?) {
         switch normalizedPath {
+        case "/Applications":
+            return (.applications, .applications)
         case "/Users":
             return (.userHomeVisibleStorage, .userHomeStorage)
         case "/Library":
@@ -230,6 +233,9 @@ struct StorageAttributionAnalyzer: Sendable {
         if normalizedPath.hasPrefix("/System/Volumes/Data/.") || normalizedPath.hasPrefix("/.") {
             return (.dataVolumeHiddenStorage, .dataVolumeHiddenStorage)
         }
+        if normalizedPath.hasPrefix("/Applications") {
+            return (.applications, .applications)
+        }
         if normalizedPath.hasPrefix("/private") {
             return (.privateStorage, .privateStorage)
         }
@@ -246,6 +252,7 @@ struct StorageAttributionAnalyzer: Sendable {
         reconciliationReport: StorageReconciliationReport
     ) -> [DataVolumeRootAttribution] {
         let standardEntries: [(name: String, path: String, owner: StorageCanonicalRoot, stage: StorageAnalyzerStage)] = [
+            ("Applications", "/Applications", .applications, .applications),
             ("Users", "/Users", .userHomeVisibleStorage, .userHomeStorage),
             ("Library", "/Library", .systemLibrary, .systemLibrary),
             ("private", "/private", .privateStorage, .privateStorage),
@@ -351,16 +358,16 @@ struct StorageAttributionAnalyzer: Sendable {
 
         // Category 1: Measured Gaps (from Coverage Expansion)
         if let coverageReport = reconciliationReport.analyzerResults.coverageExpansion {
-            for candidate in coverageReport.largestDiscoveredRegions where candidate.status == .measured {
+            for candidate in coverageReport.largestDiscoveredRegions where candidate.status.isMeasuredOrPartial {
                 items.append(StorageAttributionItem(
                     id: "gap:\(candidate.normalizedPath)",
                     category: .measuredGaps,
                     name: candidate.name,
                     path: candidate.normalizedPath,
-                    status: .measured,
+                    status: candidate.status == .measured ? .measured : .partial,
                     allocatedBytes: candidate.allocatedBytes,
                     explanation: "Discovered and measured by storage coverage expansion (\(candidate.scope.rawValue)).",
-                    isFilesystemAdditive: true
+                    isFilesystemAdditive: candidate.contributesToExplainedBytes
                 ))
             }
         }

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/SystemLibraryAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/SystemLibraryAnalyzer.swift
@@ -1,0 +1,305 @@
+import Darwin
+import Foundation
+
+/// Explanatory categories for immediate children of the system-wide
+/// `/Library` directory. Categories describe storage; they never imply that
+/// the represented files are safe to remove.
+enum SystemLibraryStorageCategory: String, Codable, CaseIterable, Sendable {
+    case applicationSupport = "system-library.application-support"
+    case caches = "system-library.caches"
+    case developer = "system-library.developer"
+    case logs = "system-library.logs"
+    case frameworks = "system-library.frameworks"
+    case launchAgents = "system-library.launch-agents"
+    case launchDaemons = "system-library.launch-daemons"
+    case privilegedHelperTools = "system-library.privileged-helper-tools"
+    case preferences = "system-library.preferences"
+    case extensions = "system-library.extensions"
+    case updates = "system-library.updates"
+    case audio = "system-library.audio"
+    case fonts = "system-library.fonts"
+    case other = "system-library.other"
+
+    var explanation: String {
+        switch self {
+        case .applicationSupport:
+            return "System-wide shared application data and support files."
+        case .caches:
+            return "System-wide cache storage; this label does not classify its contents as disposable."
+        case .developer:
+            return "System-wide developer tools, support files, and related components."
+        case .logs:
+            return "System-wide application and service logs."
+        case .frameworks:
+            return "Frameworks shared by applications and system-wide components."
+        case .launchAgents:
+            return "Definitions for system-wide per-user background agents."
+        case .launchDaemons:
+            return "Definitions for system-wide background daemons."
+        case .privilegedHelperTools:
+            return "Privileged helper executables installed for applications or services."
+        case .preferences:
+            return "System-wide application and service preferences."
+        case .extensions:
+            return "System-wide extensions and driver-related components."
+        case .updates:
+            return "System-wide update support and staged update data."
+        case .audio:
+            return "System-wide audio plug-ins, presets, and support data."
+        case .fonts:
+            return "Fonts available system-wide."
+        case .other:
+            return "Other storage directly inside the system-wide Library directory."
+        }
+    }
+}
+
+/// Read-only storage analysis of the macOS Data-volume `/Library` path.
+///
+/// Filesystem traversal, volume-boundary enforcement, hard-link accounting,
+/// and error capture remain exclusively owned by `FileTreeScanner`. This
+/// analyzer only validates the root's semantic role, orders immediate
+/// children, and adds explanatory metadata for future drill-down UI.
+struct SystemLibraryAnalyzer: Sendable {
+    enum MetadataKey {
+        static let directChildCount = "systemLibrary.directChildCount"
+        static let largeAllocatedSizeThreshold = "systemLibrary.largeAllocatedSizeThreshold"
+        static let virtualDiskImageCount = "systemLibrary.virtualDiskImageCount"
+        static let virtualDiskFormat = "systemLibrary.virtualDiskFormat"
+        static let virtualDiskSparseState = "systemLibrary.virtualDiskSparseState"
+        static let storageScope = "systemLibrary.storageScope"
+        static let canonicalUserFacingPath = "systemLibrary.canonicalUserFacingPath"
+    }
+
+    static let storageCategoryIdentifier = "system-library"
+    static let defaultLargeAllocatedSizeThreshold: Int64 = 1_073_741_824
+    static let defaultSystemLibraryURL = URL(fileURLWithPath: "/Library", isDirectory: true)
+
+    private enum VirtualDiskFormat: String {
+        case raw
+        case img
+        case qcow2
+        case vmdk
+        case sparseBundle = "sparsebundle"
+    }
+
+    private enum SparseState: String {
+        case sparse
+        case notSparse = "not-sparse"
+        case unknown
+    }
+
+    private let systemLibraryURL: URL
+    private let scanner: FileTreeScanner
+    private let largeAllocatedSizeThreshold: Int64
+
+    init(
+        systemLibraryURL: URL = SystemLibraryAnalyzer.defaultSystemLibraryURL,
+        scanner: FileTreeScanner = FileTreeScanner(),
+        largeAllocatedSizeThreshold: Int64 = SystemLibraryAnalyzer.defaultLargeAllocatedSizeThreshold
+    ) {
+        self.systemLibraryURL = systemLibraryURL
+        self.scanner = scanner
+        self.largeAllocatedSizeThreshold = max(largeAllocatedSizeThreshold, 1)
+    }
+
+    func analyze() async -> StorageAnalysisResult {
+        let scannedResult = await scanner.scan(root: systemLibraryURL)
+        let threshold = largeAllocatedSizeThreshold
+
+        return await Task.detached(priority: .utility) {
+            Self.enrich(
+                scannedResult,
+                largeAllocatedSizeThreshold: threshold
+            )
+        }.value
+    }
+}
+
+// Internal so tests can verify that enrichment preserves synthetic volume
+// boundaries without requiring a privileged test mount.
+extension SystemLibraryAnalyzer {
+    static func enrich(
+        _ result: StorageAnalysisResult,
+        largeAllocatedSizeThreshold: Int64
+    ) -> StorageAnalysisResult {
+        var root = result.root
+        var issues = result.issues
+
+        if root.itemType != .directory, root.itemType != .unknown {
+            let issue = StorageScanIssue(
+                path: root.absolutePath,
+                kind: .notDirectory,
+                message: "System Library analysis requires a directory root.",
+                posixErrorCode: ENOTDIR
+            )
+            var rootIssues = root.scanIssues
+            if !rootIssues.contains(issue) { rootIssues.append(issue) }
+            if !issues.contains(issue) { issues.append(issue) }
+            root = copy(
+                root,
+                children: root.children,
+                accessibility: .inaccessible,
+                scanIssues: rootIssues,
+                metadata: root.metadata
+            )
+        }
+
+        let entries = root.children
+            .map {
+                enrichImmediateChild(
+                    $0,
+                    largeAllocatedSizeThreshold: largeAllocatedSizeThreshold
+                )
+            }
+            .sorted(by: allocatedSizeDescending)
+
+        var rootMetadata = root.metadata
+        rootMetadata.storageCategoryIdentifier = storageCategoryIdentifier
+        rootMetadata.explanation = "Storage in the system-wide /Library directory."
+        rootMetadata.attributes[MetadataKey.directChildCount] = String(entries.count)
+        rootMetadata.attributes[MetadataKey.storageScope] = "system-wide"
+        rootMetadata.attributes[MetadataKey.canonicalUserFacingPath] = root.absolutePath
+
+        root = copy(root, children: entries, metadata: rootMetadata)
+        return StorageAnalysisResult(
+            root: root,
+            startedAt: result.startedAt,
+            completedAt: result.completedAt,
+            rootDeviceIdentifier: result.rootDeviceIdentifier,
+            wasCancelled: result.wasCancelled,
+            issues: issues.sorted(by: issueSort)
+        )
+    }
+}
+
+// MARK: - Metadata Enrichment
+
+private extension SystemLibraryAnalyzer {
+    static func enrichImmediateChild(
+        _ node: StorageNode,
+        largeAllocatedSizeThreshold: Int64
+    ) -> StorageNode {
+        let enrichedTree = enrichVirtualDiskMetadata(in: node)
+        let category = category(for: enrichedTree)
+        var metadata = enrichedTree.metadata
+        metadata.storageCategoryIdentifier = category.rawValue
+        metadata.isUnusuallyLarge = enrichedTree.allocatedSize >= largeAllocatedSizeThreshold
+        metadata.explanation = category.explanation
+        metadata.attributes[MetadataKey.directChildCount] = String(enrichedTree.children.count)
+        metadata.attributes[MetadataKey.largeAllocatedSizeThreshold] = String(largeAllocatedSizeThreshold)
+        metadata.attributes[MetadataKey.virtualDiskImageCount] = String(
+            countVirtualDiskImages(in: enrichedTree)
+        )
+        metadata.attributes[MetadataKey.storageScope] = "system-wide"
+
+        return copy(enrichedTree, children: enrichedTree.children, metadata: metadata)
+    }
+
+    static func enrichVirtualDiskMetadata(in node: StorageNode) -> StorageNode {
+        let children = node.children.map(enrichVirtualDiskMetadata)
+        var metadata = node.metadata
+
+        if let format = virtualDiskFormat(for: node) {
+            metadata.attributes[MetadataKey.virtualDiskFormat] = format.rawValue
+            metadata.attributes[MetadataKey.virtualDiskSparseState] = sparseState(for: node).rawValue
+        }
+
+        return copy(node, children: children, metadata: metadata)
+    }
+
+    static func category(for node: StorageNode) -> SystemLibraryStorageCategory {
+        guard node.itemType == .directory || node.itemType == .volumeBoundary else {
+            return .other
+        }
+
+        switch node.name {
+        case "Application Support": return .applicationSupport
+        case "Caches": return .caches
+        case "Developer": return .developer
+        case "Logs": return .logs
+        case "Frameworks": return .frameworks
+        case "LaunchAgents": return .launchAgents
+        case "LaunchDaemons": return .launchDaemons
+        case "PrivilegedHelperTools": return .privilegedHelperTools
+        case "Preferences": return .preferences
+        case "Extensions": return .extensions
+        case "Updates": return .updates
+        case "Audio": return .audio
+        case "Fonts": return .fonts
+        default: return .other
+        }
+    }
+
+    private static func virtualDiskFormat(for node: StorageNode) -> VirtualDiskFormat? {
+        guard !node.isSymbolicLink,
+              node.itemType == .regularFile || node.itemType == .directory else {
+            return nil
+        }
+
+        switch URL(fileURLWithPath: node.absolutePath).pathExtension.lowercased() {
+        case "raw": return .raw
+        case "img": return .img
+        case "qcow2": return .qcow2
+        case "vmdk": return .vmdk
+        case "sparsebundle": return .sparseBundle
+        default: return nil
+        }
+    }
+
+    private static func sparseState(for node: StorageNode) -> SparseState {
+        guard node.itemType == .regularFile else { return .unknown }
+        return node.ownLogicalSize > node.ownAllocatedSize ? .sparse : .notSparse
+    }
+
+    static func countVirtualDiskImages(in root: StorageNode) -> Int {
+        var count = 0
+        var pending = [root]
+        while let node = pending.popLast() {
+            if virtualDiskFormat(for: node) != nil { count += 1 }
+            pending.append(contentsOf: node.children)
+        }
+        return count
+    }
+
+    static func allocatedSizeDescending(_ left: StorageNode, _ right: StorageNode) -> Bool {
+        if left.allocatedSize != right.allocatedSize {
+            return left.allocatedSize > right.allocatedSize
+        }
+        if left.logicalSize != right.logicalSize {
+            return left.logicalSize > right.logicalSize
+        }
+        return left.absolutePath < right.absolutePath
+    }
+
+    static func copy(
+        _ node: StorageNode,
+        children: [StorageNode],
+        accessibility: StorageAccessibility? = nil,
+        scanIssues: [StorageScanIssue]? = nil,
+        metadata: StorageAnalysisMetadata
+    ) -> StorageNode {
+        StorageNode(
+            name: node.name,
+            absolutePath: node.absolutePath,
+            logicalSize: node.logicalSize,
+            allocatedSize: node.allocatedSize,
+            ownLogicalSize: node.ownLogicalSize,
+            ownAllocatedSize: node.ownAllocatedSize,
+            itemType: node.itemType,
+            children: children,
+            accessibility: accessibility ?? node.accessibility,
+            scanIssues: scanIssues ?? node.scanIssues,
+            isHidden: node.isHidden,
+            isSymbolicLink: node.isSymbolicLink,
+            isCountedInParentTotals: node.isCountedInParentTotals,
+            metadata: metadata
+        )
+    }
+
+    static func issueSort(_ left: StorageScanIssue, _ right: StorageScanIssue) -> Bool {
+        if left.path != right.path { return left.path < right.path }
+        if left.kind != right.kind { return left.kind.rawValue < right.kind.rawValue }
+        return left.message < right.message
+    }
+}

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/SystemLibraryAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/SystemLibraryAnalyzer.swift
@@ -91,20 +91,30 @@ struct SystemLibraryAnalyzer: Sendable {
 
     private let systemLibraryURL: URL
     private let scanner: FileTreeScanner
+    private let cache: StorageAnalysisCache?
     private let largeAllocatedSizeThreshold: Int64
 
     init(
         systemLibraryURL: URL = SystemLibraryAnalyzer.defaultSystemLibraryURL,
         scanner: FileTreeScanner = FileTreeScanner(),
+        cache: StorageAnalysisCache? = nil,
         largeAllocatedSizeThreshold: Int64 = SystemLibraryAnalyzer.defaultLargeAllocatedSizeThreshold
     ) {
         self.systemLibraryURL = systemLibraryURL
         self.scanner = scanner
+        self.cache = cache
         self.largeAllocatedSizeThreshold = max(largeAllocatedSizeThreshold, 1)
     }
 
     func analyze() async -> StorageAnalysisResult {
-        let scannedResult = await scanner.scan(root: systemLibraryURL)
+        let scannedResult: StorageAnalysisResult
+        if let cached = cache?.get(path: systemLibraryURL.path) {
+            scannedResult = cached
+        } else {
+            let result = await scanner.scan(root: systemLibraryURL)
+            cache?.store(result, isFullSubtree: true)
+            scannedResult = result
+        }
         let threshold = largeAllocatedSizeThreshold
 
         return await Task.detached(priority: .utility) {

--- a/PureMac/Logic/Storage/SpecializedAnalyzers/UserHomeStorageAnalyzer.swift
+++ b/PureMac/Logic/Storage/SpecializedAnalyzers/UserHomeStorageAnalyzer.swift
@@ -1,0 +1,256 @@
+import Foundation
+
+enum UserHomeStandardDirectory: String, Codable, CaseIterable, Sendable {
+    case desktop = "Desktop"
+    case documents = "Documents"
+    case downloads = "Downloads"
+    case movies = "Movies"
+    case music = "Music"
+    case pictures = "Pictures"
+    case `public` = "Public"
+}
+
+enum UserHomeStandardDirectoryState: String, Codable, Sendable {
+    case present
+    case missing
+}
+
+struct UserHomeStandardDirectoryStatus: Hashable, Codable, Sendable {
+    let directory: UserHomeStandardDirectory
+    let absolutePath: String
+    let state: UserHomeStandardDirectoryState
+}
+
+struct UserHomeStorageRoot: Identifiable, Hashable, Codable, Sendable {
+    var id: String { node.absolutePath }
+
+    let standardDirectory: UserHomeStandardDirectory?
+    let node: StorageNode
+}
+
+/// One canonical selected-children tree for ordinary visible storage in the
+/// current user's home directory. The home directory object's own bytes are
+/// excluded by FileTreeScanner; only the selected roots contribute.
+struct UserHomeStorageReport: Hashable, Codable, Sendable {
+    let homeDirectoryPath: String
+    let roots: [UserHomeStorageRoot]
+    let standardDirectories: [UserHomeStandardDirectoryStatus]
+    let excludedCanonicalPaths: [String]
+    let result: StorageAnalysisResult
+    let combinedUniqueLogicalSize: Int64
+    let combinedUniqueAllocatedSize: Int64
+    let wasCancelled: Bool
+    let issues: [StorageScanIssue]
+}
+
+/// Read-only analysis of visible immediate children of the user's home.
+///
+/// The scanner enumerates the home once and recursively traverses accepted
+/// children with a shared hard-link ledger. Hidden top-level entries and the
+/// complete `~/Library` tree are intentionally excluded. Hidden descendants
+/// inside an accepted visible root remain part of that root's hierarchy.
+struct UserHomeStorageAnalyzer: Sendable {
+    enum MetadataKey {
+        static let directChildCount = "userHome.directChildCount"
+        static let rootKind = "userHome.rootKind"
+        static let standardDirectory = "userHome.standardDirectory"
+        static let largeAllocatedSizeThreshold = "userHome.largeAllocatedSizeThreshold"
+        static let localDiskAccounting = "userHome.localDiskAccounting"
+    }
+
+    static let storageCategoryIdentifier = "user-home-visible-storage"
+    static let defaultLargeAllocatedSizeThreshold: Int64 = 1_073_741_824
+
+    static var currentUserHomeURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+    }
+
+    private let homeDirectoryURL: URL
+    private let scanner: FileTreeScanner
+    private let largeAllocatedSizeThreshold: Int64
+
+    init(
+        homeDirectoryURL: URL = UserHomeStorageAnalyzer.currentUserHomeURL,
+        scanner: FileTreeScanner = FileTreeScanner(),
+        largeAllocatedSizeThreshold: Int64 = UserHomeStorageAnalyzer.defaultLargeAllocatedSizeThreshold
+    ) {
+        self.homeDirectoryURL = homeDirectoryURL.standardizedFileURL
+        self.scanner = scanner
+        self.largeAllocatedSizeThreshold = max(largeAllocatedSizeThreshold, 1)
+    }
+
+    func analyze() async -> UserHomeStorageReport {
+        let home = homeDirectoryURL
+        let libraryPath = home
+            .appendingPathComponent("Library", isDirectory: true)
+            .standardizedFileURL.path
+        let scanned = await scanner.scanSelectedImmediateChildren(root: home) { child in
+            !child.isHidden
+                && URL(fileURLWithPath: child.absolutePath).standardizedFileURL.path != libraryPath
+        }
+        let threshold = largeAllocatedSizeThreshold
+
+        return await Task.detached(priority: .utility) {
+            Self.makeReport(
+                scanned,
+                homeDirectoryURL: home,
+                largeAllocatedSizeThreshold: threshold
+            )
+        }.value
+    }
+}
+
+// Internal so tests can verify enrichment without scanning a real home.
+extension UserHomeStorageAnalyzer {
+    static func makeReport(
+        _ input: StorageAnalysisResult,
+        homeDirectoryURL: URL,
+        largeAllocatedSizeThreshold: Int64
+    ) -> UserHomeStorageReport {
+        let home = homeDirectoryURL.standardizedFileURL
+        let enrichedRoots = input.root.children.map {
+            enrichRoot(
+                $0,
+                homeDirectoryURL: home,
+                largeAllocatedSizeThreshold: largeAllocatedSizeThreshold
+            )
+        }.sorted(by: allocatedSizeDescending)
+
+        var rootMetadata = input.root.metadata
+        rootMetadata.storageCategoryIdentifier = storageCategoryIdentifier
+        rootMetadata.explanation = "Ordinary visible storage directly below the user's home directory."
+        rootMetadata.attributes[MetadataKey.directChildCount] = String(enrichedRoots.count)
+        rootMetadata.attributes[MetadataKey.localDiskAccounting] = "allocated-size-only"
+        let root = copy(input.root, children: enrichedRoots, metadata: rootMetadata)
+        let result = StorageAnalysisResult(
+            root: root,
+            startedAt: input.startedAt,
+            completedAt: input.completedAt,
+            rootDeviceIdentifier: input.rootDeviceIdentifier,
+            wasCancelled: input.wasCancelled,
+            issues: input.issues
+        )
+        let roots = enrichedRoots.map {
+            UserHomeStorageRoot(
+                standardDirectory: standardDirectory(
+                    for: $0.absolutePath,
+                    homeDirectoryURL: home
+                ),
+                node: $0
+            )
+        }
+        let presentPaths = Set(enrichedRoots.map { standardizedPath($0.absolutePath) })
+        let standardDirectories = UserHomeStandardDirectory.allCases.map { directory in
+            let path = home
+                .appendingPathComponent(directory.rawValue, isDirectory: true)
+                .standardizedFileURL.path
+            return UserHomeStandardDirectoryStatus(
+                directory: directory,
+                absolutePath: path,
+                state: presentPaths.contains(path) ? .present : .missing
+            )
+        }
+
+        return UserHomeStorageReport(
+            homeDirectoryPath: home.path,
+            roots: roots,
+            standardDirectories: standardDirectories,
+            excludedCanonicalPaths: excludedPaths(homeDirectoryURL: home),
+            result: result,
+            combinedUniqueLogicalSize: max(root.logicalSize, 0),
+            combinedUniqueAllocatedSize: max(root.allocatedSize, 0),
+            wasCancelled: input.wasCancelled,
+            issues: input.issues
+        )
+    }
+}
+
+private extension UserHomeStorageAnalyzer {
+    static func enrichRoot(
+        _ node: StorageNode,
+        homeDirectoryURL: URL,
+        largeAllocatedSizeThreshold: Int64
+    ) -> StorageNode {
+        let standard = standardDirectory(
+            for: node.absolutePath,
+            homeDirectoryURL: homeDirectoryURL
+        )
+        var metadata = node.metadata
+        metadata.storageCategoryIdentifier = standard.map {
+            "\(storageCategoryIdentifier).\($0.rawValue.lowercased())"
+        } ?? "\(storageCategoryIdentifier).custom"
+        metadata.isUnusuallyLarge = node.allocatedSize >= largeAllocatedSizeThreshold
+        metadata.explanation = standard.map {
+            "Visible user storage in the \($0.rawValue) folder; no cleanup classification is implied."
+        } ?? "Visible custom user storage; no cleanup classification is implied."
+        metadata.attributes[MetadataKey.directChildCount] = String(node.children.count)
+        metadata.attributes[MetadataKey.rootKind] = standard == nil ? "custom" : "standard"
+        metadata.attributes[MetadataKey.largeAllocatedSizeThreshold] = String(
+            largeAllocatedSizeThreshold
+        )
+        metadata.attributes[MetadataKey.localDiskAccounting] = "allocated-size-only"
+        if let standard {
+            metadata.attributes[MetadataKey.standardDirectory] = standard.rawValue
+        }
+        return copy(node, children: node.children, metadata: metadata)
+    }
+
+    static func standardDirectory(
+        for path: String,
+        homeDirectoryURL: URL
+    ) -> UserHomeStandardDirectory? {
+        let candidate = standardizedPath(path)
+        return UserHomeStandardDirectory.allCases.first { directory in
+            homeDirectoryURL
+                .appendingPathComponent(directory.rawValue, isDirectory: true)
+                .standardizedFileURL.path == candidate
+        }
+    }
+
+    static func excludedPaths(homeDirectoryURL: URL) -> [String] {
+        let library = homeDirectoryURL.appendingPathComponent("Library", isDirectory: true)
+        return [
+            library,
+            library.appendingPathComponent("Application Support", isDirectory: true),
+            library.appendingPathComponent("Containers", isDirectory: true),
+            library.appendingPathComponent("Group Containers", isDirectory: true),
+        ].map { $0.standardizedFileURL.path }
+    }
+
+    static func standardizedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.path
+    }
+
+    static func allocatedSizeDescending(_ left: StorageNode, _ right: StorageNode) -> Bool {
+        if left.allocatedSize != right.allocatedSize {
+            return left.allocatedSize > right.allocatedSize
+        }
+        if left.logicalSize != right.logicalSize {
+            return left.logicalSize > right.logicalSize
+        }
+        return left.absolutePath < right.absolutePath
+    }
+
+    static func copy(
+        _ node: StorageNode,
+        children: [StorageNode],
+        metadata: StorageAnalysisMetadata
+    ) -> StorageNode {
+        StorageNode(
+            name: node.name,
+            absolutePath: node.absolutePath,
+            logicalSize: node.logicalSize,
+            allocatedSize: node.allocatedSize,
+            ownLogicalSize: node.ownLogicalSize,
+            ownAllocatedSize: node.ownAllocatedSize,
+            itemType: node.itemType,
+            children: children,
+            accessibility: node.accessibility,
+            scanIssues: node.scanIssues,
+            isHidden: node.isHidden,
+            isSymbolicLink: node.isSymbolicLink,
+            isCountedInParentTotals: node.isCountedInParentTotals,
+            metadata: metadata
+        )
+    }
+}

--- a/PureMac/Logic/Storage/StorageAnalysisCache.swift
+++ b/PureMac/Logic/Storage/StorageAnalysisCache.swift
@@ -1,0 +1,189 @@
+import Foundation
+
+/// Performance metrics for run-scoped storage scan caching and subtree reuse.
+struct StorageAnalysisCacheMetrics: Hashable, Codable, Sendable {
+    var physicalTraversalsCount: Int = 0
+    var cacheHitCount: Int = 0
+    var cacheMissCount: Int = 0
+    var reusedSubtreeCount: Int = 0
+    var avoidedTraversalsCount: Int = 0
+}
+
+/// Run-scoped, thread-safe cache for filesystem scan results with in-flight task coalescing.
+///
+/// Ensures that any canonical filesystem subtree is physically traversed at most
+/// once per analysis run. When an analyzer requests a scan for a path that is
+/// identical to, currently in flight, or contained within an already-scanned full
+/// recursive tree, the existing or in-flight subtree is reused with zero duplicate I/O.
+final class StorageAnalysisCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var resultsByNormalizedPath: [String: StorageAnalysisResult] = [:]
+    private var fullSubtreeRootPaths: Set<String> = []
+    private var inFlightTasks: [String: Task<StorageAnalysisResult, Error>] = [:]
+
+    private var _metrics = StorageAnalysisCacheMetrics()
+
+    var metrics: StorageAnalysisCacheMetrics {
+        lock.withLock { _metrics }
+    }
+
+    init() {}
+
+    /// Retrieves an existing result if the exact normalized path or a containing
+    /// full-subtree parent has already been scanned with compatible semantics.
+    func get(path: String) -> StorageAnalysisResult? {
+        let normPath = StoragePathNormalizer.normalize(path)
+        return lock.withLock {
+            getSynchronouslyLocked(normPath: normPath)
+        }
+    }
+
+    private func getSynchronouslyLocked(normPath: String) -> StorageAnalysisResult? {
+        // 1. Exact match
+        if let exact = resultsByNormalizedPath[normPath] {
+            _metrics.cacheHitCount += 1
+            _metrics.avoidedTraversalsCount += 1
+            return exact
+        }
+
+        // 2. Subtree match inside an existing full recursive scan
+        for parentPath in fullSubtreeRootPaths {
+            guard normPath == parentPath || normPath.hasPrefix(parentPath + "/") else {
+                continue
+            }
+
+            guard let parentResult = resultsByNormalizedPath[parentPath] else {
+                continue
+            }
+
+            if let subtreeNode = Self.findSubtreeNode(in: parentResult.root, targetNormalizedPath: normPath) {
+                let subtreeResult = Self.makeSubtreeResult(from: subtreeNode, parentResult: parentResult)
+                resultsByNormalizedPath[normPath] = subtreeResult
+                _metrics.cacheHitCount += 1
+                _metrics.reusedSubtreeCount += 1
+                _metrics.avoidedTraversalsCount += 1
+                return subtreeResult
+            }
+        }
+
+        _metrics.cacheMissCount += 1
+        return nil
+    }
+
+    /// Performs an asynchronous scan or coalesces with an already running scan
+    /// for the same canonical root, caching the result on completion.
+    func scanOrCoalesce(
+        path: String,
+        performScan: @Sendable @escaping () async throws -> StorageAnalysisResult
+    ) async throws -> StorageAnalysisResult {
+        let normPath = StoragePathNormalizer.normalize(path)
+
+        enum InFlightAction {
+            case returnCached(StorageAnalysisResult)
+            case awaitExisting(Task<StorageAnalysisResult, Error>)
+            case awaitCreated(Task<StorageAnalysisResult, Error>)
+        }
+
+        let action: InFlightAction = lock.withLock {
+            if let cached = getSynchronouslyLocked(normPath: normPath) {
+                return .returnCached(cached)
+            }
+            if let existing = inFlightTasks[normPath] {
+                _metrics.cacheHitCount += 1
+                _metrics.avoidedTraversalsCount += 1
+                return .awaitExisting(existing)
+            }
+
+            let task = Task<StorageAnalysisResult, Error> {
+                try await performScan()
+            }
+            inFlightTasks[normPath] = task
+            _metrics.physicalTraversalsCount += 1
+            return .awaitCreated(task)
+        }
+
+        switch action {
+        case let .returnCached(result):
+            return result
+        case let .awaitExisting(task):
+            return try await task.value
+        case let .awaitCreated(task):
+            do {
+                let result = try await task.value
+                lock.withLock {
+                    inFlightTasks.removeValue(forKey: normPath)
+                    if !result.wasCancelled {
+                        resultsByNormalizedPath[normPath] = result
+                        fullSubtreeRootPaths.insert(normPath)
+                    }
+                }
+                return result
+            } catch {
+                lock.withLock {
+                    inFlightTasks.removeValue(forKey: normPath)
+                }
+                throw error
+            }
+        }
+    }
+
+    /// Stores a scan result in the run-scoped cache.
+    func store(_ result: StorageAnalysisResult, isFullSubtree: Bool) {
+        guard !result.wasCancelled else { return }
+        let normPath = StoragePathNormalizer.normalize(result.root.absolutePath)
+
+        lock.withLock {
+            resultsByNormalizedPath[normPath] = result
+            if isFullSubtree {
+                fullSubtreeRootPaths.insert(normPath)
+            }
+        }
+    }
+
+    /// Recursively locates a descendant node matching the target normalized path.
+    static func findSubtreeNode(in root: StorageNode, targetNormalizedPath: String) -> StorageNode? {
+        let rootNorm = StoragePathNormalizer.normalize(root.absolutePath)
+        if rootNorm == targetNormalizedPath {
+            return root
+        }
+
+        guard targetNormalizedPath.hasPrefix(rootNorm + "/") || rootNorm == "/" else {
+            return nil
+        }
+
+        for child in root.children {
+            let childNorm = StoragePathNormalizer.normalize(child.absolutePath)
+            if childNorm == targetNormalizedPath {
+                return child
+            }
+            if targetNormalizedPath.hasPrefix(childNorm + "/") {
+                if let match = findSubtreeNode(in: child, targetNormalizedPath: targetNormalizedPath) {
+                    return match
+                }
+            }
+        }
+
+        return nil
+    }
+
+    /// Builds a standalone StorageAnalysisResult representing the extracted subtree.
+    static func makeSubtreeResult(
+        from node: StorageNode,
+        parentResult: StorageAnalysisResult
+    ) -> StorageAnalysisResult {
+        let nodeNorm = StoragePathNormalizer.normalize(node.absolutePath)
+        let relevantIssues = parentResult.issues.filter { issue in
+            let issueNorm = StoragePathNormalizer.normalize(issue.path)
+            return issueNorm == nodeNorm || issueNorm.hasPrefix(nodeNorm + "/")
+        }
+
+        return StorageAnalysisResult(
+            root: node,
+            startedAt: parentResult.startedAt,
+            completedAt: parentResult.completedAt,
+            rootDeviceIdentifier: parentResult.rootDeviceIdentifier,
+            wasCancelled: parentResult.wasCancelled,
+            issues: relevantIssues
+        )
+    }
+}

--- a/PureMac/Logic/Storage/StorageAnalysisPerformanceDiagnostics.swift
+++ b/PureMac/Logic/Storage/StorageAnalysisPerformanceDiagnostics.swift
@@ -1,0 +1,364 @@
+import Foundation
+
+/// Read-only debug-only performance diagnostics for PureMac Storage Intelligence.
+///
+/// This utility measures wall-clock duration and aggregates filesystem traversal
+/// metrics (entries, directories, files, bytes, permission issues, boundary skips)
+/// directly from produced `StorageNode` trees with zero additional disk I/O.
+struct StorageScanMetrics: Hashable, Codable, Sendable {
+    var totalEntries: Int = 0
+    var directoryCount: Int = 0
+    var fileCount: Int = 0
+    var otherCount: Int = 0
+    var allocatedBytes: Int64 = 0
+    var logicalBytes: Int64 = 0
+    var permissionFailureCount: Int = 0
+    var boundarySkipCount: Int = 0
+    var packageAggregatesCount: Int = 0
+    var packageDescendantsMeasured: Int = 0
+    var packageNodesAvoided: Int = 0
+
+    init(
+        totalEntries: Int = 0,
+        directoryCount: Int = 0,
+        fileCount: Int = 0,
+        otherCount: Int = 0,
+        allocatedBytes: Int64 = 0,
+        logicalBytes: Int64 = 0,
+        permissionFailureCount: Int = 0,
+        boundarySkipCount: Int = 0,
+        packageAggregatesCount: Int = 0,
+        packageDescendantsMeasured: Int = 0,
+        packageNodesAvoided: Int = 0
+    ) {
+        self.totalEntries = totalEntries
+        self.directoryCount = directoryCount
+        self.fileCount = fileCount
+        self.otherCount = otherCount
+        self.allocatedBytes = allocatedBytes
+        self.logicalBytes = logicalBytes
+        self.permissionFailureCount = permissionFailureCount
+        self.boundarySkipCount = boundarySkipCount
+        self.packageAggregatesCount = packageAggregatesCount
+        self.packageDescendantsMeasured = packageDescendantsMeasured
+        self.packageNodesAvoided = packageNodesAvoided
+    }
+
+    static func compute(from node: StorageNode) -> StorageScanMetrics {
+        var metrics = StorageScanMetrics()
+        accumulate(node: node, into: &metrics)
+        if let pkgs = node.metadata.attributes["fileTreeScanner.packagesAggregated"].flatMap(Int.init) ?? node.metadata.attributes[ApplicationsStorageAnalyzer.MetadataKey.packagesAggregated].flatMap(Int.init) {
+            metrics.packageAggregatesCount = pkgs
+            metrics.packageDescendantsMeasured = node.metadata.attributes["fileTreeScanner.descendantEntriesMeasured"].flatMap(Int.init) ?? node.metadata.attributes[ApplicationsStorageAnalyzer.MetadataKey.descendantEntriesMeasured].flatMap(Int.init) ?? 0
+            metrics.packageNodesAvoided = node.metadata.attributes["fileTreeScanner.descendantNodesAvoided"].flatMap(Int.init) ?? node.metadata.attributes[ApplicationsStorageAnalyzer.MetadataKey.descendantNodesAvoided].flatMap(Int.init) ?? 0
+        }
+        return metrics
+    }
+
+    static func compute(from nodes: [StorageNode]) -> StorageScanMetrics {
+        var metrics = StorageScanMetrics()
+        for node in nodes {
+            accumulate(node: node, into: &metrics)
+            if let pkgs = node.metadata.attributes["fileTreeScanner.packagesAggregated"].flatMap(Int.init) ?? node.metadata.attributes[ApplicationsStorageAnalyzer.MetadataKey.packagesAggregated].flatMap(Int.init) {
+                metrics.packageAggregatesCount += pkgs
+                metrics.packageDescendantsMeasured += node.metadata.attributes["fileTreeScanner.descendantEntriesMeasured"].flatMap(Int.init) ?? node.metadata.attributes[ApplicationsStorageAnalyzer.MetadataKey.descendantEntriesMeasured].flatMap(Int.init) ?? 0
+                metrics.packageNodesAvoided += node.metadata.attributes["fileTreeScanner.descendantNodesAvoided"].flatMap(Int.init) ?? node.metadata.attributes[ApplicationsStorageAnalyzer.MetadataKey.descendantNodesAvoided].flatMap(Int.init) ?? 0
+            }
+        }
+        return metrics
+    }
+
+    private static func accumulate(node: StorageNode, into metrics: inout StorageScanMetrics) {
+        metrics.totalEntries += 1
+        switch node.itemType {
+        case .directory:
+            metrics.directoryCount += 1
+        case .regularFile:
+            metrics.fileCount += 1
+        default:
+            metrics.otherCount += 1
+        }
+        if node.children.isEmpty {
+            metrics.allocatedBytes += node.allocatedSize
+            metrics.logicalBytes += node.logicalSize
+        } else {
+            metrics.allocatedBytes += node.ownAllocatedSize
+            metrics.logicalBytes += node.ownLogicalSize
+        }
+
+        if node.accessibility == .inaccessible || node.accessibility == .partiallyAccessible {
+            metrics.permissionFailureCount += node.scanIssues.filter {
+                $0.kind == .permissionDenied || $0.kind == .unreadable
+            }.count
+        }
+        if node.accessibility == .skippedDifferentVolume {
+            metrics.boundarySkipCount += 1
+        }
+
+        for child in node.children {
+            accumulate(node: child, into: &metrics)
+        }
+    }
+}
+
+struct SlowestSubtreeRecord: Hashable, Codable, Sendable {
+    let path: String
+    let totalEntries: Int
+    let directoryCount: Int
+    let fileCount: Int
+    let allocatedBytes: Int64
+    let isPackageOrApp: Bool
+}
+
+struct StagePerformanceRecord: Hashable, Codable, Sendable {
+    let stageName: String
+    let durationSeconds: Double
+    let metrics: StorageScanMetrics?
+    let customNote: String?
+
+    init(
+        stageName: String,
+        durationSeconds: Double,
+        metrics: StorageScanMetrics? = nil,
+        customNote: String? = nil
+    ) {
+        self.stageName = stageName
+        self.durationSeconds = durationSeconds
+        self.metrics = metrics
+        self.customNote = customNote
+    }
+}
+
+struct DuplicateScanObservation: Hashable, Codable, Sendable {
+    let path: String
+    let primaryScanner: String
+    let secondaryScanner: String
+    let relationship: String
+
+    init(
+        path: String,
+        primaryScanner: String,
+        secondaryScanner: String,
+        relationship: String
+    ) {
+        self.path = path
+        self.primaryScanner = primaryScanner
+        self.secondaryScanner = secondaryScanner
+        self.relationship = relationship
+    }
+}
+
+struct StorageAnalysisPerformanceReport: Hashable, Codable, Sendable {
+    let totalDurationSeconds: Double
+    let stageRecords: [StagePerformanceRecord]
+    let duplicateObservations: [DuplicateScanObservation]
+    let cacheMetrics: StorageAnalysisCacheMetrics?
+    let heaviestSubtrees: [SlowestSubtreeRecord]
+
+    init(
+        totalDurationSeconds: Double,
+        stageRecords: [StagePerformanceRecord],
+        duplicateObservations: [DuplicateScanObservation],
+        cacheMetrics: StorageAnalysisCacheMetrics? = nil,
+        heaviestSubtrees: [SlowestSubtreeRecord] = []
+    ) {
+        self.totalDurationSeconds = totalDurationSeconds
+        self.stageRecords = stageRecords
+        self.duplicateObservations = duplicateObservations
+        self.cacheMetrics = cacheMetrics
+        self.heaviestSubtrees = heaviestSubtrees
+    }
+
+    func formattedDebugString() -> String {
+        var output = "\n=== PureMac Storage Analysis Performance ===\n"
+        let totalDurationStr = String(format: "%.2f", totalDurationSeconds)
+        output += "Total Duration: \(totalDurationStr)s\n\n"
+        output += "Stage Breakdown:\n"
+
+        let maxNameWidth = stageRecords.map(\.stageName.count).max() ?? 25
+        for record in stageRecords {
+            let paddedName = record.stageName.padding(toLength: max(maxNameWidth + 2, 28), withPad: " ", startingAt: 0)
+            let durationStr = (String(format: "%.2f", record.durationSeconds) + "s").leftPadded(toLength: 7)
+
+            if let metrics = record.metrics, metrics.totalEntries > 0 {
+                let bytesStr = ByteCountFormatter.string(fromByteCount: max(metrics.allocatedBytes, 0), countStyle: .file)
+                let rate = record.durationSeconds > 0 ? Double(metrics.totalEntries) / record.durationSeconds : 0
+                let rateStr = String(format: "%.0f entries/s", rate)
+                let note = record.customNote.map { " (\($0))" } ?? ""
+                if metrics.packageAggregatesCount > 0 {
+                    let pkgNote = " (\(metrics.packageAggregatesCount) apps aggregated, \(metrics.packageDescendantsMeasured) descendants measured, \(metrics.packageNodesAvoided) nodes avoided)"
+                    output += "\(paddedName) \(durationStr)   \(metrics.totalEntries) materialized entries (\(metrics.directoryCount) dirs, \(metrics.fileCount) files)  [\(bytesStr)] [\(rateStr)]\(pkgNote)\(note)\n"
+                } else {
+                    output += "\(paddedName) \(durationStr)   \(metrics.totalEntries) entries (\(metrics.directoryCount) dirs, \(metrics.fileCount) files)  [\(bytesStr)] [\(rateStr)]\(note)\n"
+                }
+            } else if let note = record.customNote {
+                output += "\(paddedName) \(durationStr)   [\(note)]\n"
+            } else {
+                output += "\(paddedName) \(durationStr)\n"
+            }
+        }
+
+        if let cache = cacheMetrics {
+            output += "\nScan Cache & Subtree Reuse:\n"
+            output += "  Physical Traversals:    \(cache.physicalTraversalsCount)\n"
+            output += "  Cache Hits:             \(cache.cacheHitCount)\n"
+            output += "  Cache Misses:           \(cache.cacheMissCount)\n"
+            output += "  Reused Subtrees:        \(cache.reusedSubtreeCount)\n"
+            output += "  Avoided Traversals:     \(cache.avoidedTraversalsCount)\n"
+        }
+
+        if !heaviestSubtrees.isEmpty {
+            output += "\nTop High-Density Subtrees & Application Bundles:\n"
+            for (index, subtree) in heaviestSubtrees.prefix(20).enumerated() {
+                let bytesStr = ByteCountFormatter.string(fromByteCount: max(subtree.allocatedBytes, 0), countStyle: .file)
+                let tag = subtree.isPackageOrApp ? "[App Bundle]" : "[Directory]"
+                let indexStr = "\(index + 1)".leftPadded(toLength: 2)
+                let tagStr = tag.padding(toLength: 12, withPad: " ", startingAt: 0)
+                let entriesStr = "\(subtree.totalEntries)".leftPadded(toLength: 6)
+                let dirsStr = "\(subtree.directoryCount)".leftPadded(toLength: 5)
+                let filesStr = "\(subtree.fileCount)".leftPadded(toLength: 5)
+                let bytesPadded = bytesStr.leftPadded(toLength: 8)
+                output += "  \(indexStr). \(tagStr) \(entriesStr) entries (\(dirsStr) dirs, \(filesStr) files) [\(bytesPadded)] \(subtree.path)\n"
+            }
+        }
+
+        if !duplicateObservations.isEmpty {
+            output += "\nPotential Duplicate / Overlapping Recursive Coverage:\n"
+            for obs in duplicateObservations {
+                output += "- \(obs.path)\n"
+                output += "  Primary:   \(obs.primaryScanner)\n"
+                output += "  Secondary: \(obs.secondaryScanner) (\(obs.relationship))\n"
+            }
+        }
+
+        output += "=============================================\n"
+        return output
+    }
+}
+
+enum StorageAnalysisPerformanceDiagnostics {
+    static func analyzeDuplicates(
+        results: StorageAnalyzerResults,
+        expansionReport: StorageCoverageExpansionReport?
+    ) -> [DuplicateScanObservation] {
+        var observations: [DuplicateScanObservation] = []
+
+        // 1. Docker host locations overlapping specialized analyzers
+        if let docker = results.dockerStorage {
+            for location in docker.hostFootprint.locations {
+                let path = location.root.absolutePath
+                if path.contains("/Library/Containers/") {
+                    observations.append(DuplicateScanObservation(
+                        path: path,
+                        primaryScanner: "ContainersAnalyzer (scans ~/Library/Containers)",
+                        secondaryScanner: "DockerStorageAnalyzer",
+                        relationship: "Nested inside Containers hierarchy"
+                    ))
+                } else if path.contains("/Library/Group Containers/") {
+                    observations.append(DuplicateScanObservation(
+                        path: path,
+                        primaryScanner: "GroupContainersAnalyzer (scans ~/Library/Group Containers)",
+                        secondaryScanner: "DockerStorageAnalyzer",
+                        relationship: "Nested inside Group Containers hierarchy"
+                    ))
+                } else if path.contains("/Library/Application Support/") {
+                    observations.append(DuplicateScanObservation(
+                        path: path,
+                        primaryScanner: "ApplicationSupportAnalyzer (scans ~/Library/Application Support)",
+                        secondaryScanner: "DockerStorageAnalyzer",
+                        relationship: "Nested inside Application Support hierarchy"
+                    ))
+                } else if path.hasSuffix("/.docker") {
+                    observations.append(DuplicateScanObservation(
+                        path: path,
+                        primaryScanner: "CoverageExpansionAnalyzer (discovers ~/.docker as hidden home root)",
+                        secondaryScanner: "DockerStorageAnalyzer",
+                        relationship: "Duplicate scan of ~/.docker"
+                    ))
+                }
+            }
+        }
+
+        // 2. Coverage Expansion candidates overlapping with other roots
+        if let expansion = expansionReport {
+            for candidate in expansion.candidates where candidate.status == .excludedAlreadyAccounted || candidate.status == .excludedNested || candidate.status == .skippedAlreadyOwned || candidate.status == .skippedUnsafeOverlap {
+                observations.append(DuplicateScanObservation(
+                    path: candidate.originalPath,
+                    primaryScanner: candidate.exclusionReason ?? "Canonical Root Analyzer",
+                    secondaryScanner: "CoverageExpansionAnalyzer",
+                    relationship: "Identified and excluded during Stage A discovery"
+                ))
+            }
+        }
+
+        // 3. Firmlink canonical roots
+        observations.append(DuplicateScanObservation(
+            path: "/Applications vs /System/Volumes/Data/Applications",
+            primaryScanner: "ApplicationsStorageAnalyzer (/Applications)",
+            secondaryScanner: "StoragePathNormalizer",
+            relationship: "Firmlink alias normalized to /Applications"
+        ))
+
+        return observations
+    }
+
+    /// Finds high-density subtrees and application packages across scanned trees.
+    static func findHeaviestSubtrees(
+        from rootNodes: [StorageNode],
+        limit: Int = 20
+    ) -> [SlowestSubtreeRecord] {
+        var records: [SlowestSubtreeRecord] = []
+
+        for root in rootNodes {
+            inspectNode(root, isRoot: true, records: &records)
+        }
+
+        return records.sorted { $0.totalEntries > $1.totalEntries }.prefix(limit).map { $0 }
+    }
+
+    private static func inspectNode(
+        _ node: StorageNode,
+        isRoot: Bool,
+        records: inout [SlowestSubtreeRecord]
+    ) {
+        let isApp = node.name.hasSuffix(".app") || node.name.hasSuffix(".framework") || node.name.hasSuffix(".bundle")
+        let isHighDensityFolder = !isRoot && (node.name == "node_modules" || node.name == ".git" || node.name == "Pods" || node.name == "DerivedData" || node.name == "venv" || node.name == ".venv" || node.name == "target")
+
+        if !isRoot && (isApp || isHighDensityFolder || node.children.count > 50) {
+            let metrics = StorageScanMetrics.compute(from: node)
+            if metrics.totalEntries >= 100 {
+                records.append(SlowestSubtreeRecord(
+                    path: node.absolutePath,
+                    totalEntries: metrics.totalEntries,
+                    directoryCount: metrics.directoryCount,
+                    fileCount: metrics.fileCount,
+                    allocatedBytes: metrics.allocatedBytes,
+                    isPackageOrApp: isApp
+                ))
+            }
+        }
+
+        if !isRoot && isApp {
+            // Do not recurse deeper into apps for candidate ranking
+            return
+        }
+
+        for child in node.children where child.itemType == .directory {
+            inspectNode(child, isRoot: false, records: &records)
+        }
+    }
+
+    static func printDebugReport(_ report: StorageAnalysisPerformanceReport) {
+        #if DEBUG
+        print(report.formattedDebugString())
+        #endif
+    }
+}
+
+extension String {
+    func leftPadded(toLength length: Int, withPad pad: Character = " ") -> String {
+        guard count < length else { return self }
+        return String(repeating: pad, count: length - count) + self
+    }
+}
+

--- a/PureMac/Logic/Storage/StorageCoverageDiagnostics.swift
+++ b/PureMac/Logic/Storage/StorageCoverageDiagnostics.swift
@@ -1,0 +1,1128 @@
+import Darwin
+import Foundation
+
+/// Performs only immediate-child metadata discovery. It never recurses and it
+/// never calculates or assigns bytes to discovered coverage gaps.
+struct StorageCoverageGapDiscovery: Sendable {
+    private struct Child: Sendable {
+        let name: String
+        let path: String
+        let isHidden: Bool
+    }
+
+    private struct DirectoryListing: Sendable {
+        let children: [Child]
+        let issue: StorageScanIssue?
+        let wasCancelled: Bool
+    }
+
+    private static let specializedLibraryNames: Set<String> = [
+        "Application Support",
+        "Containers",
+        "Group Containers",
+    ]
+
+    private let homeDirectoryURL: URL
+
+    init(
+        homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) {
+        self.homeDirectoryURL = homeDirectoryURL.standardizedFileURL
+    }
+
+    func discover() async -> StorageCoverageDiscoveryResult {
+        let home = homeDirectoryURL
+        let task = Task.detached(priority: .utility) {
+            Self.discoverSynchronously(homeDirectoryURL: home)
+        }
+        return await withTaskCancellationHandler(operation: {
+            await task.value
+        }, onCancel: {
+            task.cancel()
+        })
+    }
+
+    static func discoverSynchronously(
+        homeDirectoryURL: URL
+    ) -> StorageCoverageDiscoveryResult {
+        let home = homeDirectoryURL.standardizedFileURL
+        let library = home.appendingPathComponent("Library", isDirectory: true)
+        let homeListing = immediateChildren(at: home.path)
+
+        if homeListing.wasCancelled {
+            return StorageCoverageDiscoveryResult(
+                homeDirectoryPath: home.path,
+                hiddenHomeEntries: [],
+                unspecializedLibraryEntries: [],
+                issues: homeListing.issue.map { [$0] } ?? [],
+                wasCancelled: true
+            )
+        }
+
+        let libraryListing = immediateChildren(at: library.path)
+        let hiddenHome = homeListing.children
+            .filter(\.isHidden)
+            .map { child in
+                StorageCoverageGap(
+                    kind: .hiddenHomeEntry,
+                    name: child.name,
+                    absolutePath: child.path,
+                    category: .uncoveredFilesystemRegion,
+                    state: .presentButUnmeasured,
+                    confidence: .unmeasured,
+                    explanation: "This hidden home entry exists but is intentionally outside the visible-home analyzer. No size was measured."
+                )
+            }
+            .sorted { ($0.absolutePath ?? "") < ($1.absolutePath ?? "") }
+        let unspecializedLibrary = libraryListing.children
+            .filter { !specializedLibraryNames.contains($0.name) }
+            .map { child in
+                StorageCoverageGap(
+                    kind: .unspecializedUserLibraryEntry,
+                    name: child.name,
+                    absolutePath: child.path,
+                    category: .uncoveredFilesystemRegion,
+                    state: .presentButUnmeasured,
+                    confidence: .unmeasured,
+                    explanation: "This immediate Library entry exists outside the three specialized user-Library analyzers. No size was measured."
+                )
+            }
+            .sorted { ($0.absolutePath ?? "") < ($1.absolutePath ?? "") }
+
+        return StorageCoverageDiscoveryResult(
+            homeDirectoryPath: home.path,
+            hiddenHomeEntries: hiddenHome,
+            unspecializedLibraryEntries: unspecializedLibrary,
+            issues: [homeListing.issue, libraryListing.issue]
+                .compactMap { $0 }
+                .sorted(by: issueSort),
+            wasCancelled: libraryListing.wasCancelled
+        )
+    }
+
+    private static func immediateChildren(at path: String) -> DirectoryListing {
+        guard !Task.isCancelled else {
+            return DirectoryListing(children: [], issue: cancellationIssue(path), wasCancelled: true)
+        }
+        guard let directory = opendir(path) else {
+            let errorCode = Darwin.errno
+            return DirectoryListing(
+                children: [],
+                issue: posixIssue(path: path, errorCode: errorCode, operation: "Coverage discovery"),
+                wasCancelled: false
+            )
+        }
+        defer { closedir(directory) }
+
+        var children: [Child] = []
+        while true {
+            guard !Task.isCancelled else {
+                return DirectoryListing(
+                    children: children,
+                    issue: cancellationIssue(path),
+                    wasCancelled: true
+                )
+            }
+            Darwin.errno = 0
+            guard let entry = readdir(directory) else {
+                let errorCode = Darwin.errno
+                return DirectoryListing(
+                    children: children.sorted { $0.path < $1.path },
+                    issue: errorCode == 0
+                        ? nil
+                        : posixIssue(path: path, errorCode: errorCode, operation: "Coverage discovery"),
+                    wasCancelled: false
+                )
+            }
+
+            var nameBuffer = entry.pointee.d_name
+            let capacity = MemoryLayout.size(ofValue: nameBuffer)
+            let name = withUnsafePointer(to: &nameBuffer) { pointer in
+                pointer.withMemoryRebound(to: CChar.self, capacity: capacity) {
+                    String(cString: $0)
+                }
+            }
+            guard name != ".", name != ".." else { continue }
+
+            let childPath = path == "/" ? "/\(name)" : "\(path)/\(name)"
+            var metadata = stat()
+            let metadataAvailable = lstat(childPath, &metadata) == 0
+            let hiddenByFlag = metadataAvailable
+                && (UInt32(metadata.st_flags) & UInt32(UF_HIDDEN)) != 0
+            children.append(Child(
+                name: name,
+                path: childPath,
+                isHidden: name.hasPrefix(".") || hiddenByFlag
+            ))
+        }
+    }
+
+    private static func posixIssue(
+        path: String,
+        errorCode: Int32,
+        operation: String
+    ) -> StorageScanIssue {
+        let kind: StorageScanIssueKind
+        if errorCode == EACCES || errorCode == EPERM {
+            kind = .permissionDenied
+        } else {
+            kind = .directoryEnumerationFailed
+        }
+        return StorageScanIssue(
+            path: path,
+            kind: kind,
+            message: "\(operation) failed: \(String(cString: strerror(errorCode)))",
+            posixErrorCode: errorCode
+        )
+    }
+
+    private static func cancellationIssue(_ path: String) -> StorageScanIssue {
+        StorageScanIssue(
+            path: path,
+            kind: .cancelled,
+            message: "Coverage discovery was cancelled before it completed.",
+            posixErrorCode: nil
+        )
+    }
+
+    private static func issueSort(_ left: StorageScanIssue, _ right: StorageScanIssue) -> Bool {
+        if left.path != right.path { return left.path < right.path }
+        if left.kind != right.kind { return left.kind.rawValue < right.kind.rawValue }
+        return (left.posixErrorCode ?? 0) < (right.posixErrorCode ?? 0)
+    }
+}
+
+/// Builds compact diagnostics from analyzer results that already exist. The
+/// builder does not traverse filesystem trees and does not alter reconciliation
+/// byte values.
+struct StorageCoverageDiagnosticBuilder: Sendable {
+    struct Event: Hashable, Sendable {
+        let category: StorageCoverageDiagnosticCategory
+        let severity: StorageCoverageDiagnosticSeverity
+        let source: StorageCoverageDiagnosticSource
+        let canonicalRoot: StorageCanonicalRoot?
+        let originalPath: String?
+        let normalizedPath: String?
+        let posixErrorCode: Int32?
+        let explanation: String
+    }
+
+    private let representativePathLimit: Int
+    private let parentPathLimit: Int
+
+    init(representativePathLimit: Int = 5, parentPathLimit: Int = 10) {
+        self.representativePathLimit = max(representativePathLimit, 1)
+        self.parentPathLimit = max(parentPathLimit, 1)
+    }
+
+    func build(
+        analyzerResults: StorageAnalyzerResults,
+        canonicalRootCoverage: [StorageCanonicalRootCoverage],
+        filesystemContributions: [StorageFilesystemContribution],
+        analysisIssues: [StorageReconciliationIssue],
+        discovery: StorageCoverageDiscoveryResult,
+        unexplainedBytes: Int64?,
+        purgeableEstimateBytes: Int64?,
+        incompleteCoverage: Bool,
+        wasCancelled: Bool
+    ) -> StorageCoverageDiagnostic {
+        var events = filesystemEvents(
+            from: analyzerResults,
+            coverage: canonicalRootCoverage
+        )
+        events.append(contentsOf: canonicalRootEvents(from: canonicalRootCoverage))
+        events.append(contentsOf: discovery.issues.map {
+            event(
+                for: $0,
+                source: .coverageDiscovery,
+                coverage: canonicalRootCoverage
+            )
+        })
+        events.append(contentsOf: dockerEvents(
+            from: analyzerResults.dockerStorage,
+            existing: events,
+            coverage: canonicalRootCoverage
+        ))
+        events.append(contentsOf: apfsEvents(from: analyzerResults.apfsStorage))
+        events.append(contentsOf: reconciliationEvents(
+            analysisIssues,
+            existing: events,
+            coverage: canonicalRootCoverage
+        ))
+        if wasCancelled, !events.contains(where: { $0.category == .cancelled }) {
+            events.append(Event(
+                category: .cancelled,
+                severity: .warning,
+                source: .reconciliation,
+                canonicalRoot: nil,
+                originalPath: nil,
+                normalizedPath: nil,
+                posixErrorCode: nil,
+                explanation: Self.explanation(for: .cancelled)
+            ))
+        }
+
+        let aggregation = aggregate(events, coverage: canonicalRootCoverage)
+        let gaps = coverageGaps(
+            discovery: discovery,
+            coverage: canonicalRootCoverage,
+            aggregation: aggregation
+        )
+        let map = coverageMap(
+            coverage: canonicalRootCoverage,
+            contributions: filesystemContributions,
+            gaps: gaps,
+            hasAPFS: analyzerResults.apfsStorage != nil
+        )
+        let statuses = analyzerStatuses(
+            results: analyzerResults,
+            coverage: canonicalRootCoverage,
+            issues: analysisIssues,
+            aggregation: aggregation,
+            wasCancelled: wasCancelled
+        )
+        let explanations = unexplainedExplanations(
+            aggregation: aggregation,
+            unexplainedBytes: unexplainedBytes,
+            purgeableEstimateBytes: purgeableEstimateBytes,
+            hasAPFS: analyzerResults.apfsStorage != nil,
+            incompleteCoverage: incompleteCoverage
+        )
+        let explainedConfidence: StorageMeasurementConfidence
+        if wasCancelled || canonicalRootCoverage.contains(where: {
+            $0.state == .partiallyCompleted || $0.state == .failed || $0.state == .cancelled
+        }) {
+            explainedConfidence = .knownLowerBound
+        } else if incompleteCoverage {
+            explainedConfidence = .partialCoverage
+        } else {
+            explainedConfidence = .completeMeasurement
+        }
+
+        return StorageCoverageDiagnostic(
+            measurementIssues: aggregation,
+            coverageMap: map,
+            coverageGaps: gaps,
+            analyzerStatuses: statuses,
+            unexplainedSpaceExplanations: explanations,
+            explainedStorageConfidence: explainedConfidence,
+            unexplainedStorageConfidence: .unmeasured,
+            hiddenHomeEntryCount: discovery.hiddenHomeEntries.count,
+            unspecializedLibraryEntryCount: discovery.unspecializedLibraryEntries.count
+        )
+    }
+}
+
+extension StorageCoverageDiagnosticBuilder {
+    static func category(for issue: StorageScanIssue) -> StorageCoverageDiagnosticCategory {
+        if issue.posixErrorCode == EACCES || issue.posixErrorCode == EPERM {
+            return .permissionDenied
+        }
+        if issue.posixErrorCode == ENOENT {
+            return .concurrentFilesystemChange
+        }
+        switch issue.kind {
+        case .permissionDenied: return .permissionDenied
+        case .unreadable, .notDirectory: return .inaccessible
+        case .directoryEnumerationFailed: return .enumerationFailure
+        case .metadataUnavailable: return .metadataFailure
+        case .differentVolume: return .differentVolumeBoundary
+        case .cancelled: return .cancelled
+        }
+    }
+
+    static func explanation(for category: StorageCoverageDiagnosticCategory) -> String {
+        switch category {
+        case .permissionDenied:
+            return "The operating system denied access to this location (EACCES or EPERM where reported)."
+        case .inaccessible:
+            return "The location could not be read for a reason that was not identified as a permission denial."
+        case .enumerationFailure:
+            return "The directory opened incompletely or its entries could not be enumerated."
+        case .metadataFailure:
+            return "Filesystem or analyzer metadata could not be read or parsed."
+        case .differentVolumeBoundary:
+            return "Traversal stopped at another mounted filesystem to preserve volume-local accounting."
+        case .cancelled:
+            return "The operation stopped before this measurement completed."
+        case .missingOptionalRoot:
+            return "An optional configured location was not present; no bytes were inferred."
+        case .failedAnalyzer:
+            return "An analyzer or one of its read-only inspection commands did not complete."
+        case .uncoveredFilesystemRegion:
+            return "This filesystem region is outside the current configured scan coverage."
+        case .nonAdditiveAPFSStorage:
+            return "APFS metadata and snapshot values are explanatory and not additive to file totals."
+        case .possibleSharedExtentAccounting:
+            return "Shared extents, clones, or cross-scope identity can limit direct physical attribution."
+        case .concurrentFilesystemChange:
+            return "The path disappeared while the scan was running (ENOENT) and is not a permission failure."
+        case .unknown:
+            return "The available issue metadata is insufficient for a more specific classification."
+        }
+    }
+}
+
+private extension StorageCoverageDiagnosticBuilder {
+    func canonicalRootEvents(
+        from coverage: [StorageCanonicalRootCoverage]
+    ) -> [Event] {
+        coverage.compactMap { item in
+            guard item.state == .missingOptional else { return nil }
+            return Event(
+                category: .missingOptionalRoot,
+                severity: .informational,
+                source: .canonicalRoot(item.root),
+                canonicalRoot: item.root,
+                originalPath: item.configuredPath,
+                normalizedPath: StoragePathNormalizer.normalize(item.configuredPath),
+                posixErrorCode: nil,
+                explanation: Self.explanation(for: .missingOptionalRoot)
+            )
+        }
+    }
+
+    func filesystemEvents(
+        from results: StorageAnalyzerResults,
+        coverage: [StorageCanonicalRootCoverage]
+    ) -> [Event] {
+        var pairs: [(StorageScanIssue, StorageAnalyzerStage)] = []
+        append(results.userHomeStorage?.issues, stage: .userHomeStorage, to: &pairs)
+        append(results.applicationSupport?.issues, stage: .applicationSupport, to: &pairs)
+        append(results.containers?.issues, stage: .containers, to: &pairs)
+        append(results.groupContainers?.issues, stage: .groupContainers, to: &pairs)
+        append(results.systemLibrary?.issues, stage: .systemLibrary, to: &pairs)
+        append(results.privateStorage?.issues, stage: .privateStorage, to: &pairs)
+        append(results.dataVolumeHiddenStorage?.issues, stage: .dataVolumeHiddenStorage, to: &pairs)
+        append(results.developerSystemStorage?.issues, stage: .developerSystemStorage, to: &pairs)
+        append(results.coverageExpansion?.issues, stage: .coverageExpansion, to: &pairs)
+        results.dockerStorage?.hostFootprint.locations.forEach {
+            append($0.issues, stage: .dockerStorage, to: &pairs)
+        }
+        return pairs.map { issue, stage in
+            event(for: issue, source: .analyzer(stage), coverage: coverage)
+        }
+    }
+
+    func append(
+        _ issues: [StorageScanIssue]?,
+        stage: StorageAnalyzerStage,
+        to pairs: inout [(StorageScanIssue, StorageAnalyzerStage)]
+    ) {
+        guard let issues else { return }
+        pairs.append(contentsOf: issues.map { ($0, stage) })
+    }
+
+    func event(
+        for issue: StorageScanIssue,
+        source: StorageCoverageDiagnosticSource,
+        coverage: [StorageCanonicalRootCoverage]
+    ) -> Event {
+        let category = Self.category(for: issue)
+        let original = issue.path
+        let norm = StoragePathNormalizer.normalize(original)
+        let explanation: String
+        if category == .permissionDenied && StoragePathNormalizer.isSystemProtectedLocation(norm) {
+            explanation = "This system-managed location is protected by macOS security policies (EACCES/EPERM); it remains inaccessible even when Full Disk Access is granted."
+        } else {
+            explanation = Self.explanation(for: category)
+        }
+        return Event(
+            category: category,
+            severity: category == .differentVolumeBoundary ? .informational : .warning,
+            source: source,
+            canonicalRoot: canonicalRoot(for: original, coverage: coverage),
+            originalPath: original,
+            normalizedPath: norm,
+            posixErrorCode: issue.posixErrorCode,
+            explanation: explanation
+        )
+    }
+
+    func dockerEvents(
+        from report: DockerStorageReport?,
+        existing: [Event],
+        coverage: [StorageCanonicalRootCoverage]
+    ) -> [Event] {
+        guard let report else { return [] }
+        let existingPaths = Set(existing.compactMap { event -> String? in
+            guard event.source == .analyzer(.dockerStorage) else { return nil }
+            return event.normalizedPath
+        })
+        return report.issues.compactMap { issue in
+            if issue.kind == .filesystem,
+               let path = issue.path.map({ StoragePathNormalizer.normalize($0) }),
+               existingPaths.contains(path) {
+                return nil
+            }
+            let category: StorageCoverageDiagnosticCategory
+            switch issue.kind {
+            case .filesystem: category = .inaccessible
+            case .executableNotFound: category = .missingOptionalRoot
+            case .cancelled: category = .cancelled
+            case .contextInspectionFailed, .daemonUnavailable, .commandFailed:
+                category = .failedAnalyzer
+            case .malformedRuntimeOutput: category = .metadataFailure
+            case .runtimeLocationUnknown: category = .unknown
+            }
+            let original = issue.path
+            let norm = original.map { StoragePathNormalizer.normalize($0) }
+            return Event(
+                category: category,
+                severity: category == .missingOptionalRoot || category == .unknown
+                    ? .informational
+                    : .warning,
+                source: .analyzer(.dockerStorage),
+                canonicalRoot: original.flatMap { canonicalRoot(for: $0, coverage: coverage) },
+                originalPath: original,
+                normalizedPath: norm,
+                posixErrorCode: nil,
+                explanation: Self.explanation(for: category)
+            )
+        }
+    }
+
+    func apfsEvents(from report: APFSStorageReport?) -> [Event] {
+        guard let report else { return [] }
+        return report.issues.map { issue in
+            let category: StorageCoverageDiagnosticCategory
+            switch issue.kind {
+            case .permissionDenied: category = .permissionDenied
+            case .cancelled: category = .cancelled
+            case .commandUnavailable, .commandFailed: category = .failedAnalyzer
+            case .volumeStatisticsUnavailable, .malformedPlist, .malformedOutput, .partialMetadata:
+                category = .metadataFailure
+            }
+            return Event(
+                category: category,
+                severity: .warning,
+                source: .analyzer(.apfsVolume),
+                canonicalRoot: nil,
+                originalPath: nil,
+                normalizedPath: nil,
+                posixErrorCode: nil,
+                explanation: Self.explanation(for: category)
+            )
+        }
+    }
+
+    func reconciliationEvents(
+        _ issues: [StorageReconciliationIssue],
+        existing: [Event],
+        coverage: [StorageCanonicalRootCoverage]
+    ) -> [Event] {
+        let existingCancellationStages = Set(existing.compactMap { event -> StorageAnalyzerStage? in
+            guard event.category == .cancelled,
+                  case let .analyzer(stage) = event.source else { return nil }
+            return stage
+        })
+        let existingAnalyzerPaths = Set(existing.compactMap { event -> String? in
+            guard case let .analyzer(stage) = event.source else { return nil }
+            return "\(stage.rawValue)|\(event.normalizedPath ?? "<none>")"
+        })
+        return issues.compactMap { issue in
+            let category: StorageCoverageDiagnosticCategory
+            switch issue.kind {
+            case .analyzerFailure: category = .failedAnalyzer
+            case .cancelled:
+                if let stage = issue.stage, existingCancellationStages.contains(stage) { return nil }
+                category = .cancelled
+            case .analyzerIssue, .permissionIncomplete:
+                if let stage = issue.stage {
+                    let path = issue.path.map { StoragePathNormalizer.normalize($0) } ?? "<none>"
+                    if existingAnalyzerPaths.contains("\(stage.rawValue)|\(path)") {
+                        return nil
+                    }
+                }
+                category = .unknown
+            default:
+                return nil
+            }
+            let source = issue.stage.map(StorageCoverageDiagnosticSource.analyzer)
+                ?? .reconciliation
+            let original = issue.path
+            let norm = original.map { StoragePathNormalizer.normalize($0) }
+            return Event(
+                category: category,
+                severity: .warning,
+                source: source,
+                canonicalRoot: original.flatMap { canonicalRoot(for: $0, coverage: coverage) },
+                originalPath: original,
+                normalizedPath: norm,
+                posixErrorCode: nil,
+                explanation: Self.explanation(for: category)
+            )
+        }
+    }
+
+    func aggregate(
+        _ events: [Event],
+        coverage: [StorageCanonicalRootCoverage]
+    ) -> StorageCoverageIssueAggregation {
+        struct LocationKey: Hashable {
+            let category: StorageCoverageDiagnosticCategory
+            let normalizedPath: String?
+            let posixErrorCode: Int32?
+        }
+
+        struct AggregatedLocation {
+            let category: StorageCoverageDiagnosticCategory
+            let severity: StorageCoverageDiagnosticSeverity
+            let normalizedPath: String?
+            let posixErrorCode: Int32?
+            var originalPaths: Set<String>
+            var sources: Set<StorageCoverageDiagnosticSource>
+            var canonicalRoots: Set<StorageCanonicalRoot>
+            var primarySource: StorageCoverageDiagnosticSource
+            var primaryCanonicalRoot: StorageCanonicalRoot?
+            var explanation: String
+        }
+
+        var locationsByKey: [LocationKey: AggregatedLocation] = [:]
+        var orderedKeys: [LocationKey] = []
+
+        for event in events {
+            let key = LocationKey(
+                category: event.category,
+                normalizedPath: event.normalizedPath,
+                posixErrorCode: event.posixErrorCode
+            )
+
+            if var existing = locationsByKey[key] {
+                if let orig = event.originalPath {
+                    existing.originalPaths.insert(orig)
+                }
+                existing.sources.insert(event.source)
+                if let root = event.canonicalRoot {
+                    existing.canonicalRoots.insert(root)
+                }
+                if existing.primarySource.identifier.starts(with: "reconciliation")
+                    || existing.primarySource.identifier.starts(with: "coverage-discovery") {
+                    existing.primarySource = event.source
+                }
+                if existing.primaryCanonicalRoot == nil {
+                    existing.primaryCanonicalRoot = event.canonicalRoot
+                }
+                if event.explanation.contains("system-managed") {
+                    existing.explanation = event.explanation
+                }
+                locationsByKey[key] = existing
+            } else {
+                var origSet = Set<String>()
+                if let orig = event.originalPath {
+                    origSet.insert(orig)
+                }
+                var rootSet = Set<StorageCanonicalRoot>()
+                if let root = event.canonicalRoot {
+                    rootSet.insert(root)
+                }
+                let newLocation = AggregatedLocation(
+                    category: event.category,
+                    severity: event.severity,
+                    normalizedPath: event.normalizedPath,
+                    posixErrorCode: event.posixErrorCode,
+                    originalPaths: origSet,
+                    sources: [event.source],
+                    canonicalRoots: rootSet,
+                    primarySource: event.source,
+                    primaryCanonicalRoot: event.canonicalRoot,
+                    explanation: event.explanation
+                )
+                locationsByKey[key] = newLocation
+                orderedKeys.append(key)
+            }
+        }
+
+        let deduplicatedLocations = orderedKeys.compactMap { locationsByKey[$0] }
+
+        var categoryCounts: [StorageCoverageDiagnosticCategory: Int] = [:]
+        var analyzerCounts: [StorageAnalyzerStage: Int] = [:]
+        var rootCounts: [StorageCanonicalRoot: Int] = [:]
+        var errnoCounts: [Int32: Int] = [:]
+        var parentCounts: [String: Int] = [:]
+
+        struct GroupIdentity: Hashable {
+            let category: StorageCoverageDiagnosticCategory
+            let severity: StorageCoverageDiagnosticSeverity
+            let source: StorageCoverageDiagnosticSource
+            let canonicalRoot: StorageCanonicalRoot?
+            let posixErrorCode: Int32?
+            let explanation: String
+        }
+
+        var groupedLocations: [GroupIdentity: [AggregatedLocation]] = [:]
+
+        for location in deduplicatedLocations {
+            categoryCounts[location.category, default: 0] += 1
+            for src in location.sources {
+                if case let .analyzer(stage) = src {
+                    analyzerCounts[stage, default: 0] += 1
+                }
+            }
+            for root in location.canonicalRoots {
+                rootCounts[root, default: 0] += 1
+            }
+            if let errorCode = location.posixErrorCode {
+                errnoCounts[errorCode, default: 0] += 1
+            }
+            if let path = location.normalizedPath {
+                parentCounts[StoragePathNormalizer.parentPath(of: path), default: 0] += 1
+            }
+
+            let groupKey = GroupIdentity(
+                category: location.category,
+                severity: location.severity,
+                source: location.primarySource,
+                canonicalRoot: location.primaryCanonicalRoot,
+                posixErrorCode: location.posixErrorCode,
+                explanation: location.explanation
+            )
+            groupedLocations[groupKey, default: []].append(location)
+        }
+
+        let configuredPaths = Dictionary(
+            uniqueKeysWithValues: coverage.map { ($0.root, $0.configuredPath) }
+        )
+
+        let groups = groupedLocations.map { identity, locs in
+            var allRepresentativePaths: [String] = []
+            var allContributingSources: Set<StorageCoverageDiagnosticSource> = []
+            for loc in locs {
+                if loc.originalPaths.isEmpty {
+                    if let p = loc.normalizedPath {
+                        allRepresentativePaths.append(p)
+                    }
+                } else {
+                    allRepresentativePaths.append(contentsOf: loc.originalPaths)
+                }
+                allContributingSources.formUnion(loc.sources)
+            }
+
+            let sortedPaths = Array(Set(allRepresentativePaths))
+                .sorted()
+                .prefix(representativePathLimit)
+                .map { $0 }
+
+            let sortedSources = allContributingSources.sorted { $0.identifier < $1.identifier }
+
+            return StorageCoverageDiagnosticIssueGroup(
+                category: identity.category,
+                severity: identity.severity,
+                source: identity.source,
+                contributingSources: sortedSources,
+                canonicalRoot: identity.canonicalRoot,
+                posixErrorCode: identity.posixErrorCode,
+                count: locs.count,
+                representativePaths: sortedPaths,
+                explanation: identity.explanation
+            )
+        }.sorted(by: groupSort)
+
+        return StorageCoverageIssueAggregation(
+            totalIssueCount: deduplicatedLocations.count,
+            categoryCounts: categoryCounts.map {
+                StorageCoverageDiagnosticCategoryCount(category: $0.key, count: $0.value)
+            }.sorted { $0.category.rawValue < $1.category.rawValue },
+            analyzerCounts: analyzerCounts.map {
+                StorageCoverageDiagnosticAnalyzerCount(analyzer: $0.key, count: $0.value)
+            }.sorted { analyzerIndex($0.analyzer) < analyzerIndex($1.analyzer) },
+            canonicalRootCounts: rootCounts.map {
+                StorageCoverageDiagnosticRootCount(
+                    root: $0.key,
+                    configuredPath: configuredPaths[$0.key] ?? $0.key.rawValue,
+                    count: $0.value
+                )
+            }.sorted { rootIndex($0.root) < rootIndex($1.root) },
+            errnoCounts: errnoCounts.map {
+                StorageCoverageDiagnosticErrnoCount(errorCode: $0.key, count: $0.value)
+            }.sorted { $0.errorCode < $1.errorCode },
+            topAffectedParentPaths: parentCounts.map {
+                StorageCoverageDiagnosticParentCount(parentPath: $0.key, count: $0.value)
+            }.sorted {
+                if $0.count != $1.count { return $0.count > $1.count }
+                return $0.parentPath < $1.parentPath
+            }.prefix(parentPathLimit).map { $0 },
+            groups: groups
+        )
+    }
+
+    func coverageGaps(
+        discovery: StorageCoverageDiscoveryResult,
+        coverage: [StorageCanonicalRootCoverage],
+        aggregation: StorageCoverageIssueAggregation
+    ) -> [StorageCoverageGap] {
+        var gaps = discovery.hiddenHomeEntries + discovery.unspecializedLibraryEntries
+        gaps.append(contentsOf: coverage.compactMap { item in
+            guard item.state == .missingOptional else { return nil }
+            return StorageCoverageGap(
+                kind: .rootFilesystemRegion,
+                name: item.root.rawValue,
+                absolutePath: item.configuredPath,
+                category: .missingOptionalRoot,
+                state: .missingOptional,
+                confidence: .unmeasured,
+                explanation: "This optional configured root was not present; no bytes were inferred for it."
+            )
+        })
+        gaps.append(StorageCoverageGap(
+            kind: .otherUsers,
+            name: "Other users",
+            absolutePath: "/Users",
+            category: .uncoveredFilesystemRegion,
+            state: .intentionallyUnmeasured,
+            confidence: .unmeasured,
+            explanation: "Other user home directories are outside the current per-user scan coverage."
+        ))
+        gaps.append(StorageCoverageGap(
+            kind: .rootFilesystemRegion,
+            name: "Other root-level regions",
+            absolutePath: "/",
+            category: .uncoveredFilesystemRegion,
+            state: .intentionallyUnmeasured,
+            confidence: .unmeasured,
+            explanation: "Root-level filesystem regions without a canonical analyzer are not recursively measured."
+        ))
+        gaps.append(StorageCoverageGap(
+            kind: .otherMountedVolume,
+            name: "Other mounted volumes",
+            absolutePath: "/Volumes",
+            category: .uncoveredFilesystemRegion,
+            state: .intentionallyUnmeasured,
+            confidence: .unmeasured,
+            explanation: "Other mounted filesystems are intentionally excluded from startup-volume accounting."
+        ))
+        let incompleteCategories: Set<StorageCoverageDiagnosticCategory> = [
+            .permissionDenied,
+            .inaccessible,
+            .enumerationFailure,
+            .metadataFailure,
+            .concurrentFilesystemChange,
+        ]
+        for group in aggregation.groups where incompleteCategories.contains(group.category) {
+            for path in group.representativePaths {
+                gaps.append(StorageCoverageGap(
+                    kind: .inaccessibleSubtree,
+                    name: URL(fileURLWithPath: path).lastPathComponent,
+                    absolutePath: path,
+                    category: group.category,
+                    state: .partiallyMeasured,
+                    confidence: .knownLowerBound,
+                    explanation: group.explanation
+                ))
+            }
+        }
+        return gaps.uniqued(by: \StorageCoverageGap.id).sorted {
+            if $0.kind != $1.kind { return $0.kind.rawValue < $1.kind.rawValue }
+            return ($0.absolutePath ?? $0.name) < ($1.absolutePath ?? $1.name)
+        }
+    }
+
+    func coverageMap(
+        coverage: [StorageCanonicalRootCoverage],
+        contributions: [StorageFilesystemContribution],
+        gaps: [StorageCoverageGap],
+        hasAPFS: Bool
+    ) -> [StorageCoverageMapEntry] {
+        var entries = coverage.map { item in
+            StorageCoverageMapEntry(
+                identifier: "canonical:\(item.root.rawValue)",
+                title: rootTitle(item.root),
+                absolutePath: item.configuredPath,
+                source: .canonicalRoot(item.root),
+                state: mapState(item.state),
+                confidence: item.measurementConfidence,
+                explanation: rootExplanation(item)
+            )
+        }
+        for contribution in contributions where
+            contribution.source == .dockerHostOutsideCanonicalRoots
+                && contribution.relationship == .externalSpecializedUnique {
+            entries.append(StorageCoverageMapEntry(
+                identifier: "docker:\(contribution.normalizedPath)",
+                title: "External Docker host storage",
+                absolutePath: contribution.absolutePath,
+                source: .analyzer(.dockerStorage),
+                state: .measured,
+                confidence: .completeMeasurement,
+                explanation: "This non-overlapping Docker host path is measured by the Docker analyzer."
+            ))
+        }
+        entries.append(contentsOf: gaps.map { gap in
+            StorageCoverageMapEntry(
+                identifier: "gap:\(gap.id)",
+                title: gap.name,
+                absolutePath: gap.absolutePath,
+                source: .coverageDiscovery,
+                state: gap.state,
+                confidence: gap.confidence,
+                explanation: gap.explanation
+            )
+        })
+        if hasAPFS {
+            entries.append(StorageCoverageMapEntry(
+                identifier: "apfs:non-additive",
+                title: "APFS metadata and snapshots",
+                absolutePath: nil,
+                source: .apfs,
+                state: .nonAdditive,
+                confidence: .nonAdditiveMetadata,
+                explanation: "APFS metadata, snapshots, clones, and shared extents cannot be added directly to filesystem tree totals."
+            ))
+        }
+        return entries.sorted { $0.identifier < $1.identifier }
+    }
+
+    func analyzerStatuses(
+        results: StorageAnalyzerResults,
+        coverage: [StorageCanonicalRootCoverage],
+        issues: [StorageReconciliationIssue],
+        aggregation: StorageCoverageIssueAggregation,
+        wasCancelled: Bool
+    ) -> [StorageAnalyzerCoverageDiagnostic] {
+        let counts = Dictionary(uniqueKeysWithValues: aggregation.analyzerCounts.map {
+            ($0.analyzer, $0.count)
+        })
+        let failedStages = Set(issues.compactMap {
+            $0.kind == .analyzerFailure ? $0.stage : nil
+        })
+        let cancelledStages = Set(issues.compactMap {
+            $0.kind == .cancelled ? $0.stage : nil
+        })
+
+        return StorageAnalyzerStage.allCases.map { stage in
+            let state: StorageAnalyzerDiagnosticState
+            if failedStages.contains(stage) {
+                state = .failed
+            } else if cancelledStages.contains(stage) {
+                state = .cancelled
+            } else if wasCancelled && !hasResult(for: stage, in: results) {
+                state = .cancelled
+            } else if stage == .apfsVolume {
+                switch results.apfsStorage?.state {
+                case .cancelled: state = .cancelled
+                case .partial: state = .knownLowerBound
+                case .unavailable, nil: state = .failed
+                case .complete, .nonAPFS: state = .nonAdditiveMetadata
+                }
+            } else if stage == .dockerStorage {
+                if results.dockerStorage?.wasCancelled == true {
+                    state = .cancelled
+                } else if results.dockerStorage == nil {
+                    state = .failed
+                } else {
+                    state = .complete
+                }
+            } else {
+                let roots = roots(for: stage, coverage: coverage)
+                if roots.isEmpty {
+                    state = .failed
+                } else if roots.allSatisfy({ $0.state == .missingOptional }) {
+                    state = .optionalRootMissing
+                } else if roots.contains(where: { $0.state == .cancelled }) {
+                    state = .cancelled
+                } else if roots.contains(where: { $0.state == .failed }) {
+                    state = .failed
+                } else if roots.contains(where: { $0.state == .partiallyCompleted }) {
+                    state = .knownLowerBound
+                } else {
+                    state = .complete
+                }
+            }
+            return StorageAnalyzerCoverageDiagnostic(
+                analyzer: stage,
+                state: state,
+                issueCount: counts[stage] ?? 0,
+                confidence: confidence(for: state)
+            )
+        }
+    }
+
+    func unexplainedExplanations(
+        aggregation: StorageCoverageIssueAggregation,
+        unexplainedBytes: Int64?,
+        purgeableEstimateBytes: Int64?,
+        hasAPFS: Bool,
+        incompleteCoverage: Bool
+    ) -> [StorageCoverageExplanation] {
+        var values: [StorageCoverageExplanation] = []
+        if incompleteCoverage || unexplainedBytes != 0 {
+            values.append(StorageCoverageExplanation(
+                category: .uncoveredFilesystemRegion,
+                severity: .informational,
+                title: "Filesystem coverage gaps",
+                detail: "Unexplained capacity may include filesystem regions that PureMac does not currently scan or descendants it could not measure."
+            ))
+        }
+        if hasAPFS {
+            values.append(StorageCoverageExplanation(
+                category: .nonAdditiveAPFSStorage,
+                severity: .informational,
+                title: "APFS storage is non-additive",
+                detail: "Snapshots and APFS metadata can share physical extents with live files, so they are not added to explained filesystem bytes."
+            ))
+            values.append(StorageCoverageExplanation(
+                category: .possibleSharedExtentAccounting,
+                severity: .informational,
+                title: "Shared extents and clones",
+                detail: "APFS clones and shared extents can make physical attribution differ from a simple sum of directory trees."
+            ))
+        }
+        if purgeableEstimateBytes != nil {
+            values.append(StorageCoverageExplanation(
+                category: .nonAdditiveAPFSStorage,
+                severity: .informational,
+                title: "Purgeable capacity is an estimate",
+                detail: "The system purgeable estimate remains separate from explained and unexplained storage."
+            ))
+        }
+        if aggregation.categoryCounts.contains(where: {
+            $0.category == .concurrentFilesystemChange && $0.count > 0
+        }) {
+            values.append(StorageCoverageExplanation(
+                category: .concurrentFilesystemChange,
+                severity: .informational,
+                title: "Files changed during analysis",
+                detail: "Some paths disappeared while the scan was running, which can leave a small point-in-time accounting difference."
+            ))
+        }
+        return values.sorted {
+            if $0.category != $1.category { return $0.category.rawValue < $1.category.rawValue }
+            return $0.title < $1.title
+        }
+    }
+
+    func canonicalRoot(
+        for path: String,
+        coverage: [StorageCanonicalRootCoverage]
+    ) -> StorageCanonicalRoot? {
+        let candidate = normalized(path)
+        return coverage
+            .filter { contains(parent: normalized($0.configuredPath), child: candidate) }
+            .max { normalized($0.configuredPath).count < normalized($1.configuredPath).count }?
+            .root
+    }
+
+    func roots(
+        for stage: StorageAnalyzerStage,
+        coverage: [StorageCanonicalRootCoverage]
+    ) -> [StorageCanonicalRootCoverage] {
+        let expected: Set<StorageCanonicalRoot>
+        switch stage {
+        case .userHomeStorage: expected = [.userHomeVisibleStorage]
+        case .applicationSupport: expected = [.applicationSupport]
+        case .containers: expected = [.containers]
+        case .groupContainers: expected = [.groupContainers]
+        case .systemLibrary: expected = [.systemLibrary]
+        case .privateStorage: expected = [.privateStorage]
+        case .dataVolumeHiddenStorage: expected = [.dataVolumeHiddenStorage]
+        case .developerSystemStorage: expected = [.opt, .usrLocal]
+        case .coverageExpansion: expected = [.additionalCoverageGap]
+        case .dockerStorage, .apfsVolume: expected = []
+        }
+        return coverage.filter { expected.contains($0.root) }
+    }
+
+    func confidence(for state: StorageAnalyzerDiagnosticState) -> StorageMeasurementConfidence {
+        switch state {
+        case .complete: return .completeMeasurement
+        case .knownLowerBound, .failed, .cancelled: return .knownLowerBound
+        case .optionalRootMissing: return .unmeasured
+        case .nonAdditiveMetadata: return .nonAdditiveMetadata
+        }
+    }
+
+    func hasResult(
+        for stage: StorageAnalyzerStage,
+        in results: StorageAnalyzerResults
+    ) -> Bool {
+        switch stage {
+        case .apfsVolume: return results.apfsStorage != nil
+        case .userHomeStorage: return results.userHomeStorage != nil
+        case .applicationSupport: return results.applicationSupport != nil
+        case .containers: return results.containers != nil
+        case .groupContainers: return results.groupContainers != nil
+        case .systemLibrary: return results.systemLibrary != nil
+        case .privateStorage: return results.privateStorage != nil
+        case .dataVolumeHiddenStorage: return results.dataVolumeHiddenStorage != nil
+        case .developerSystemStorage: return results.developerSystemStorage != nil
+        case .dockerStorage: return results.dockerStorage != nil
+        case .coverageExpansion: return results.coverageExpansion != nil
+        }
+    }
+
+    func mapState(_ state: StorageCanonicalRootState) -> StorageCoverageMapState {
+        switch state {
+        case .completed: return .measured
+        case .partiallyCompleted: return .partiallyMeasured
+        case .failed, .cancelled: return .unavailable
+        case .missingOptional: return .missingOptional
+        }
+    }
+
+    func rootExplanation(_ item: StorageCanonicalRootCoverage) -> String {
+        switch item.state {
+        case .completed: return "This configured root completed its measurement."
+        case .partiallyCompleted: return "Measured bytes are a known lower bound because some descendants were incomplete."
+        case .failed: return "This configured root did not produce a complete measurement."
+        case .missingOptional: return "This optional configured root was not present."
+        case .cancelled: return "This configured root was only measured up to cancellation."
+        }
+    }
+
+    func rootTitle(_ root: StorageCanonicalRoot) -> String {
+        switch root {
+        case .userHomeVisibleStorage: return "Visible user-home roots"
+        case .applicationSupport: return "Application Support"
+        case .containers: return "Containers"
+        case .groupContainers: return "Group Containers"
+        case .systemLibrary: return "System Library"
+        case .privateStorage: return "Private / System State"
+        case .dataVolumeHiddenStorage: return "Hidden Data-volume roots"
+        case .opt: return "/opt"
+        case .usrLocal: return "/usr/local"
+        case .additionalCoverageGap: return "Additional Storage Coverage"
+        }
+    }
+
+    func normalized(_ path: String) -> String {
+        StoragePathNormalizer.normalize(path)
+    }
+
+    func contains(parent: String, child: String) -> Bool {
+        StoragePathNormalizer.contains(parent: parent, child: child)
+    }
+
+    func parentPath(of path: String) -> String {
+        StoragePathNormalizer.parentPath(of: path)
+    }
+
+    func analyzerIndex(_ stage: StorageAnalyzerStage) -> Int {
+        StorageAnalyzerStage.allCases.firstIndex(of: stage) ?? Int.max
+    }
+
+    func rootIndex(_ root: StorageCanonicalRoot) -> Int {
+        StorageCanonicalRoot.allCases.firstIndex(of: root) ?? Int.max
+    }
+
+    func groupSort(
+        _ left: StorageCoverageDiagnosticIssueGroup,
+        _ right: StorageCoverageDiagnosticIssueGroup
+    ) -> Bool {
+        if left.count != right.count { return left.count > right.count }
+        if left.category != right.category { return left.category.rawValue < right.category.rawValue }
+        if left.source.identifier != right.source.identifier {
+            return left.source.identifier < right.source.identifier
+        }
+        if left.canonicalRoot != right.canonicalRoot {
+            return (left.canonicalRoot?.rawValue ?? "") < (right.canonicalRoot?.rawValue ?? "")
+        }
+        return (left.posixErrorCode ?? 0) < (right.posixErrorCode ?? 0)
+    }
+}
+
+private extension Array {
+    func uniqued<Key: Hashable>(by keyPath: KeyPath<Element, Key>) -> [Element] {
+        var seen: Set<Key> = []
+        return filter { seen.insert($0[keyPath: keyPath]).inserted }
+    }
+}

--- a/PureMac/Logic/Storage/StorageCoverageDiagnostics.swift
+++ b/PureMac/Logic/Storage/StorageCoverageDiagnostics.swift
@@ -266,7 +266,8 @@ struct StorageCoverageDiagnosticBuilder: Sendable {
         let gaps = coverageGaps(
             discovery: discovery,
             coverage: canonicalRootCoverage,
-            aggregation: aggregation
+            aggregation: aggregation,
+            expansion: analyzerResults.coverageExpansion
         )
         let map = coverageMap(
             coverage: canonicalRootCoverage,
@@ -749,9 +750,132 @@ private extension StorageCoverageDiagnosticBuilder {
     func coverageGaps(
         discovery: StorageCoverageDiscoveryResult,
         coverage: [StorageCanonicalRootCoverage],
-        aggregation: StorageCoverageIssueAggregation
+        aggregation: StorageCoverageIssueAggregation,
+        expansion: StorageCoverageExpansionReport? = nil
     ) -> [StorageCoverageGap] {
-        var gaps = discovery.hiddenHomeEntries + discovery.unspecializedLibraryEntries
+        var gaps: [StorageCoverageGap] = []
+
+        let expansionCandidatesByNormPath = Dictionary(
+            (expansion?.candidates ?? []).map { ($0.normalizedPath, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        for rawGap in (discovery.hiddenHomeEntries + discovery.unspecializedLibraryEntries) {
+            let norm = rawGap.absolutePath.map { StoragePathNormalizer.normalize($0) } ?? ""
+            if let candidate = expansionCandidatesByNormPath[norm] {
+                let state: StorageCoverageMapState
+                let confidence: StorageMeasurementConfidence
+                let isAdditive: Bool
+                let explanation: String
+
+                switch candidate.status {
+                case .measured:
+                    state = .measured
+                    confidence = candidate.issue == nil ? .completeMeasurement : .knownLowerBound
+                    isAdditive = candidate.contributesToExplainedBytes
+                    explanation = "Discovered and measured by targeted coverage expansion pass."
+                case .partiallyMeasured:
+                    state = .partiallyMeasured
+                    confidence = .knownLowerBound
+                    isAdditive = candidate.contributesToExplainedBytes
+                    explanation = candidate.exclusionReason ?? "Partially measured; some items had restricted access."
+                case .inaccessible, .excludedProtectedSystem:
+                    state = .partiallyMeasured
+                    confidence = .knownLowerBound
+                    isAdditive = false
+                    explanation = candidate.exclusionReason ?? "Protected macOS location with restricted access."
+                case .excludedAlreadyAccounted, .excludedNested, .skippedAlreadyOwned, .skippedUnsafeOverlap:
+                    state = .measured
+                    confidence = .nonAdditiveMetadata
+                    isAdditive = false
+                    explanation = candidate.exclusionReason ?? "Already accounted by a specialized canonical root."
+                default:
+                    state = rawGap.state
+                    confidence = rawGap.confidence
+                    isAdditive = false
+                    explanation = rawGap.explanation
+                }
+
+                gaps.append(StorageCoverageGap(
+                    kind: rawGap.kind,
+                    name: rawGap.name,
+                    absolutePath: rawGap.absolutePath,
+                    category: rawGap.category,
+                    state: state,
+                    confidence: confidence,
+                    explanation: explanation,
+                    allocatedBytes: candidate.allocatedBytes,
+                    logicalBytes: candidate.logicalBytes,
+                    isFilesystemAdditive: isAdditive,
+                    issueCount: candidate.issue == nil ? 0 : 1
+                ))
+            } else {
+                gaps.append(rawGap)
+            }
+        }
+
+        if let expansionCandidates = expansion?.candidates {
+            for candidate in expansionCandidates {
+                let norm = candidate.normalizedPath
+                let alreadyInGaps = gaps.contains { ($0.absolutePath.map { StoragePathNormalizer.normalize($0) }) == norm }
+                if !alreadyInGaps {
+                    let kind: StorageCoverageGapKind
+                    switch candidate.scope {
+                    case .hiddenHome: kind = .hiddenHomeEntry
+                    case .userLibrary: kind = .unspecializedUserLibraryEntry
+                    case .dataVolumeRoot, .other: kind = .rootFilesystemRegion
+                    }
+
+                    let state: StorageCoverageMapState
+                    let confidence: StorageMeasurementConfidence
+                    let isAdditive: Bool
+                    let explanation: String
+
+                    switch candidate.status {
+                    case .measured:
+                        state = .measured
+                        confidence = candidate.issue == nil ? .completeMeasurement : .knownLowerBound
+                        isAdditive = candidate.contributesToExplainedBytes
+                        explanation = "Discovered and measured by targeted coverage expansion pass."
+                    case .partiallyMeasured:
+                        state = .partiallyMeasured
+                        confidence = .knownLowerBound
+                        isAdditive = candidate.contributesToExplainedBytes
+                        explanation = candidate.exclusionReason ?? "Partially measured; some items had restricted access."
+                    case .inaccessible, .excludedProtectedSystem:
+                        state = .partiallyMeasured
+                        confidence = .knownLowerBound
+                        isAdditive = false
+                        explanation = candidate.exclusionReason ?? "Protected macOS location with restricted access."
+                    case .excludedAlreadyAccounted, .excludedNested, .skippedAlreadyOwned, .skippedUnsafeOverlap:
+                        state = .measured
+                        confidence = .nonAdditiveMetadata
+                        isAdditive = false
+                        explanation = candidate.exclusionReason ?? "Already accounted by a specialized canonical root."
+                    default:
+                        state = .presentButUnmeasured
+                        confidence = .unmeasured
+                        isAdditive = false
+                        explanation = candidate.exclusionReason ?? "Data-volume candidate discovered during coverage expansion pass."
+                    }
+
+                    gaps.append(StorageCoverageGap(
+                        kind: kind,
+                        name: candidate.name,
+                        absolutePath: candidate.originalPath,
+                        category: candidate.status == .excludedProtectedSystem ? .permissionDenied : .uncoveredFilesystemRegion,
+                        state: state,
+                        confidence: confidence,
+                        explanation: explanation,
+                        allocatedBytes: candidate.allocatedBytes,
+                        logicalBytes: candidate.logicalBytes,
+                        isFilesystemAdditive: isAdditive,
+                        issueCount: candidate.issue == nil ? 0 : 1
+                    ))
+                }
+            }
+        }
+
         gaps.append(contentsOf: coverage.compactMap { item in
             guard item.state == .missingOptional else { return nil }
             return StorageCoverageGap(
@@ -1009,6 +1133,7 @@ private extension StorageCoverageDiagnosticBuilder {
         let expected: Set<StorageCanonicalRoot>
         switch stage {
         case .userHomeStorage: expected = [.userHomeVisibleStorage]
+        case .applications: expected = [.applications]
         case .applicationSupport: expected = [.applicationSupport]
         case .containers: expected = [.containers]
         case .groupContainers: expected = [.groupContainers]
@@ -1038,6 +1163,7 @@ private extension StorageCoverageDiagnosticBuilder {
         switch stage {
         case .apfsVolume: return results.apfsStorage != nil
         case .userHomeStorage: return results.userHomeStorage != nil
+        case .applications: return results.applications != nil
         case .applicationSupport: return results.applicationSupport != nil
         case .containers: return results.containers != nil
         case .groupContainers: return results.groupContainers != nil
@@ -1072,6 +1198,7 @@ private extension StorageCoverageDiagnosticBuilder {
     func rootTitle(_ root: StorageCanonicalRoot) -> String {
         switch root {
         case .userHomeVisibleStorage: return "Visible user-home roots"
+        case .applications: return "Applications"
         case .applicationSupport: return "Application Support"
         case .containers: return "Containers"
         case .groupContainers: return "Group Containers"

--- a/PureMac/Logic/Storage/StoragePathNormalizer.swift
+++ b/PureMac/Logic/Storage/StoragePathNormalizer.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+/// Deterministic, read-only path identity normalization for macOS Data-volume
+/// storage reconciliation and diagnostics.
+///
+/// This type performs pure string and path-component manipulation only. It
+/// never accesses the filesystem, never follows arbitrary symlinks, never calls
+/// shell commands or diskutil, and has zero side effects.
+public enum StoragePathNormalizer: Sendable {
+    private static let dataVolumePrefix = "/System/Volumes/Data"
+
+    /// Normalizes a macOS path to its canonical storage identity path.
+    ///
+    /// Rules applied:
+    /// 1. Standardizes redundant slashes, "." and ".." segments via standard URL path normalization.
+    /// 2. Synthetic root aliases:
+    ///    - `/var` or `/var/...` -> `/private/var` or `/private/var/...`
+    ///    - `/etc` or `/etc/...` -> `/private/etc` or `/private/etc/...`
+    ///    - `/tmp` or `/tmp/...` -> `/private/tmp` or `/private/tmp/...`
+    /// 3. Data-volume firmlink aliases:
+    ///    - `/System/Volumes/Data/private` or `/System/Volumes/Data/private/...` -> `/private` or `/private/...`
+    ///    - `/System/Volumes/Data/Users` or `/System/Volumes/Data/Users/...` -> `/Users` or `/Users/...`
+    ///    - `/System/Volumes/Data/Library` or `/System/Volumes/Data/Library/...` -> `/Library` or `/Library/...`
+    ///    - `/System/Volumes/Data/Applications` or `/System/Volumes/Data/Applications/...` -> `/Applications` or `/Applications/...`
+    ///    - `/System/Volumes/Data/opt` or `/System/Volumes/Data/opt/...` -> `/opt` or `/opt/...`
+    ///    - `/System/Volumes/Data/usr/local` or `/System/Volumes/Data/usr/local/...` -> `/usr/local` or `/usr/local/...`
+    ///    - `/System/Volumes/Data/var` or `/System/Volumes/Data/var/...` -> `/private/var` or `/private/var/...`
+    ///    - `/System/Volumes/Data/etc` or `/System/Volumes/Data/etc/...` -> `/private/etc` or `/private/etc/...`
+    ///    - `/System/Volumes/Data/tmp` or `/System/Volumes/Data/tmp/...` -> `/private/tmp` or `/private/tmp/...`
+    ///
+    /// Exact prefix boundaries are strictly enforced so similar names such as
+    /// `/private2`, `/various`, `/System/Volumes/Database`, etc. are NOT treated as aliases.
+    public static func normalize(_ path: String) -> String {
+        guard !path.isEmpty else { return "" }
+        let standardized = URL(fileURLWithPath: path).standardizedFileURL.path
+
+        // Check /var, /etc, /tmp
+        if standardized == "/var" {
+            return "/private/var"
+        } else if standardized.hasPrefix("/var/") {
+            return "/private/var" + standardized.dropFirst("/var".count)
+        }
+
+        if standardized == "/etc" {
+            return "/private/etc"
+        } else if standardized.hasPrefix("/etc/") {
+            return "/private/etc" + standardized.dropFirst("/etc".count)
+        }
+
+        if standardized == "/tmp" {
+            return "/private/tmp"
+        } else if standardized.hasPrefix("/tmp/") {
+            return "/private/tmp" + standardized.dropFirst("/tmp".count)
+        }
+
+        // Check /System/Volumes/Data firmlinks
+        if standardized == dataVolumePrefix {
+            return dataVolumePrefix
+        }
+
+        if standardized.hasPrefix(dataVolumePrefix + "/") {
+            let relative = String(standardized.dropFirst((dataVolumePrefix + "/").count))
+
+            // Check specific known firmlinks under /System/Volumes/Data
+            if relative == "private" {
+                return "/private"
+            } else if relative.hasPrefix("private/") {
+                return "/" + relative
+            }
+
+            if relative == "Users" {
+                return "/Users"
+            } else if relative.hasPrefix("Users/") {
+                return "/" + relative
+            }
+
+            if relative == "Library" {
+                return "/Library"
+            } else if relative.hasPrefix("Library/") {
+                return "/" + relative
+            }
+
+            if relative == "Applications" {
+                return "/Applications"
+            } else if relative.hasPrefix("Applications/") {
+                return "/" + relative
+            }
+
+            if relative == "opt" {
+                return "/opt"
+            } else if relative.hasPrefix("opt/") {
+                return "/" + relative
+            }
+
+            if relative == "usr/local" {
+                return "/usr/local"
+            } else if relative.hasPrefix("usr/local/") {
+                return "/" + relative
+            }
+
+            if relative == "var" {
+                return "/private/var"
+            } else if relative.hasPrefix("var/") {
+                return "/private/var" + relative.dropFirst("var".count)
+            }
+
+            if relative == "etc" {
+                return "/private/etc"
+            } else if relative.hasPrefix("etc/") {
+                return "/private/etc" + relative.dropFirst("etc".count)
+            }
+
+            if relative == "tmp" {
+                return "/private/tmp"
+            } else if relative.hasPrefix("tmp/") {
+                return "/private/tmp" + relative.dropFirst("tmp".count)
+            }
+        }
+
+        return standardized
+    }
+
+    /// Checks if a parent path contains or is equal to a child path using normalized identities.
+    public static func contains(parent: String, child: String) -> Bool {
+        let normParent = normalize(parent)
+        let normChild = normalize(child)
+        if normParent == normChild { return true }
+        if normParent == "/" { return normChild.hasPrefix("/") }
+        return normChild.hasPrefix(normParent + "/")
+    }
+
+    /// Checks if two paths overlap (either one contains the other) using normalized identities.
+    public static func pathsOverlap(_ left: String, _ right: String) -> Bool {
+        contains(parent: left, child: right) || contains(parent: right, child: left)
+    }
+
+    /// Returns the parent path of a path using normalized identities.
+    public static func parentPath(of path: String) -> String {
+        let norm = normalize(path)
+        guard norm != "/" else { return "/" }
+        return URL(fileURLWithPath: norm).deletingLastPathComponent().path
+    }
+
+    /// Returns whether a path is a known system-managed / system-protected location on macOS.
+    public static func isSystemProtectedLocation(_ path: String) -> Bool {
+        let norm = normalize(path)
+
+        // Data volume root system structures
+        if norm == "/System/Volumes/Data/.DocumentRevisions-V100" || norm.hasPrefix("/System/Volumes/Data/.DocumentRevisions-V100/")
+            || norm == "/System/Volumes/Data/.Spotlight-V100" || norm.hasPrefix("/System/Volumes/Data/.Spotlight-V100/")
+            || norm == "/System/Volumes/Data/.fseventsd" || norm.hasPrefix("/System/Volumes/Data/.fseventsd/")
+            || norm == "/System/Volumes/Data/.Trashes" || norm.hasPrefix("/System/Volumes/Data/.Trashes/") {
+            return true
+        }
+
+        // Also check if someone passed non-normalized root data volume paths
+        let standardized = URL(fileURLWithPath: path).standardizedFileURL.path
+        if standardized == "/.DocumentRevisions-V100" || standardized.hasPrefix("/.DocumentRevisions-V100/")
+            || standardized == "/.Spotlight-V100" || standardized.hasPrefix("/.Spotlight-V100/")
+            || standardized == "/.fseventsd" || standardized.hasPrefix("/.fseventsd/")
+            || standardized == "/.Trashes" || standardized.hasPrefix("/.Trashes/") {
+            return true
+        }
+
+        // /private/var and /private/etc protected subtrees
+        if norm == "/private/var/audit" || norm.hasPrefix("/private/var/audit/")
+            || norm == "/private/var/root" || norm.hasPrefix("/private/var/root/")
+            || norm == "/private/var/protected" || norm.hasPrefix("/private/var/protected/")
+            || norm == "/private/var/db" || norm.hasPrefix("/private/var/db/")
+            || norm == "/private/var/agentx" || norm.hasPrefix("/private/var/agentx/")
+            || norm == "/private/etc/cups/certs" || norm.hasPrefix("/private/etc/cups/certs/") {
+            return true
+        }
+
+        return false
+    }
+}

--- a/PureMac/Logic/Storage/VolumeStatisticsProvider.swift
+++ b/PureMac/Logic/Storage/VolumeStatisticsProvider.swift
@@ -1,0 +1,173 @@
+import Foundation
+
+/// Capacity facts supplied by Foundation for one mounted volume.
+///
+/// `purgeableEstimate` is intentionally derived from Apple's important-usage
+/// capacity rather than treated as guaranteed reclaimable storage.
+struct VolumeCapacityStatistics: Hashable, Codable, Sendable {
+    let totalCapacity: Int64?
+    let availableCapacity: Int64?
+    let usedCapacity: Int64?
+    let availableCapacityForImportantUsage: Int64?
+    let availableCapacityForOpportunisticUsage: Int64?
+    let purgeableEstimate: Int64?
+    let volumeName: String?
+    let volumeIdentifier: String?
+    let filesystemDescription: String?
+    let mountPoint: String
+}
+
+enum VolumeStatisticsReadIssueKind: String, Codable, Sendable {
+    case filesystemAttributesUnavailable
+    case resourceValuesUnavailable
+    case capacityUnavailable
+}
+
+struct VolumeStatisticsReadIssue: Hashable, Codable, Sendable {
+    let kind: VolumeStatisticsReadIssueKind
+    let message: String
+}
+
+struct VolumeStatisticsReadResult: Hashable, Codable, Sendable {
+    let statistics: VolumeCapacityStatistics
+    let issues: [VolumeStatisticsReadIssue]
+}
+
+/// Shared, read-only volume-capacity calculation used by the existing disk
+/// summary and specialized storage analyzers.
+struct VolumeStatisticsProvider {
+    static func read(at volumeURL: URL) -> VolumeStatisticsReadResult {
+        let standardizedURL = volumeURL.standardizedFileURL
+        var issues: [VolumeStatisticsReadIssue] = []
+        var attributeTotal: Int64?
+        var attributeAvailable: Int64?
+
+        do {
+            let attributes = try FileManager.default.attributesOfFileSystem(
+                forPath: standardizedURL.path
+            )
+            attributeTotal = int64(attributes[.systemSize])
+            attributeAvailable = int64(attributes[.systemFreeSize])
+        } catch {
+            issues.append(.init(
+                kind: .filesystemAttributesUnavailable,
+                message: "Filesystem capacity attributes are unavailable for this volume."
+            ))
+        }
+
+        var resourceTotal: Int64?
+        var resourceAvailable: Int64?
+        var importantAvailable: Int64?
+        var opportunisticAvailable: Int64?
+        var volumeName: String?
+        var volumeIdentifier: String?
+        var filesystemDescription: String?
+
+        do {
+            let values = try standardizedURL.resourceValues(forKeys: [
+                .volumeTotalCapacityKey,
+                .volumeAvailableCapacityKey,
+                .volumeAvailableCapacityForImportantUsageKey,
+                .volumeAvailableCapacityForOpportunisticUsageKey,
+                .volumeNameKey,
+                .volumeUUIDStringKey,
+                .volumeLocalizedFormatDescriptionKey,
+            ])
+            resourceTotal = values.volumeTotalCapacity.map(Int64.init)
+            resourceAvailable = values.volumeAvailableCapacity.map(Int64.init)
+            importantAvailable = values.volumeAvailableCapacityForImportantUsage
+            opportunisticAvailable = values.volumeAvailableCapacityForOpportunisticUsage
+            volumeName = values.volumeName
+            volumeIdentifier = values.volumeUUIDString
+            filesystemDescription = values.volumeLocalizedFormatDescription
+        } catch {
+            issues.append(.init(
+                kind: .resourceValuesUnavailable,
+                message: "Foundation volume resource values are unavailable."
+            ))
+        }
+
+        let total = nonnegative(resourceTotal) ?? nonnegative(attributeTotal)
+        let available = nonnegative(resourceAvailable) ?? nonnegative(attributeAvailable)
+        let statistics = calculate(
+            totalCapacity: total,
+            availableCapacity: available,
+            availableCapacityForImportantUsage: nonnegative(importantAvailable),
+            availableCapacityForOpportunisticUsage: nonnegative(opportunisticAvailable),
+            volumeName: volumeName,
+            volumeIdentifier: volumeIdentifier,
+            filesystemDescription: filesystemDescription,
+            mountPoint: standardizedURL.path
+        )
+
+        if statistics.totalCapacity == nil || statistics.availableCapacity == nil {
+            issues.append(.init(
+                kind: .capacityUnavailable,
+                message: "Complete total and available capacity values are unavailable."
+            ))
+        }
+
+        return VolumeStatisticsReadResult(statistics: statistics, issues: issues)
+    }
+
+    /// Pure calculation entry point used by synthetic tests and callers that
+    /// already obtained capacity values from another stable API.
+    static func calculate(
+        totalCapacity: Int64?,
+        availableCapacity: Int64?,
+        availableCapacityForImportantUsage: Int64?,
+        availableCapacityForOpportunisticUsage: Int64? = nil,
+        volumeName: String? = nil,
+        volumeIdentifier: String? = nil,
+        filesystemDescription: String? = nil,
+        mountPoint: String = "/"
+    ) -> VolumeCapacityStatistics {
+        let total = nonnegative(totalCapacity)
+        let available = nonnegative(availableCapacity)
+        let used: Int64?
+        if let total, let available {
+            used = max(0, total - min(total, available))
+        } else {
+            used = nil
+        }
+
+        let purgeable: Int64?
+        if let important = nonnegative(availableCapacityForImportantUsage),
+           let available {
+            purgeable = max(0, important - available)
+        } else {
+            purgeable = nil
+        }
+
+        return VolumeCapacityStatistics(
+            totalCapacity: total,
+            availableCapacity: available,
+            usedCapacity: used,
+            availableCapacityForImportantUsage: nonnegative(
+                availableCapacityForImportantUsage
+            ),
+            availableCapacityForOpportunisticUsage: nonnegative(
+                availableCapacityForOpportunisticUsage
+            ),
+            purgeableEstimate: purgeable,
+            volumeName: volumeName,
+            volumeIdentifier: volumeIdentifier,
+            filesystemDescription: filesystemDescription,
+            mountPoint: mountPoint
+        )
+    }
+}
+
+private extension VolumeStatisticsProvider {
+    static func nonnegative(_ value: Int64?) -> Int64? {
+        guard let value, value >= 0 else { return nil }
+        return value
+    }
+
+    static func int64(_ value: Any?) -> Int64? {
+        if let value = value as? NSNumber { return value.int64Value }
+        if let value = value as? Int64 { return value }
+        if let value = value as? Int { return Int64(value) }
+        return nil
+    }
+}

--- a/PureMac/Models/APFSPhysicalReconciliationModels.swift
+++ b/PureMac/Models/APFSPhysicalReconciliationModels.swift
@@ -1,0 +1,316 @@
+import Foundation
+
+/// Evidence of an individual APFS volume residing in the same APFS container pool.
+struct APFSSiblingVolumeEvidence: Identifiable, Hashable, Codable, Sendable {
+    let id: String
+    let name: String
+    let role: String
+    let deviceIdentifier: String
+    let capacityInUseBytes: Int64?
+
+    init(
+        name: String,
+        role: String,
+        deviceIdentifier: String,
+        capacityInUseBytes: Int64?
+    ) {
+        self.id = deviceIdentifier
+        self.name = name
+        self.role = role
+        self.deviceIdentifier = deviceIdentifier
+        self.capacityInUseBytes = capacityInUseBytes
+    }
+}
+
+/// Container-level APFS evidence detailing shared storage pool metrics and sibling volumes.
+struct APFSContainerEvidence: Hashable, Codable, Sendable {
+    let containerReference: String
+    let containerUUID: String?
+    let totalCapacityBytes: Int64?
+    let freeCapacityBytes: Int64?
+    let physicalStoreIdentifier: String?
+    let volumes: [APFSSiblingVolumeEvidence]
+    let totalSiblingVolumeBytesOutsideData: Int64
+
+    init(
+        containerReference: String,
+        containerUUID: String?,
+        totalCapacityBytes: Int64?,
+        freeCapacityBytes: Int64?,
+        physicalStoreIdentifier: String?,
+        volumes: [APFSSiblingVolumeEvidence],
+        totalSiblingVolumeBytesOutsideData: Int64
+    ) {
+        self.containerReference = containerReference
+        self.containerUUID = containerUUID
+        self.totalCapacityBytes = totalCapacityBytes
+        self.freeCapacityBytes = freeCapacityBytes
+        self.physicalStoreIdentifier = physicalStoreIdentifier
+        self.volumes = volumes
+        self.totalSiblingVolumeBytesOutsideData = totalSiblingVolumeBytesOutsideData
+    }
+}
+
+/// Specific physical evidence for the target writable Data volume.
+struct APFSVolumeEvidence: Hashable, Codable, Sendable {
+    let name: String
+    let mountPoint: String
+    let deviceIdentifier: String
+    let volumeUUID: String?
+    let volumeGroupUUID: String?
+    let roles: [String]
+    let capacityInUseBytes: Int64?
+    let isEncrypted: Bool
+    let isSealed: Bool
+    let isWritable: Bool
+
+    init(
+        name: String,
+        mountPoint: String,
+        deviceIdentifier: String,
+        volumeUUID: String?,
+        volumeGroupUUID: String?,
+        roles: [String],
+        capacityInUseBytes: Int64?,
+        isEncrypted: Bool,
+        isSealed: Bool,
+        isWritable: Bool
+    ) {
+        self.name = name
+        self.mountPoint = mountPoint
+        self.deviceIdentifier = deviceIdentifier
+        self.volumeUUID = volumeUUID
+        self.volumeGroupUUID = volumeGroupUUID
+        self.roles = roles
+        self.capacityInUseBytes = capacityInUseBytes
+        self.isEncrypted = isEncrypted
+        self.isSealed = isSealed
+        self.isWritable = isWritable
+    }
+}
+
+/// APFS snapshot evidence summary.
+struct APFSSnapshotEvidence: Hashable, Codable, Sendable {
+    let snapshotCount: Int
+    let totalReportedSnapshotBytes: Int64?
+    let snapshots: [APFSSnapshotInformation]
+    let isNonAdditive: Bool
+    let explanation: String
+
+    init(
+        snapshotCount: Int,
+        totalReportedSnapshotBytes: Int64?,
+        snapshots: [APFSSnapshotInformation],
+        isNonAdditive: Bool = true,
+        explanation: String = "APFS copy-on-write snapshots share extents with the live filesystem and are non-additive."
+    ) {
+        self.snapshotCount = snapshotCount
+        self.totalReportedSnapshotBytes = totalReportedSnapshotBytes
+        self.snapshots = snapshots
+        self.isNonAdditive = isNonAdditive
+        self.explanation = explanation
+    }
+
+    static let empty = APFSSnapshotEvidence(
+        snapshotCount: 0,
+        totalReportedSnapshotBytes: nil,
+        snapshots: []
+    )
+}
+
+/// System-managed storage evidence (VM swap, sleepimage, VM volume, system databases).
+struct APFSSystemManagedEvidence: Hashable, Codable, Sendable {
+    let vmFootprintBytes: Int64?
+    let swapFileBytes: Int64?
+    let sleepImageBytes: Int64?
+    let vmVolumeBytes: Int64?
+    let hasSystemIndexingDatabases: Bool
+    let explanation: String
+
+    init(
+        vmFootprintBytes: Int64?,
+        swapFileBytes: Int64?,
+        sleepImageBytes: Int64?,
+        vmVolumeBytes: Int64?,
+        hasSystemIndexingDatabases: Bool,
+        explanation: String
+    ) {
+        self.vmFootprintBytes = vmFootprintBytes
+        self.swapFileBytes = swapFileBytes
+        self.sleepImageBytes = sleepImageBytes
+        self.vmVolumeBytes = vmVolumeBytes
+        self.hasSystemIndexingDatabases = hasSystemIndexingDatabases
+        self.explanation = explanation
+    }
+
+    static let empty = APFSSystemManagedEvidence(
+        vmFootprintBytes: nil,
+        swapFileBytes: nil,
+        sleepImageBytes: nil,
+        vmVolumeBytes: nil,
+        hasSystemIndexingDatabases: false,
+        explanation: "No system-managed virtual memory or update storage detected."
+    )
+}
+
+/// Protected system storage evidence.
+struct APFSProtectedStorageEvidence: Hashable, Codable, Sendable {
+    let protectedRegionCount: Int
+    let inaccessibleKnownLowerBoundBytes: Int64
+    let unreadablePathCount: Int
+    let explanation: String
+
+    init(
+        protectedRegionCount: Int,
+        inaccessibleKnownLowerBoundBytes: Int64,
+        unreadablePathCount: Int,
+        explanation: String
+    ) {
+        self.protectedRegionCount = protectedRegionCount
+        self.inaccessibleKnownLowerBoundBytes = inaccessibleKnownLowerBoundBytes
+        self.unreadablePathCount = unreadablePathCount
+        self.explanation = explanation
+    }
+
+    static let empty = APFSProtectedStorageEvidence(
+        protectedRegionCount: 0,
+        inaccessibleKnownLowerBoundBytes: 0,
+        unreadablePathCount: 0,
+        explanation: "No macOS protected system access barriers recorded."
+    )
+}
+
+/// Quantitative metrics bridging physical APFS volume used bytes to filesystem attributed bytes.
+struct APFSPhysicalAccountingMetrics: Hashable, Codable, Sendable {
+    /// Physical container used capacity (e.g. 217.20 GB from container total - free).
+    let physicalVolumeUsedBytes: Int64?
+    /// Exclusive physical allocation reported for the Data volume (e.g. 189.65 GB).
+    let dataVolumePhysicalInUseBytes: Int64?
+    /// Unique allocated filesystem bytes attributed by PureMac scanners (e.g. 143.24 GB).
+    let filesystemAttributedBytes: Int64
+    /// Total physical space consumed by sibling APFS volumes in the container (e.g. 27.41 GB).
+    let containerSiblingVolumesBytes: Int64
+    /// Overall physical accounting gap: `max(physicalVolumeUsedBytes - filesystemAttributedBytes, 0)`.
+    let physicalAccountingGapBytes: Int64?
+    /// Data volume internal delta: `max(dataVolumePhysicalInUseBytes - filesystemAttributedBytes, 0)`.
+    let dataVolumeInternalGapBytes: Int64?
+    /// Purgeable capacity estimate (kept non-additive).
+    let purgeableEstimateBytes: Int64?
+    /// Difference between container used and sum of sibling volumes + data volume in-use.
+    let containerAccountingDiscrepancyBytes: Int64?
+
+    init(
+        physicalVolumeUsedBytes: Int64?,
+        dataVolumePhysicalInUseBytes: Int64?,
+        filesystemAttributedBytes: Int64,
+        containerSiblingVolumesBytes: Int64,
+        physicalAccountingGapBytes: Int64?,
+        dataVolumeInternalGapBytes: Int64?,
+        purgeableEstimateBytes: Int64?,
+        containerAccountingDiscrepancyBytes: Int64?
+    ) {
+        self.physicalVolumeUsedBytes = physicalVolumeUsedBytes
+        self.dataVolumePhysicalInUseBytes = dataVolumePhysicalInUseBytes
+        self.filesystemAttributedBytes = filesystemAttributedBytes
+        self.containerSiblingVolumesBytes = containerSiblingVolumesBytes
+        self.physicalAccountingGapBytes = physicalAccountingGapBytes
+        self.dataVolumeInternalGapBytes = dataVolumeInternalGapBytes
+        self.purgeableEstimateBytes = purgeableEstimateBytes
+        self.containerAccountingDiscrepancyBytes = containerAccountingDiscrepancyBytes
+    }
+}
+
+/// High-level deterministic classification for physical reconciliation.
+enum APFSPhysicalReconciliationStatus: String, Codable, CaseIterable, Sendable {
+    case fullyReconciled
+    case mostlyReconciled
+    case filesystemCoverageLimited
+    case apfsNonAdditiveFactorsPresent
+    case protectedSystemStoragePresent
+    case physicalAccountingGapRemaining
+    case insufficientEvidence
+
+    var displayName: String {
+        switch self {
+        case .fullyReconciled: return "Fully Reconciled"
+        case .mostlyReconciled: return "Mostly Reconciled"
+        case .filesystemCoverageLimited: return "Coverage Limited"
+        case .apfsNonAdditiveFactorsPresent: return "APFS Non-Additive Factors Present"
+        case .protectedSystemStoragePresent: return "Protected System Storage Present"
+        case .physicalAccountingGapRemaining: return "Physical Accounting Gap Remaining"
+        case .insufficientEvidence: return "Insufficient Evidence"
+        }
+    }
+}
+
+/// Comprehensive physical reconciliation report explaining the physical-accounting gap.
+struct APFSPhysicalReconciliationReport: Hashable, Codable, Sendable {
+    let status: APFSPhysicalReconciliationStatus
+    let metrics: APFSPhysicalAccountingMetrics
+    let targetVolume: APFSVolumeEvidence?
+    let container: APFSContainerEvidence?
+    let snapshots: APFSSnapshotEvidence
+    let systemManaged: APFSSystemManagedEvidence
+    let protectedStorage: APFSProtectedStorageEvidence
+    let dataVolumeInternalGap: DataVolumeInternalGapReport?
+    let humanReadableInterpretation: String
+    let warnings: [String]
+    let evidenceSources: [String]
+    let wasCancelled: Bool
+    let issues: [APFSStorageIssue]
+
+    init(
+        status: APFSPhysicalReconciliationStatus,
+        metrics: APFSPhysicalAccountingMetrics,
+        targetVolume: APFSVolumeEvidence?,
+        container: APFSContainerEvidence?,
+        snapshots: APFSSnapshotEvidence,
+        systemManaged: APFSSystemManagedEvidence,
+        protectedStorage: APFSProtectedStorageEvidence,
+        dataVolumeInternalGap: DataVolumeInternalGapReport? = nil,
+        humanReadableInterpretation: String,
+        warnings: [String] = [],
+        evidenceSources: [String] = [],
+        wasCancelled: Bool = false,
+        issues: [APFSStorageIssue] = []
+    ) {
+        self.status = status
+        self.metrics = metrics
+        self.targetVolume = targetVolume
+        self.container = container
+        self.snapshots = snapshots
+        self.systemManaged = systemManaged
+        self.protectedStorage = protectedStorage
+        self.dataVolumeInternalGap = dataVolumeInternalGap
+        self.humanReadableInterpretation = humanReadableInterpretation
+        self.warnings = warnings
+        self.evidenceSources = evidenceSources
+        self.wasCancelled = wasCancelled
+        self.issues = issues
+    }
+
+    static let empty = APFSPhysicalReconciliationReport(
+        status: .insufficientEvidence,
+        metrics: APFSPhysicalAccountingMetrics(
+            physicalVolumeUsedBytes: nil,
+            dataVolumePhysicalInUseBytes: nil,
+            filesystemAttributedBytes: 0,
+            containerSiblingVolumesBytes: 0,
+            physicalAccountingGapBytes: nil,
+            dataVolumeInternalGapBytes: nil,
+            purgeableEstimateBytes: nil,
+            containerAccountingDiscrepancyBytes: nil
+        ),
+        targetVolume: nil,
+        container: nil,
+        snapshots: .empty,
+        systemManaged: .empty,
+        protectedStorage: .empty,
+        dataVolumeInternalGap: nil,
+        humanReadableInterpretation: "Insufficient physical volume information available for reconciliation.",
+        warnings: [],
+        evidenceSources: [],
+        wasCancelled: false,
+        issues: []
+    )
+}

--- a/PureMac/Models/APFSStorageModels.swift
+++ b/PureMac/Models/APFSStorageModels.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+enum APFSAnalysisState: String, Codable, Sendable {
+    case complete
+    case partial
+    case nonAPFS
+    case unavailable
+    case cancelled
+}
+
+enum APFSFilesystemKind: String, Codable, Sendable {
+    case apfs
+    case nonAPFS
+    case unknown
+}
+
+enum APFSDataVolumeRelationship: String, Codable, Sendable {
+    case dataVolume
+    case systemVolume
+    case volumeGroupMember
+    case notApplicable
+    case unknown
+}
+
+enum APFSPurgeableEstimateKnowledge: String, Codable, Sendable {
+    case estimated
+    case unavailable
+}
+
+struct APFSVolumeCapacity: Hashable, Codable, Sendable {
+    let totalCapacity: Int64?
+    let availableCapacity: Int64?
+    let usedCapacity: Int64?
+    let availableCapacityForImportantUsage: Int64?
+    let availableCapacityForOpportunisticUsage: Int64?
+    let purgeableEstimate: Int64?
+    let purgeableEstimateKnowledge: APFSPurgeableEstimateKnowledge
+}
+
+struct APFSVolumeInformation: Hashable, Codable, Sendable {
+    let name: String?
+    let volumeIdentifier: String?
+    let volumeUUID: String?
+    let containerIdentifier: String?
+    let volumeGroupIdentifier: String?
+    let filesystemType: String?
+    let filesystemKind: APFSFilesystemKind
+    let mountPoint: String
+    let dataVolumeRelationship: APFSDataVolumeRelationship
+    let capacity: APFSVolumeCapacity
+}
+
+enum APFSSnapshotType: String, Codable, Sendable {
+    case timeMachine
+    case operatingSystemUpdate
+    case otherAPFS
+    case unknown
+}
+
+enum APFSSnapshotSource: String, Codable, Sendable {
+    case tmutil
+    case diskutil
+    case tmutilAndDiskutil
+}
+
+enum APFSSnapshotSizeKnowledge: String, Codable, Sendable {
+    case reportedBySystem
+    case unavailable
+}
+
+/// APFS copy-on-write data can share extents with the live filesystem. Even a
+/// system-reported snapshot size is therefore never automatically additive.
+enum APFSSnapshotStorageRelationship: String, Codable, Sendable {
+    case sharedNonAdditive
+    case sizeUnavailable
+    case unknown
+}
+
+struct APFSSnapshotInformation: Identifiable, Hashable, Codable, Sendable {
+    let identifier: String
+    let name: String?
+    let uuid: String?
+    let creationDate: Date?
+    let size: Int64?
+    let sizeKnowledge: APFSSnapshotSizeKnowledge
+    let type: APFSSnapshotType
+    let source: APFSSnapshotSource
+    let storageRelationship: APFSSnapshotStorageRelationship
+
+    var id: String { identifier }
+}
+
+enum APFSAccountingRelationship: String, Codable, Sendable {
+    case volumeMetadataAndSnapshotsAreNonAdditiveToFilesystemTrees
+}
+
+enum APFSStorageIssueKind: String, Codable, Sendable {
+    case volumeStatisticsUnavailable
+    case commandUnavailable
+    case commandFailed
+    case permissionDenied
+    case malformedPlist
+    case malformedOutput
+    case partialMetadata
+    case cancelled
+}
+
+struct APFSStorageIssue: Identifiable, Hashable, Codable, Sendable {
+    let kind: APFSStorageIssueKind
+    let message: String
+    let source: String?
+
+    var id: String { "\(kind.rawValue)|\(source ?? "")|\(message)" }
+}
+
+struct APFSStorageReport: Hashable, Codable, Sendable {
+    let volume: APFSVolumeInformation
+    let snapshots: [APFSSnapshotInformation]
+    let state: APFSAnalysisState
+    let accountingRelationship: APFSAccountingRelationship
+    let wasCancelled: Bool
+    let issues: [APFSStorageIssue]
+}
+
+struct APFSCommandRequest: Equatable, Sendable {
+    let executableURL: URL
+    let arguments: [String]
+}
+
+struct APFSCommandResult: Equatable, Sendable {
+    let terminationStatus: Int32
+    let stdout: Data
+    let stderr: Data
+    let launchError: String?
+    let wasCancelled: Bool
+}

--- a/PureMac/Models/DataVolumeInternalGapModels.swift
+++ b/PureMac/Models/DataVolumeInternalGapModels.swift
@@ -1,0 +1,241 @@
+import Foundation
+
+/// Strict 5-tier classification for Data-volume accounting evidence.
+enum DataVolumeGapEvidenceTier: String, Codable, CaseIterable, Sendable {
+    /// Reliable exclusive filesystem allocation that can participate in byte accounting.
+    case measuredAdditive
+    /// Reliable measurement exists, but may overlap existing filesystem or APFS blocks.
+    case measuredNonAdditive
+    /// macOS reports a value (e.g. Purgeable estimate) but it cannot safely be treated as exclusive physical allocation.
+    case estimatedOSReported
+    /// Storage mechanism is confirmed to exist, but exclusive physical bytes cannot be determined from userland APIs.
+    case presenceOnly
+    /// Inaccessible SIP/TCC restricted locations where bytes cannot be measured.
+    case unknownProtected
+
+    var displayName: String {
+        switch self {
+        case .measuredAdditive: return "Additive"
+        case .measuredNonAdditive: return "Non-additive"
+        case .estimatedOSReported: return "Estimate"
+        case .presenceOnly: return "Presence-only"
+        case .unknownProtected: return "Protected"
+        }
+    }
+}
+
+/// Categorization of evidence items explaining the Data-volume internal gap.
+enum DataVolumeGapEvidenceCategory: String, Codable, CaseIterable, Sendable {
+    case filesystemAllocationDelta
+    case purgeableEstimate
+    case protectedStorage
+    case apfsSnapshots
+    case cloneSharedExtents
+    case apfsFilesystemMetadata
+    case unresolvedResidual
+
+    var displayName: String {
+        switch self {
+        case .filesystemAllocationDelta: return "Allocation vs Logical Size Delta"
+        case .purgeableEstimate: return "Purgeable Capacity Estimate"
+        case .protectedStorage: return "Protected & Inaccessible Locations"
+        case .apfsSnapshots: return "APFS Snapshots & Extents"
+        case .cloneSharedExtents: return "APFS Clones & Shared Extents"
+        case .apfsFilesystemMetadata: return "APFS Metadata & Structure Overhead"
+        case .unresolvedResidual: return "Unresolved Physical Accounting Delta"
+        }
+    }
+}
+
+/// An individual row in the Data Volume Internal Gap Waterfall.
+struct DataVolumeGapWaterfallItem: Identifiable, Hashable, Codable, Sendable {
+    let id: String
+    let title: String
+    let category: DataVolumeGapEvidenceCategory
+    let tier: DataVolumeGapEvidenceTier
+    let reportedBytes: Int64?
+    let explanation: String
+    let badgeText: String
+
+    init(
+        id: String,
+        title: String,
+        category: DataVolumeGapEvidenceCategory,
+        tier: DataVolumeGapEvidenceTier,
+        reportedBytes: Int64?,
+        explanation: String,
+        badgeText: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.category = category
+        self.tier = tier
+        self.reportedBytes = reportedBytes
+        self.explanation = explanation
+        self.badgeText = badgeText ?? tier.displayName
+    }
+}
+
+/// A grouped family of macOS-protected / SIP / TCC inaccessible locations.
+struct DataVolumeProtectedFamily: Identifiable, Hashable, Codable, Sendable {
+    let id: String
+    let name: String
+    let pathPattern: String
+    let issueCount: Int
+    let knownLowerBoundBytes: Int64?
+    let explanation: String
+
+    init(
+        id: String,
+        name: String,
+        pathPattern: String,
+        issueCount: Int,
+        knownLowerBoundBytes: Int64?,
+        explanation: String
+    ) {
+        self.id = id
+        self.name = name
+        self.pathPattern = pathPattern
+        self.issueCount = issueCount
+        self.knownLowerBoundBytes = knownLowerBoundBytes
+        self.explanation = explanation
+    }
+}
+
+/// Aggregated summary of protected and restricted storage across the Data volume.
+struct DataVolumeProtectedStorageSummary: Hashable, Codable, Sendable {
+    let families: [DataVolumeProtectedFamily]
+    let totalProtectedIssueCount: Int
+    let inaccessiblePathCount: Int
+    let knownLowerBoundBytes: Int64
+    let explanation: String
+
+    init(
+        families: [DataVolumeProtectedFamily],
+        totalProtectedIssueCount: Int,
+        inaccessiblePathCount: Int,
+        knownLowerBoundBytes: Int64,
+        explanation: String
+    ) {
+        self.families = families
+        self.totalProtectedIssueCount = totalProtectedIssueCount
+        self.inaccessiblePathCount = inaccessiblePathCount
+        self.knownLowerBoundBytes = knownLowerBoundBytes
+        self.explanation = explanation
+    }
+
+    static let empty = DataVolumeProtectedStorageSummary(
+        families: [],
+        totalProtectedIssueCount: 0,
+        inaccessiblePathCount: 0,
+        knownLowerBoundBytes: 0,
+        explanation: "No macOS protected system access barriers recorded."
+    )
+}
+
+/// Comparison between logical bytes (st_size) and physical allocated blocks (st_blocks * 512).
+struct DataVolumeAllocationDeltaSummary: Hashable, Codable, Sendable {
+    let totalMeasuredLogicalBytes: Int64
+    let totalMeasuredAllocatedBytes: Int64
+    /// `totalMeasuredAllocatedBytes - totalMeasuredLogicalBytes`
+    let deltaBytes: Int64
+    let sparseFilesObserved: Bool
+    let blockPaddingObserved: Bool
+    let explanation: String
+
+    init(
+        totalMeasuredLogicalBytes: Int64,
+        totalMeasuredAllocatedBytes: Int64,
+        deltaBytes: Int64,
+        sparseFilesObserved: Bool,
+        blockPaddingObserved: Bool,
+        explanation: String
+    ) {
+        self.totalMeasuredLogicalBytes = totalMeasuredLogicalBytes
+        self.totalMeasuredAllocatedBytes = totalMeasuredAllocatedBytes
+        self.deltaBytes = deltaBytes
+        self.sparseFilesObserved = sparseFilesObserved
+        self.blockPaddingObserved = blockPaddingObserved
+        self.explanation = explanation
+    }
+
+    static let empty = DataVolumeAllocationDeltaSummary(
+        totalMeasuredLogicalBytes: 0,
+        totalMeasuredAllocatedBytes: 0,
+        deltaBytes: 0,
+        sparseFilesObserved: false,
+        blockPaddingObserved: false,
+        explanation: "Allocation-to-logical size comparison is unavailable."
+    )
+}
+
+/// Comprehensive report deconstructing the Data-volume internal gap (~46.41 GB).
+struct DataVolumeInternalGapReport: Hashable, Codable, Sendable {
+    /// Physical allocation reported by APFS for the Data volume (e.g. 189.65 GB).
+    let dataVolumePhysicalInUseBytes: Int64?
+    /// Unique filesystem allocated blocks attributed by PureMac scanners (e.g. 143.24 GB).
+    let filesystemAttributedBytes: Int64
+    /// Internal accounting gap: `max(dataVolumePhysicalInUseBytes - filesystemAttributedBytes, 0)` (~46.41 GB).
+    let internalPhysicalGapBytes: Int64?
+
+    /// Logical vs physical allocated block diagnostic.
+    let allocationDeltaSummary: DataVolumeAllocationDeltaSummary
+    /// Waterfall rows deconstructing the gap.
+    let waterfallItems: [DataVolumeGapWaterfallItem]
+    /// Protected storage aggregated families.
+    let protectedSummary: DataVolumeProtectedStorageSummary
+
+    /// Total bytes justified by MEASURED ADDITIVE evidence (strictly 0 GB unless exclusive).
+    let additiveExplainedPortionBytes: Int64
+    /// Total bytes supported by non-additive, estimated, or presence-only evidence.
+    let nonAdditiveEvidencedPortionBytes: Int64
+    /// Unresolved residual gap: `internalPhysicalGapBytes - additiveExplainedPortionBytes`.
+    let unresolvedResidualGapBytes: Int64?
+
+    let humanReadableInterpretation: String
+    let wasCancelled: Bool
+    let issues: [APFSStorageIssue]
+
+    init(
+        dataVolumePhysicalInUseBytes: Int64?,
+        filesystemAttributedBytes: Int64,
+        internalPhysicalGapBytes: Int64?,
+        allocationDeltaSummary: DataVolumeAllocationDeltaSummary,
+        waterfallItems: [DataVolumeGapWaterfallItem],
+        protectedSummary: DataVolumeProtectedStorageSummary,
+        additiveExplainedPortionBytes: Int64 = 0,
+        nonAdditiveEvidencedPortionBytes: Int64,
+        unresolvedResidualGapBytes: Int64?,
+        humanReadableInterpretation: String,
+        wasCancelled: Bool = false,
+        issues: [APFSStorageIssue] = []
+    ) {
+        self.dataVolumePhysicalInUseBytes = dataVolumePhysicalInUseBytes
+        self.filesystemAttributedBytes = filesystemAttributedBytes
+        self.internalPhysicalGapBytes = internalPhysicalGapBytes
+        self.allocationDeltaSummary = allocationDeltaSummary
+        self.waterfallItems = waterfallItems
+        self.protectedSummary = protectedSummary
+        self.additiveExplainedPortionBytes = additiveExplainedPortionBytes
+        self.nonAdditiveEvidencedPortionBytes = nonAdditiveEvidencedPortionBytes
+        self.unresolvedResidualGapBytes = unresolvedResidualGapBytes
+        self.humanReadableInterpretation = humanReadableInterpretation
+        self.wasCancelled = wasCancelled
+        self.issues = issues
+    }
+
+    static let empty = DataVolumeInternalGapReport(
+        dataVolumePhysicalInUseBytes: nil,
+        filesystemAttributedBytes: 0,
+        internalPhysicalGapBytes: nil,
+        allocationDeltaSummary: .empty,
+        waterfallItems: [],
+        protectedSummary: .empty,
+        additiveExplainedPortionBytes: 0,
+        nonAdditiveEvidencedPortionBytes: 0,
+        unresolvedResidualGapBytes: nil,
+        humanReadableInterpretation: "Data volume internal gap analysis is currently unavailable.",
+        wasCancelled: false,
+        issues: []
+    )
+}

--- a/PureMac/Models/DataVolumeTopLevelSafetyNetModels.swift
+++ b/PureMac/Models/DataVolumeTopLevelSafetyNetModels.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Classification of immediate children under `/System/Volumes/Data`.
+///
+/// This provides a non-invasive safety net preventing future blind spots
+/// where newly added macOS directories are omitted from both canonical
+/// analyzers and coverage expansion.
+enum DataVolumeTopLevelOwnershipStatus: String, Codable, Sendable {
+    /// Owned directly by a dedicated canonical analyzer (e.g. /Applications, /Users, /private).
+    case ownedByCanonicalAnalyzer
+    /// Owned and measured by the coverage expansion pass (e.g. /System/Volumes/Data/macOS Install Data).
+    case ownedByCoverageExpansion
+    /// Firmlink alias that normalizes to a standard root (e.g. /System/Volumes/Data/var -> /private/var).
+    case firmlinkAlias
+    /// Intentionally non-additive (e.g. /System/Volumes/Data/Volumes, snapshots, firmlinked System mount).
+    case intentionallyNonAdditive
+    /// An unowned entry that contains allocated blocks on the Data volume.
+    case unownedPotentialCoverageGap
+}
+
+/// Diagnostic report entry for one immediate child of `/System/Volumes/Data`.
+struct DataVolumeTopLevelSafetyNetEntry: Identifiable, Hashable, Codable, Sendable {
+    let originalPath: String
+    let normalizedPath: String
+    let name: String
+    let ownershipStatus: DataVolumeTopLevelOwnershipStatus
+    let owningAnalyzerStage: StorageAnalyzerStage?
+    let canonicalOwner: StorageCanonicalRoot?
+    let allocatedBytes: Int64?
+    let isFilesystemAdditive: Bool
+    let reason: String
+
+    var id: String { originalPath }
+}
+
+/// Comprehensive safety-net report auditing immediate children of `/System/Volumes/Data`.
+struct DataVolumeTopLevelSafetyNetReport: Hashable, Codable, Sendable {
+    let checkedDirectoryPath: String
+    let entries: [DataVolumeTopLevelSafetyNetEntry]
+    let totalEntriesCount: Int
+    let unownedEntriesCount: Int
+    let isFullyCovered: Bool
+
+    static let empty = DataVolumeTopLevelSafetyNetReport(
+        checkedDirectoryPath: "/System/Volumes/Data",
+        entries: [],
+        totalEntriesCount: 0,
+        unownedEntriesCount: 0,
+        isFullyCovered: true
+    )
+}

--- a/PureMac/Models/DockerStorageModels.swift
+++ b/PureMac/Models/DockerStorageModels.swift
@@ -1,0 +1,188 @@
+import Foundation
+
+/// The universal accounting rule between Docker's host files and runtime data.
+/// Runtime categories must never be added to host bytes as Mac disk usage.
+enum DockerAccountingRelationship: String, Codable, Sendable {
+    case runtimeBreakdownIsNonAdditiveToHostFootprint
+}
+
+/// Where the Docker engine behind the inspected active context is running.
+enum DockerRuntimeLocation: String, Codable, Sendable {
+    case local
+    case remote
+    case unknown
+}
+
+/// Whether runtime accounting can help explain the local host-side Docker
+/// footprint. Even for a local runtime, accounting remains non-additive.
+enum DockerHostRuntimeRelationship: String, Codable, Sendable {
+    case localRuntimeMayExplainHostFootprint
+    case remoteRuntimeNotRelatedToHostFootprint
+    case unknownRelationship
+}
+
+/// Sanitized metadata for the active Docker context. The endpoint never
+/// retains user information, passwords, query parameters, or fragments.
+struct DockerRuntimeContext: Hashable, Codable, Sendable {
+    let name: String?
+    let sanitizedEndpoint: String?
+    let location: DockerRuntimeLocation
+
+    static let unknown = DockerRuntimeContext(
+        name: nil,
+        sanitizedEndpoint: nil,
+        location: .unknown
+    )
+}
+
+enum DockerRuntimeStatus: String, Codable, Sendable {
+    case notInstalled
+    case installedDaemonUnavailable
+    case installedAndReachable
+    case commandFailed
+    case partiallyReadable
+    case cancelled
+}
+
+enum DockerRuntimeStorageCategory: String, Codable, CaseIterable, Sendable {
+    case images
+    case containers
+    case localVolumes
+    case buildCache
+}
+
+/// One category from Docker's read-only `system df` report.
+struct DockerRuntimeStorageUsage: Hashable, Codable, Sendable {
+    let category: DockerRuntimeStorageCategory
+    let totalBytes: Int64?
+    let reclaimableBytes: Int64?
+    let reclaimablePercentage: Double?
+    let objectCount: Int?
+    let activeCount: Int?
+
+    /// Docker local volumes commonly contain databases and other durable app
+    /// state. Reclaimability does not change this application-data meaning.
+    var isApplicationData: Bool { category == .localVolumes }
+}
+
+/// Docker's internal view of storage. These values explain runtime contents;
+/// they are not additional host filesystem bytes.
+struct DockerRuntimeAccounting: Hashable, Codable, Sendable {
+    let images: DockerRuntimeStorageUsage?
+    let containers: DockerRuntimeStorageUsage?
+    let localVolumes: DockerRuntimeStorageUsage?
+    let buildCache: DockerRuntimeStorageUsage?
+
+    var categories: [DockerRuntimeStorageUsage] {
+        [images, containers, localVolumes, buildCache].compactMap { $0 }
+    }
+
+    var totalRuntimeReportedBytes: Int64? {
+        let values = categories.compactMap(\.totalBytes)
+        return values.isEmpty ? nil : values.reduce(0, +)
+    }
+
+    var reclaimableBytes: Int64? {
+        let values = categories.compactMap(\.reclaimableBytes)
+        return values.isEmpty ? nil : values.reduce(0, +)
+    }
+
+    /// An aggregate percentage is only reported when all four categories
+    /// supplied both total and reclaimable bytes.
+    var reclaimablePercentage: Double? {
+        guard isComplete,
+              let totalRuntimeReportedBytes,
+              let reclaimableBytes,
+              totalRuntimeReportedBytes > 0 else {
+            return nil
+        }
+        return Double(reclaimableBytes) / Double(totalRuntimeReportedBytes) * 100
+    }
+
+    var isComplete: Bool {
+        let allCategories = [images, containers, localVolumes, buildCache]
+        return allCategories.allSatisfy {
+            $0?.totalBytes != nil && $0?.reclaimableBytes != nil
+        }
+    }
+}
+
+struct DockerHostFootprint: Hashable, Codable, Sendable {
+    let locations: [StorageAnalysisResult]
+    let logicalSize: Int64
+    let allocatedSize: Int64
+}
+
+enum DockerVirtualDiskFormat: String, Codable, Sendable {
+    case raw
+    case img
+    case qcow2
+    case vmdk
+    case sparseBundle
+}
+
+enum DockerSparseState: String, Codable, Sendable {
+    case sparse
+    case notSparse
+    case unknown
+}
+
+/// A recognized Docker-side virtual disk backed by its original StorageNode.
+/// Keeping the node avoids creating a second filesystem fact model.
+struct DockerVirtualDisk: Hashable, Codable, Sendable {
+    let storageNode: StorageNode
+    let format: DockerVirtualDiskFormat
+    let sparseState: DockerSparseState
+
+    var absolutePath: String { storageNode.absolutePath }
+    var logicalSize: Int64 { storageNode.logicalSize }
+    var allocatedSize: Int64 { storageNode.allocatedSize }
+    var accessibility: StorageAccessibility { storageNode.accessibility }
+    var scanIssues: [StorageScanIssue] { storageNode.scanIssues }
+}
+
+enum DockerStorageIssueKind: String, Codable, Sendable {
+    case filesystem
+    case executableNotFound
+    case contextInspectionFailed
+    case runtimeLocationUnknown
+    case daemonUnavailable
+    case commandFailed
+    case malformedRuntimeOutput
+    case cancelled
+}
+
+struct DockerStorageIssue: Identifiable, Hashable, Codable, Sendable {
+    var id: String { "\(kind.rawValue)|\(path ?? "")|\(message)" }
+
+    let kind: DockerStorageIssueKind
+    let message: String
+    let path: String?
+}
+
+/// A read-only Docker storage report with intentionally separate host and
+/// runtime perspectives.
+struct DockerStorageReport: Hashable, Codable, Sendable {
+    let hostFootprint: DockerHostFootprint
+    let virtualDisks: [DockerVirtualDisk]
+    let runtimeStatus: DockerRuntimeStatus
+    let runtimeAccounting: DockerRuntimeAccounting?
+    let dockerExecutablePath: String?
+    let runtimeContext: DockerRuntimeContext
+    let hostRuntimeRelationship: DockerHostRuntimeRelationship
+    let accountingRelationship: DockerAccountingRelationship
+    let wasCancelled: Bool
+    let issues: [DockerStorageIssue]
+
+    /// The only Docker value suitable for contribution to total Mac disk
+    /// usage. Runtime-reported bytes are deliberately excluded.
+    var macDiskUsageBytes: Int64 { hostFootprint.allocatedSize }
+
+    var totalRuntimeReportedBytes: Int64? {
+        runtimeAccounting?.totalRuntimeReportedBytes
+    }
+
+    var reclaimableBytes: Int64? {
+        runtimeAccounting?.reclaimableBytes
+    }
+}

--- a/PureMac/Models/StorageAnalysisModels.swift
+++ b/PureMac/Models/StorageAnalysisModels.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+// MARK: - Storage Analysis Types
+
+/// The filesystem object represented by a storage-analysis node.
+///
+/// This type intentionally does not describe whether an item can be cleaned.
+/// Storage analysis and cleanup are separate domains.
+enum StorageItemType: String, Codable, Sendable {
+    case directory
+    case regularFile
+    case symbolicLink
+    case volumeBoundary
+    case other
+    case unknown
+}
+
+/// Describes how completely the scanner could inspect a filesystem object.
+enum StorageAccessibility: String, Codable, Sendable {
+    case accessible
+    case partiallyAccessible
+    case inaccessible
+    case skippedDifferentVolume
+    case cancelled
+}
+
+enum StorageScanIssueKind: String, Codable, Sendable {
+    case permissionDenied
+    case unreadable
+    case metadataUnavailable
+    case directoryEnumerationFailed
+    case notDirectory
+    case differentVolume
+    case cancelled
+}
+
+/// A recoverable problem encountered while building a storage tree.
+///
+/// Scanner errors are data rather than thrown failures so a partial tree can
+/// still explain every location that was successfully inspected.
+struct StorageScanIssue: Identifiable, Hashable, Codable, Sendable {
+    var id: String {
+        let errorCode = posixErrorCode.map { String($0) } ?? "none"
+        return "\(path)|\(kind.rawValue)|\(errorCode)|\(message)"
+    }
+
+    let path: String
+    let kind: StorageScanIssueKind
+    let message: String
+    let posixErrorCode: Int32?
+}
+
+/// An application that has been reliably associated with analyzed storage.
+///
+/// Some storage locations, notably Group Containers, can be shared by more
+/// than one application. This value complements the legacy single-owner
+/// metadata without changing its meaning for existing analyzers.
+struct StorageApplicationOwner: Hashable, Codable, Sendable {
+    let bundleIdentifier: String
+    let displayName: String?
+}
+
+/// An extension point for future attribution and explanation work.
+///
+/// The first scanner leaves these fields unset. Keeping future semantic data
+/// outside the filesystem facts allows application ownership, storage
+/// categories, safety classifications, and confidence to be added without
+/// changing the tree shape or coupling the analyzer to `CleanableItem`.
+struct StorageAnalysisMetadata: Hashable, Codable, Sendable {
+    /// A bundle identifier observed from storage naming or metadata. This can
+    /// exist even when no installed application owner has been verified.
+    var bundleIdentifier: String?
+    /// A structurally valid shared-container entitlement identifier. It is
+    /// intentionally distinct from an application's bundle identifier.
+    var groupContainerIdentifier: String?
+    var owningApplicationIdentifier: String?
+    var owningApplicationName: String?
+    /// Verified owners for storage that can legitimately be shared. Optional
+    /// keeps decoding compatible with metadata produced before this field was
+    /// introduced while distinguishing unresolved ownership from an answer.
+    var owningApplications: [StorageApplicationOwner]?
+    var storageCategoryIdentifier: String?
+    var safetyClassificationIdentifier: String?
+    var confidence: Double?
+    var isUnusuallyLarge: Bool?
+    var explanation: String?
+    var attributes: [String: String]
+
+    init(
+        bundleIdentifier: String? = nil,
+        groupContainerIdentifier: String? = nil,
+        owningApplicationIdentifier: String? = nil,
+        owningApplicationName: String? = nil,
+        owningApplications: [StorageApplicationOwner]? = nil,
+        storageCategoryIdentifier: String? = nil,
+        safetyClassificationIdentifier: String? = nil,
+        confidence: Double? = nil,
+        isUnusuallyLarge: Bool? = nil,
+        explanation: String? = nil,
+        attributes: [String: String] = [:]
+    ) {
+        self.bundleIdentifier = bundleIdentifier
+        self.groupContainerIdentifier = groupContainerIdentifier
+        self.owningApplicationIdentifier = owningApplicationIdentifier
+        self.owningApplicationName = owningApplicationName
+        self.owningApplications = owningApplications
+        self.storageCategoryIdentifier = storageCategoryIdentifier
+        self.safetyClassificationIdentifier = safetyClassificationIdentifier
+        self.confidence = confidence
+        self.isUnusuallyLarge = isUnusuallyLarge
+        self.explanation = explanation
+        self.attributes = attributes
+    }
+}
+
+/// A node in a hierarchical, read-only filesystem analysis.
+///
+/// `logicalSize` and `allocatedSize` are subtree totals: they include this
+/// node's counted bytes and all counted descendants. `ownLogicalSize` and
+/// `ownAllocatedSize` contain only the filesystem object's own metadata.
+/// Consumers should use the root totals or sum leaf/own values, but should not
+/// add a parent subtree total to its children again.
+struct StorageNode: Identifiable, Hashable, Codable, Sendable {
+    var id: String { absolutePath }
+
+    let name: String
+    let absolutePath: String
+    let logicalSize: Int64
+    let allocatedSize: Int64
+    let ownLogicalSize: Int64
+    let ownAllocatedSize: Int64
+    let itemType: StorageItemType
+    let children: [StorageNode]
+    let accessibility: StorageAccessibility
+    let scanIssues: [StorageScanIssue]
+    let isHidden: Bool
+    let isSymbolicLink: Bool
+
+    /// False when this object remains visible in the tree but its own bytes
+    /// have already been attributed elsewhere (for example, a hard link).
+    let isCountedInParentTotals: Bool
+
+    let metadata: StorageAnalysisMetadata
+}
+
+/// The complete output of one filesystem analysis operation.
+struct StorageAnalysisResult: Hashable, Codable, Sendable {
+    let root: StorageNode
+    let startedAt: Date
+    let completedAt: Date
+    let rootDeviceIdentifier: UInt64?
+    let wasCancelled: Bool
+
+    /// A flat summary of all issues also attached to their corresponding
+    /// nodes, useful to callers that do not need to walk the tree first.
+    let issues: [StorageScanIssue]
+}

--- a/PureMac/Models/StorageAttributionModels.swift
+++ b/PureMac/Models/StorageAttributionModels.swift
@@ -1,0 +1,218 @@
+import Foundation
+
+/// Typed classification of a top-level directory or entry on the writable Data volume.
+enum DataVolumeRegionClassification: String, Codable, Sendable {
+    case ownedByExistingAnalyzer
+    case measuredByCoverageExpansion
+    case partiallyMeasured
+    case protectedUnreadable
+    case separateVolumeOrMount
+    case nonAdditiveAPFS
+    case intentionallyExcluded
+    case unknown
+
+    var displayName: String {
+        switch self {
+        case .ownedByExistingAnalyzer: return "Owned by Analyzer"
+        case .measuredByCoverageExpansion: return "Measured in Expansion"
+        case .partiallyMeasured: return "Partially Measured"
+        case .protectedUnreadable: return "Protected by macOS"
+        case .separateVolumeOrMount: return "Separate Mount"
+        case .nonAdditiveAPFS: return "Non-Additive APFS"
+        case .intentionallyExcluded: return "Intentionally Excluded"
+        case .unknown: return "Unknown"
+        }
+    }
+}
+
+/// A root-level region on `/System/Volumes/Data` with ownership and measurement status.
+struct DataVolumeRootAttribution: Identifiable, Hashable, Codable, Sendable {
+    let originalPath: String
+    let normalizedPath: String
+    let name: String
+    let classification: DataVolumeRegionClassification
+    let canonicalOwner: StorageCanonicalRoot?
+    let analyzerStage: StorageAnalyzerStage?
+    let allocatedBytes: Int64?
+    let logicalBytes: Int64?
+    let isFilesystemAdditive: Bool
+    let statusExplanation: String
+    let isProtectedSystem: Bool
+
+    var id: String { normalizedPath }
+
+    init(
+        originalPath: String,
+        normalizedPath: String,
+        name: String,
+        classification: DataVolumeRegionClassification,
+        canonicalOwner: StorageCanonicalRoot?,
+        analyzerStage: StorageAnalyzerStage?,
+        allocatedBytes: Int64?,
+        logicalBytes: Int64?,
+        isFilesystemAdditive: Bool,
+        statusExplanation: String,
+        isProtectedSystem: Bool
+    ) {
+        self.originalPath = originalPath
+        self.normalizedPath = normalizedPath
+        self.name = name
+        self.classification = classification
+        self.canonicalOwner = canonicalOwner
+        self.analyzerStage = analyzerStage
+        self.allocatedBytes = allocatedBytes
+        self.logicalBytes = logicalBytes
+        self.isFilesystemAdditive = isFilesystemAdditive
+        self.statusExplanation = statusExplanation
+        self.isProtectedSystem = isProtectedSystem
+    }
+}
+
+/// Confidence / measurement status for an attribution item.
+enum StorageAttributionStatus: String, Codable, CaseIterable, Sendable {
+    case measured
+    case partial
+    case protectedUnreadable
+    case estimate
+    case nonAdditive
+    case unknown
+
+    var displayName: String {
+        switch self {
+        case .measured: return "Measured"
+        case .partial: return "Partial"
+        case .protectedUnreadable: return "Protected"
+        case .estimate: return "Estimate"
+        case .nonAdditive: return "Non-additive"
+        case .unknown: return "Unknown"
+        }
+    }
+}
+
+/// High-level attribution groups explaining the composition of volume storage.
+enum StorageAttributionCategory: String, Codable, CaseIterable, Sendable {
+    case measuredGaps
+    case protectedSystemStorage
+    case systemManagedStorage
+    case apfsAndNonAdditive
+    case stillUnattributed
+
+    var displayName: String {
+        switch self {
+        case .measuredGaps: return "Measured Gaps"
+        case .protectedSystemStorage: return "Protected System Storage"
+        case .systemManagedStorage: return "System-Managed Storage"
+        case .apfsAndNonAdditive: return "APFS & Non-Additive Factors"
+        case .stillUnattributed: return "Still Unattributed"
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .measuredGaps:
+            return "Filesystem regions discovered and measured by PureMac outside specialized roots."
+        case .protectedSystemStorage:
+            return "Locations governed by macOS System Integrity Protection and privacy access controls."
+        case .systemManagedStorage:
+            return "System services, virtual memory, sleep image, update assets, and system indexing databases."
+        case .apfsAndNonAdditive:
+            return "APFS volume-level features such as snapshots, purgeable capacity, shared extents, and metadata."
+        case .stillUnattributed:
+            return "Remaining unexplained volume capacity not yet attributed by measured or evidenced factors."
+        }
+    }
+}
+
+/// An individual attribution evidence row.
+struct StorageAttributionItem: Identifiable, Hashable, Codable, Sendable {
+    let id: String
+    let category: StorageAttributionCategory
+    let name: String
+    let path: String?
+    let status: StorageAttributionStatus
+    let allocatedBytes: Int64?
+    let explanation: String
+    let isFilesystemAdditive: Bool
+
+    init(
+        id: String,
+        category: StorageAttributionCategory,
+        name: String,
+        path: String? = nil,
+        status: StorageAttributionStatus,
+        allocatedBytes: Int64?,
+        explanation: String,
+        isFilesystemAdditive: Bool
+    ) {
+        self.id = id
+        self.category = category
+        self.name = name
+        self.path = path
+        self.status = status
+        self.allocatedBytes = allocatedBytes
+        self.explanation = explanation
+        self.isFilesystemAdditive = isFilesystemAdditive
+    }
+}
+
+/// Comprehensive report explaining the volume's storage state and the unexplained gap.
+struct StorageUnexplainedAttributionReport: Hashable, Codable, Sendable {
+    let volumeUsedBytes: Int64?
+    let explainedAllocatedBytes: Int64
+    let unexplainedBytes: Int64?
+    let residualUnattributedBytes: Int64?
+
+    let dataVolumeRoots: [DataVolumeRootAttribution]
+    let attributionItems: [StorageAttributionItem]
+
+    let vmFootprintBytes: Int64?
+    let sleepImageBytes: Int64?
+    let snapshotFootprintBytes: Int64?
+    let purgeableEstimateBytes: Int64?
+
+    let wasCancelled: Bool
+    let issues: [StorageScanIssue]
+
+    static let empty = StorageUnexplainedAttributionReport(
+        volumeUsedBytes: nil,
+        explainedAllocatedBytes: 0,
+        unexplainedBytes: nil,
+        residualUnattributedBytes: nil,
+        dataVolumeRoots: [],
+        attributionItems: [],
+        vmFootprintBytes: nil,
+        sleepImageBytes: nil,
+        snapshotFootprintBytes: nil,
+        purgeableEstimateBytes: nil,
+        wasCancelled: false,
+        issues: []
+    )
+
+    init(
+        volumeUsedBytes: Int64?,
+        explainedAllocatedBytes: Int64,
+        unexplainedBytes: Int64?,
+        residualUnattributedBytes: Int64?,
+        dataVolumeRoots: [DataVolumeRootAttribution],
+        attributionItems: [StorageAttributionItem],
+        vmFootprintBytes: Int64?,
+        sleepImageBytes: Int64?,
+        snapshotFootprintBytes: Int64?,
+        purgeableEstimateBytes: Int64?,
+        wasCancelled: Bool,
+        issues: [StorageScanIssue]
+    ) {
+        self.volumeUsedBytes = volumeUsedBytes
+        self.explainedAllocatedBytes = explainedAllocatedBytes
+        self.unexplainedBytes = unexplainedBytes
+        self.residualUnattributedBytes = residualUnattributedBytes
+        self.dataVolumeRoots = dataVolumeRoots
+        self.attributionItems = attributionItems
+        self.vmFootprintBytes = vmFootprintBytes
+        self.sleepImageBytes = sleepImageBytes
+        self.snapshotFootprintBytes = snapshotFootprintBytes
+        self.purgeableEstimateBytes = purgeableEstimateBytes
+        self.wasCancelled = wasCancelled
+        self.issues = issues
+    }
+}

--- a/PureMac/Models/StorageCoverageDiagnosticModels.swift
+++ b/PureMac/Models/StorageCoverageDiagnosticModels.swift
@@ -1,0 +1,284 @@
+import Foundation
+
+/// Why a storage measurement or coverage statement is incomplete.
+///
+/// These values describe observation quality only. They never imply that an
+/// item is junk or eligible for a filesystem mutation.
+enum StorageCoverageDiagnosticCategory: String, Codable, CaseIterable, Sendable {
+    case permissionDenied
+    case inaccessible
+    case enumerationFailure
+    case metadataFailure
+    case differentVolumeBoundary
+    case cancelled
+    case missingOptionalRoot
+    case failedAnalyzer
+    case uncoveredFilesystemRegion
+    case nonAdditiveAPFSStorage
+    case possibleSharedExtentAccounting
+    case concurrentFilesystemChange
+    case unknown
+}
+
+enum StorageCoverageDiagnosticSeverity: String, Codable, Sendable {
+    case informational
+    case warning
+}
+
+enum StorageCoverageDiagnosticSource: Hashable, Codable, Sendable {
+    case analyzer(StorageAnalyzerStage)
+    case canonicalRoot(StorageCanonicalRoot)
+    case coverageDiscovery
+    case reconciliation
+    case apfs
+
+    var identifier: String {
+        switch self {
+        case let .analyzer(stage): return "analyzer:\(stage.rawValue)"
+        case let .canonicalRoot(root): return "root:\(root.rawValue)"
+        case .coverageDiscovery: return "coverage-discovery"
+        case .reconciliation: return "reconciliation"
+        case .apfs: return "apfs"
+        }
+    }
+}
+
+/// Semantic measurement confidence. Percentages are intentionally avoided
+/// because the scanner does not know the size of unreadable or uncovered data.
+enum StorageMeasurementConfidence: String, Codable, Sendable {
+    case completeMeasurement
+    case knownLowerBound
+    case partialCoverage
+    case nonAdditiveMetadata
+    case unmeasured
+}
+
+struct StorageCoverageDiagnosticCategoryCount: Identifiable, Hashable, Codable, Sendable {
+    let category: StorageCoverageDiagnosticCategory
+    let count: Int
+
+    var id: String { category.rawValue }
+}
+
+struct StorageCoverageDiagnosticAnalyzerCount: Identifiable, Hashable, Codable, Sendable {
+    let analyzer: StorageAnalyzerStage
+    let count: Int
+
+    var id: String { analyzer.rawValue }
+}
+
+struct StorageCoverageDiagnosticRootCount: Identifiable, Hashable, Codable, Sendable {
+    let root: StorageCanonicalRoot
+    let configuredPath: String
+    let count: Int
+
+    var id: String { root.rawValue }
+}
+
+struct StorageCoverageDiagnosticErrnoCount: Identifiable, Hashable, Codable, Sendable {
+    let errorCode: Int32
+    let count: Int
+
+    var id: Int32 { errorCode }
+}
+
+struct StorageCoverageDiagnosticParentCount: Identifiable, Hashable, Codable, Sendable {
+    let parentPath: String
+    let count: Int
+
+    var id: String { parentPath }
+}
+
+/// A compact issue group. Only a bounded number of example paths are retained;
+/// `count` still represents every unique issue occurrence in the group.
+struct StorageCoverageDiagnosticIssueGroup: Identifiable, Hashable, Codable, Sendable {
+    let category: StorageCoverageDiagnosticCategory
+    let severity: StorageCoverageDiagnosticSeverity
+    let source: StorageCoverageDiagnosticSource
+    let contributingSources: [StorageCoverageDiagnosticSource]
+    let canonicalRoot: StorageCanonicalRoot?
+    let posixErrorCode: Int32?
+    let count: Int
+    let representativePaths: [String]
+    let explanation: String
+
+    var id: String {
+        let root = canonicalRoot?.rawValue ?? "none"
+        let errorCode = posixErrorCode.map(String.init) ?? "none"
+        return "\(category.rawValue)|\(source.identifier)|\(root)|\(errorCode)"
+    }
+
+    init(
+        category: StorageCoverageDiagnosticCategory,
+        severity: StorageCoverageDiagnosticSeverity,
+        source: StorageCoverageDiagnosticSource,
+        contributingSources: [StorageCoverageDiagnosticSource]? = nil,
+        canonicalRoot: StorageCanonicalRoot?,
+        posixErrorCode: Int32?,
+        count: Int,
+        representativePaths: [String],
+        explanation: String
+    ) {
+        self.category = category
+        self.severity = severity
+        self.source = source
+        self.contributingSources = contributingSources ?? [source]
+        self.canonicalRoot = canonicalRoot
+        self.posixErrorCode = posixErrorCode
+        self.count = count
+        self.representativePaths = representativePaths
+        self.explanation = explanation
+    }
+}
+
+struct StorageCoverageIssueAggregation: Hashable, Codable, Sendable {
+    let totalIssueCount: Int
+    let categoryCounts: [StorageCoverageDiagnosticCategoryCount]
+    let analyzerCounts: [StorageCoverageDiagnosticAnalyzerCount]
+    let canonicalRootCounts: [StorageCoverageDiagnosticRootCount]
+    let errnoCounts: [StorageCoverageDiagnosticErrnoCount]
+    let topAffectedParentPaths: [StorageCoverageDiagnosticParentCount]
+    let groups: [StorageCoverageDiagnosticIssueGroup]
+
+    static let empty = StorageCoverageIssueAggregation(
+        totalIssueCount: 0,
+        categoryCounts: [],
+        analyzerCounts: [],
+        canonicalRootCounts: [],
+        errnoCounts: [],
+        topAffectedParentPaths: [],
+        groups: []
+    )
+}
+
+enum StorageCoverageGapKind: String, Codable, Sendable {
+    case hiddenHomeEntry
+    case unspecializedUserLibraryEntry
+    case otherUsers
+    case rootFilesystemRegion
+    case inaccessibleSubtree
+    case otherMountedVolume
+}
+
+enum StorageCoverageMapState: String, Codable, Sendable {
+    case measured
+    case partiallyMeasured
+    case presentButUnmeasured
+    case intentionallyUnmeasured
+    case missingOptional
+    case unavailable
+    case nonAdditive
+}
+
+struct StorageCoverageGap: Identifiable, Hashable, Codable, Sendable {
+    let kind: StorageCoverageGapKind
+    let name: String
+    let absolutePath: String?
+    let category: StorageCoverageDiagnosticCategory
+    let state: StorageCoverageMapState
+    let confidence: StorageMeasurementConfidence
+    let explanation: String
+
+    var id: String {
+        "\(kind.rawValue)|\(absolutePath.map { StoragePathNormalizer.normalize($0) } ?? name)"
+    }
+}
+
+struct StorageCoverageMapEntry: Identifiable, Hashable, Codable, Sendable {
+    let identifier: String
+    let title: String
+    let absolutePath: String?
+    let source: StorageCoverageDiagnosticSource
+    let state: StorageCoverageMapState
+    let confidence: StorageMeasurementConfidence
+    let explanation: String
+
+    var id: String { identifier }
+}
+
+enum StorageAnalyzerDiagnosticState: String, Codable, Sendable {
+    case complete
+    case knownLowerBound
+    case failed
+    case cancelled
+    case optionalRootMissing
+    case nonAdditiveMetadata
+}
+
+struct StorageAnalyzerCoverageDiagnostic: Identifiable, Hashable, Codable, Sendable {
+    let analyzer: StorageAnalyzerStage
+    let state: StorageAnalyzerDiagnosticState
+    let issueCount: Int
+    let confidence: StorageMeasurementConfidence
+
+    var id: String { analyzer.rawValue }
+}
+
+struct StorageCoverageExplanation: Identifiable, Hashable, Codable, Sendable {
+    let category: StorageCoverageDiagnosticCategory
+    let severity: StorageCoverageDiagnosticSeverity
+    let title: String
+    let detail: String
+
+    var id: String { "\(category.rawValue)|\(title)" }
+}
+
+/// Shallow discovery output. Entries have no byte values because discovery
+/// deliberately performs no recursive traversal or size calculation.
+struct StorageCoverageDiscoveryResult: Hashable, Codable, Sendable {
+    let homeDirectoryPath: String
+    let hiddenHomeEntries: [StorageCoverageGap]
+    let unspecializedLibraryEntries: [StorageCoverageGap]
+    let issues: [StorageScanIssue]
+    let wasCancelled: Bool
+
+    static func empty(homeDirectoryPath: String) -> StorageCoverageDiscoveryResult {
+        StorageCoverageDiscoveryResult(
+            homeDirectoryPath: homeDirectoryPath,
+            hiddenHomeEntries: [],
+            unspecializedLibraryEntries: [],
+            issues: [],
+            wasCancelled: false
+        )
+    }
+}
+
+struct StorageCoverageDiagnostic: Hashable, Codable, Sendable {
+    let measurementIssues: StorageCoverageIssueAggregation
+    let coverageMap: [StorageCoverageMapEntry]
+    let coverageGaps: [StorageCoverageGap]
+    let analyzerStatuses: [StorageAnalyzerCoverageDiagnostic]
+    let unexplainedSpaceExplanations: [StorageCoverageExplanation]
+    let explainedStorageConfidence: StorageMeasurementConfidence
+    let unexplainedStorageConfidence: StorageMeasurementConfidence
+    let hiddenHomeEntryCount: Int
+    let unspecializedLibraryEntryCount: Int
+
+    var permissionDeniedIssueCount: Int {
+        measurementIssues.categoryCounts.first {
+            $0.category == .permissionDenied
+        }?.count ?? 0
+    }
+
+    static let empty = StorageCoverageDiagnostic(
+        measurementIssues: .empty,
+        coverageMap: [],
+        coverageGaps: [],
+        analyzerStatuses: [],
+        unexplainedSpaceExplanations: [],
+        explainedStorageConfidence: .completeMeasurement,
+        unexplainedStorageConfidence: .unmeasured,
+        hiddenHomeEntryCount: 0,
+        unspecializedLibraryEntryCount: 0
+    )
+}
+
+extension StorageCanonicalRootCoverage {
+    var measurementConfidence: StorageMeasurementConfidence {
+        switch state {
+        case .completed: return .completeMeasurement
+        case .partiallyCompleted, .failed, .cancelled: return .knownLowerBound
+        case .missingOptional: return .unmeasured
+        }
+    }
+}

--- a/PureMac/Models/StorageCoverageDiagnosticModels.swift
+++ b/PureMac/Models/StorageCoverageDiagnosticModels.swift
@@ -178,9 +178,39 @@ struct StorageCoverageGap: Identifiable, Hashable, Codable, Sendable {
     let state: StorageCoverageMapState
     let confidence: StorageMeasurementConfidence
     let explanation: String
+    let allocatedBytes: Int64?
+    let logicalBytes: Int64?
+    let isFilesystemAdditive: Bool
+    let issueCount: Int
 
     var id: String {
         "\(kind.rawValue)|\(absolutePath.map { StoragePathNormalizer.normalize($0) } ?? name)"
+    }
+
+    init(
+        kind: StorageCoverageGapKind,
+        name: String,
+        absolutePath: String?,
+        category: StorageCoverageDiagnosticCategory,
+        state: StorageCoverageMapState,
+        confidence: StorageMeasurementConfidence,
+        explanation: String,
+        allocatedBytes: Int64? = nil,
+        logicalBytes: Int64? = nil,
+        isFilesystemAdditive: Bool = false,
+        issueCount: Int = 0
+    ) {
+        self.kind = kind
+        self.name = name
+        self.absolutePath = absolutePath
+        self.category = category
+        self.state = state
+        self.confidence = confidence
+        self.explanation = explanation
+        self.allocatedBytes = allocatedBytes
+        self.logicalBytes = logicalBytes
+        self.isFilesystemAdditive = isFilesystemAdditive
+        self.issueCount = issueCount
     }
 }
 

--- a/PureMac/Models/StorageReconciliationModels.swift
+++ b/PureMac/Models/StorageReconciliationModels.swift
@@ -1,0 +1,300 @@
+import Foundation
+
+/// The existing read-only analyzer stages coordinated by whole-disk
+/// reconciliation. Raw values provide stable deterministic ordering.
+enum StorageAnalyzerStage: String, Codable, CaseIterable, Sendable {
+    case apfsVolume
+    case userHomeStorage
+    case applicationSupport
+    case containers
+    case groupContainers
+    case systemLibrary
+    case privateStorage
+    case dataVolumeHiddenStorage
+    case developerSystemStorage
+    case dockerStorage
+    case coverageExpansion
+}
+
+enum StorageCoordinatorRunState: String, Codable, Sendable {
+    case running
+    case completed
+    case cancelled
+}
+
+struct StorageAnalysisProgress: Hashable, Codable, Sendable {
+    let totalStages: Int
+    let completedStages: Int
+    let runningStages: [StorageAnalyzerStage]
+    let state: StorageCoordinatorRunState
+}
+
+enum StorageCoverageStatus: String, Codable, Sendable {
+    case completeForConfiguredRoots
+    case partialDueToPermissions
+    case partialDueToMeasurementIssues
+    case partialDueToCancellation
+    case partialDueToAnalyzerFailure
+}
+
+enum StorageCanonicalRoot: String, Codable, CaseIterable, Sendable {
+    case userHomeVisibleStorage
+    case applicationSupport
+    case containers
+    case groupContainers
+    case systemLibrary
+    case privateStorage
+    case dataVolumeHiddenStorage
+    case opt
+    case usrLocal
+    case additionalCoverageGap
+}
+
+enum StorageCanonicalRootState: String, Codable, Sendable {
+    case completed
+    case partiallyCompleted
+    case failed
+    case missingOptional
+    case cancelled
+}
+
+struct StorageCanonicalRootCoverage: Hashable, Codable, Sendable {
+    let root: StorageCanonicalRoot
+    let configuredPath: String
+    let state: StorageCanonicalRootState
+    /// Successfully measured bytes. For partial roots this is a known lower
+    /// bound and never an estimate of unreadable descendants.
+    let knownAllocatedBytes: Int64
+    let unreadablePathCount: Int
+}
+
+enum StorageAccountingSource: String, Codable, Sendable {
+    case userHomeVisibleStorage
+    case applicationSupport
+    case containers
+    case groupContainers
+    case systemLibrary
+    case privateStorage
+    case dataVolumeHiddenStorage
+    case opt
+    case usrLocal
+    case dockerHostOutsideCanonicalRoots
+    case additionalCoverageGap
+}
+
+enum StorageContributionRelationship: String, Codable, Sendable {
+    case canonicalUnique
+    case externalSpecializedUnique
+    case excludedDuplicatePath
+    case excludedNestedPath
+}
+
+/// One path considered by the canonical ownership policy. Observed bytes are
+/// retained even when ownership assigns them to another enclosing root.
+struct StorageFilesystemContribution: Hashable, Codable, Sendable {
+    let source: StorageAccountingSource
+    let absolutePath: String
+    let normalizedPath: String
+    let observedAllocatedBytes: Int64
+    let accountedAllocatedBytes: Int64
+    let relationship: StorageContributionRelationship
+    let owningPath: String?
+}
+
+enum StorageHardLinkAccountingStatus: String, Codable, Sendable {
+    /// Each analyzer tree deduplicates internally and the developer analyzer
+    /// shares a ledger across /opt and /usr/local. Independent analyzer trees
+    /// currently do not expose inode identity for a global post-scan ledger.
+    case deduplicatedWithinAnalyzerScopesOnly
+}
+
+enum StorageReconciliationIssueKind: String, Codable, Sendable {
+    case analyzerFailure
+    case analyzerIssue
+    case permissionIncomplete
+    case cancelled
+    case duplicateRootExcluded
+    case nestedRootExcluded
+    case accountingAnomaly
+    case crossAnalyzerHardLinkDeduplicationUnavailable
+}
+
+struct StorageReconciliationIssue: Identifiable, Hashable, Codable, Sendable {
+    let kind: StorageReconciliationIssueKind
+    let stage: StorageAnalyzerStage?
+    let path: String?
+    let message: String
+
+    var id: String {
+        "\(kind.rawValue)|\(stage?.rawValue ?? "")|\(path ?? "")|\(message)"
+    }
+}
+
+enum StorageCoverageCandidateScope: String, Codable, Sendable {
+    case userLibrary
+    case hiddenHome
+    case dataVolumeRoot
+    case other
+}
+
+enum StorageCoverageCandidateStatus: String, Codable, Sendable {
+    case eligible
+    case measured
+    case excludedAlreadyAccounted
+    case excludedNested
+    case excludedSymlink
+    case excludedDifferentVolume
+    case excludedProtectedSystem
+    case inaccessible
+    case failed
+    case cancelled
+}
+
+struct StorageCoverageCandidate: Identifiable, Hashable, Codable, Sendable {
+    let originalPath: String
+    let normalizedPath: String
+    let name: String
+    let scope: StorageCoverageCandidateScope
+    let status: StorageCoverageCandidateStatus
+    let allocatedBytes: Int64?
+    let logicalBytes: Int64?
+    let issue: StorageScanIssue?
+    let exclusionReason: String?
+    let contributesToExplainedBytes: Bool
+
+    var id: String { normalizedPath }
+}
+
+struct StorageCoverageExpansionReport: Hashable, Codable, Sendable {
+    let totalNewlyMeasuredBytes: Int64
+    let measuredCandidateCount: Int
+    let excludedOverlapCount: Int
+    let inaccessibleCandidateCount: Int
+    let differentVolumeBoundaryCount: Int
+    let failedCandidateCount: Int
+    let candidates: [StorageCoverageCandidate]
+    let largestDiscoveredRegions: [StorageCoverageCandidate]
+    let treeResults: [StorageAnalysisResult]
+    let wasCancelled: Bool
+    let issues: [StorageScanIssue]
+
+    static let empty = StorageCoverageExpansionReport(
+        totalNewlyMeasuredBytes: 0,
+        measuredCandidateCount: 0,
+        excludedOverlapCount: 0,
+        inaccessibleCandidateCount: 0,
+        differentVolumeBoundaryCount: 0,
+        failedCandidateCount: 0,
+        candidates: [],
+        largestDiscoveredRegions: [],
+        treeResults: [],
+        wasCancelled: false,
+        issues: []
+    )
+}
+
+/// Every underlying result remains available as explanatory drill-down data.
+/// Optional values indicate a stage that failed or never started.
+struct StorageAnalyzerResults: Hashable, Codable, Sendable {
+    var userHomeStorage: UserHomeStorageReport?
+    var applicationSupport: StorageAnalysisResult?
+    var containers: StorageAnalysisResult?
+    var groupContainers: StorageAnalysisResult?
+    var systemLibrary: StorageAnalysisResult?
+    var privateStorage: StorageAnalysisResult?
+    var dataVolumeHiddenStorage: StorageAnalysisResult?
+    var developerSystemStorage: DeveloperSystemStorageReport?
+    var dockerStorage: DockerStorageReport?
+    var apfsStorage: APFSStorageReport?
+    var coverageExpansion: StorageCoverageExpansionReport?
+}
+
+struct StorageReconciliationReport: Hashable, Codable, Sendable {
+    let totalCapacityBytes: Int64?
+    let usedCapacityBytes: Int64?
+    let availableCapacityBytes: Int64?
+    /// An OS-provided estimate kept separate from both used and explained
+    /// bytes. It is not guaranteed reclaimable capacity.
+    let purgeableEstimateBytes: Int64?
+
+    /// Unique allocated filesystem bytes attributed by the configured roots
+    /// under the coordinator's ownership policy.
+    let explainedAllocatedBytes: Int64
+    /// `max(used - explained, 0)` when used capacity is known. This includes
+    /// uncovered roots, inaccessible descendants, APFS metadata/shared
+    /// extents, and current accounting limitations; it is never called junk.
+    let unexplainedBytes: Int64?
+    /// The measured subset of partial/inaccessible roots. This is contained
+    /// in explained bytes and does not estimate the unreadable remainder.
+    let inaccessibleKnownLowerBoundBytes: Int64
+    let unreadablePathCount: Int
+
+    /// True because configured analyzers still cannot fully observe every
+    /// volume path, inaccessible descendant, or APFS shared extent.
+    let incompleteCoverage: Bool
+    let coverageStatus: StorageCoverageStatus
+    let canonicalRootCoverage: [StorageCanonicalRootCoverage]
+    let filesystemContributions: [StorageFilesystemContribution]
+    let hardLinkAccountingStatus: StorageHardLinkAccountingStatus
+    let analysisIssues: [StorageReconciliationIssue]
+    let analyzerResults: StorageAnalyzerResults
+    /// Read-only explanation of incomplete measurement and intentionally
+    /// uncovered regions. It does not contribute any storage bytes.
+    let coverageDiagnostic: StorageCoverageDiagnostic
+    /// Typed attribution breakdown explaining why unexplained storage remains.
+    let attributionReport: StorageUnexplainedAttributionReport?
+
+    let startedAt: Date
+    let completedAt: Date
+    let duration: TimeInterval
+    let progress: StorageAnalysisProgress
+    let wasCancelled: Bool
+
+    init(
+        totalCapacityBytes: Int64?,
+        usedCapacityBytes: Int64?,
+        availableCapacityBytes: Int64?,
+        purgeableEstimateBytes: Int64?,
+        explainedAllocatedBytes: Int64,
+        unexplainedBytes: Int64?,
+        inaccessibleKnownLowerBoundBytes: Int64,
+        unreadablePathCount: Int,
+        incompleteCoverage: Bool,
+        coverageStatus: StorageCoverageStatus,
+        canonicalRootCoverage: [StorageCanonicalRootCoverage],
+        filesystemContributions: [StorageFilesystemContribution],
+        hardLinkAccountingStatus: StorageHardLinkAccountingStatus,
+        analysisIssues: [StorageReconciliationIssue],
+        analyzerResults: StorageAnalyzerResults,
+        coverageDiagnostic: StorageCoverageDiagnostic,
+        attributionReport: StorageUnexplainedAttributionReport? = nil,
+        startedAt: Date,
+        completedAt: Date,
+        duration: TimeInterval,
+        progress: StorageAnalysisProgress,
+        wasCancelled: Bool
+    ) {
+        self.totalCapacityBytes = totalCapacityBytes
+        self.usedCapacityBytes = usedCapacityBytes
+        self.availableCapacityBytes = availableCapacityBytes
+        self.purgeableEstimateBytes = purgeableEstimateBytes
+        self.explainedAllocatedBytes = explainedAllocatedBytes
+        self.unexplainedBytes = unexplainedBytes
+        self.inaccessibleKnownLowerBoundBytes = inaccessibleKnownLowerBoundBytes
+        self.unreadablePathCount = unreadablePathCount
+        self.incompleteCoverage = incompleteCoverage
+        self.coverageStatus = coverageStatus
+        self.canonicalRootCoverage = canonicalRootCoverage
+        self.filesystemContributions = filesystemContributions
+        self.hardLinkAccountingStatus = hardLinkAccountingStatus
+        self.analysisIssues = analysisIssues
+        self.analyzerResults = analyzerResults
+        self.coverageDiagnostic = coverageDiagnostic
+        self.attributionReport = attributionReport
+        self.startedAt = startedAt
+        self.completedAt = completedAt
+        self.duration = duration
+        self.progress = progress
+        self.wasCancelled = wasCancelled
+    }
+}

--- a/PureMac/Models/StorageReconciliationModels.swift
+++ b/PureMac/Models/StorageReconciliationModels.swift
@@ -5,6 +5,7 @@ import Foundation
 enum StorageAnalyzerStage: String, Codable, CaseIterable, Sendable {
     case apfsVolume
     case userHomeStorage
+    case applications
     case applicationSupport
     case containers
     case groupContainers
@@ -39,6 +40,7 @@ enum StorageCoverageStatus: String, Codable, Sendable {
 
 enum StorageCanonicalRoot: String, Codable, CaseIterable, Sendable {
     case userHomeVisibleStorage
+    case applications
     case applicationSupport
     case containers
     case groupContainers
@@ -70,6 +72,7 @@ struct StorageCanonicalRootCoverage: Hashable, Codable, Sendable {
 
 enum StorageAccountingSource: String, Codable, Sendable {
     case userHomeVisibleStorage
+    case applications
     case applicationSupport
     case containers
     case groupContainers
@@ -140,14 +143,39 @@ enum StorageCoverageCandidateScope: String, Codable, Sendable {
 enum StorageCoverageCandidateStatus: String, Codable, Sendable {
     case eligible
     case measured
+    case partiallyMeasured
+    case inaccessible
+    case skippedAlreadyOwned
+    case skippedNonAdditive
+    case skippedUnsafeOverlap
     case excludedAlreadyAccounted
     case excludedNested
     case excludedSymlink
     case excludedDifferentVolume
     case excludedProtectedSystem
-    case inaccessible
     case failed
     case cancelled
+
+    var isMeasuredOrPartial: Bool {
+        self == .measured || self == .partiallyMeasured
+    }
+
+    var displayName: String {
+        switch self {
+        case .eligible: return "Eligible"
+        case .measured: return "Measured"
+        case .partiallyMeasured: return "Partial"
+        case .inaccessible: return "Inaccessible"
+        case .skippedAlreadyOwned, .excludedAlreadyAccounted: return "Already Accounted"
+        case .skippedNonAdditive: return "Non-additive"
+        case .skippedUnsafeOverlap, .excludedNested: return "Excluded (Overlap)"
+        case .excludedSymlink: return "Excluded (Symlink)"
+        case .excludedDifferentVolume: return "Different Volume"
+        case .excludedProtectedSystem: return "Protected System"
+        case .failed: return "Failed"
+        case .cancelled: return "Cancelled"
+        }
+    }
 }
 
 struct StorageCoverageCandidate: Identifiable, Hashable, Codable, Sendable {
@@ -197,6 +225,7 @@ struct StorageCoverageExpansionReport: Hashable, Codable, Sendable {
 /// Optional values indicate a stage that failed or never started.
 struct StorageAnalyzerResults: Hashable, Codable, Sendable {
     var userHomeStorage: UserHomeStorageReport?
+    var applications: StorageAnalysisResult?
     var applicationSupport: StorageAnalysisResult?
     var containers: StorageAnalysisResult?
     var groupContainers: StorageAnalysisResult?
@@ -207,6 +236,37 @@ struct StorageAnalyzerResults: Hashable, Codable, Sendable {
     var dockerStorage: DockerStorageReport?
     var apfsStorage: APFSStorageReport?
     var coverageExpansion: StorageCoverageExpansionReport?
+    var physicalReconciliation: APFSPhysicalReconciliationReport?
+
+    init(
+        userHomeStorage: UserHomeStorageReport? = nil,
+        applications: StorageAnalysisResult? = nil,
+        applicationSupport: StorageAnalysisResult? = nil,
+        containers: StorageAnalysisResult? = nil,
+        groupContainers: StorageAnalysisResult? = nil,
+        systemLibrary: StorageAnalysisResult? = nil,
+        privateStorage: StorageAnalysisResult? = nil,
+        dataVolumeHiddenStorage: StorageAnalysisResult? = nil,
+        developerSystemStorage: DeveloperSystemStorageReport? = nil,
+        dockerStorage: DockerStorageReport? = nil,
+        apfsStorage: APFSStorageReport? = nil,
+        coverageExpansion: StorageCoverageExpansionReport? = nil,
+        physicalReconciliation: APFSPhysicalReconciliationReport? = nil
+    ) {
+        self.userHomeStorage = userHomeStorage
+        self.applications = applications
+        self.applicationSupport = applicationSupport
+        self.containers = containers
+        self.groupContainers = groupContainers
+        self.systemLibrary = systemLibrary
+        self.privateStorage = privateStorage
+        self.dataVolumeHiddenStorage = dataVolumeHiddenStorage
+        self.developerSystemStorage = developerSystemStorage
+        self.dockerStorage = dockerStorage
+        self.apfsStorage = apfsStorage
+        self.coverageExpansion = coverageExpansion
+        self.physicalReconciliation = physicalReconciliation
+    }
 }
 
 struct StorageReconciliationReport: Hashable, Codable, Sendable {
@@ -243,6 +303,8 @@ struct StorageReconciliationReport: Hashable, Codable, Sendable {
     let coverageDiagnostic: StorageCoverageDiagnostic
     /// Typed attribution breakdown explaining why unexplained storage remains.
     let attributionReport: StorageUnexplainedAttributionReport?
+    /// Physical reconciliation report bridging container/volume usage to filesystem accounting.
+    let physicalReconciliation: APFSPhysicalReconciliationReport?
 
     let startedAt: Date
     let completedAt: Date
@@ -268,6 +330,7 @@ struct StorageReconciliationReport: Hashable, Codable, Sendable {
         analyzerResults: StorageAnalyzerResults,
         coverageDiagnostic: StorageCoverageDiagnostic,
         attributionReport: StorageUnexplainedAttributionReport? = nil,
+        physicalReconciliation: APFSPhysicalReconciliationReport? = nil,
         startedAt: Date,
         completedAt: Date,
         duration: TimeInterval,
@@ -291,6 +354,7 @@ struct StorageReconciliationReport: Hashable, Codable, Sendable {
         self.analyzerResults = analyzerResults
         self.coverageDiagnostic = coverageDiagnostic
         self.attributionReport = attributionReport
+        self.physicalReconciliation = physicalReconciliation
         self.startedAt = startedAt
         self.completedAt = completedAt
         self.duration = duration

--- a/PureMac/Services/ScanEngine.swift
+++ b/PureMac/Services/ScanEngine.swift
@@ -75,33 +75,30 @@ actor ScanEngine {
     }
 
     func getDiskInfo() -> DiskInfo {
-        var info = DiskInfo()
-        do {
-            let attrs = try fileManager.attributesOfFileSystem(forPath: "/")
-            if let total = attrs[.systemSize] as? Int64 {
-                info.totalSpace = total
-            }
-            if let free = attrs[.systemFreeSize] as? Int64 {
-                info.freeSpace = free
-            }
-            info.usedSpace = info.totalSpace - info.freeSpace
+        let result = VolumeStatisticsProvider.read(
+            at: URL(fileURLWithPath: "/", isDirectory: true)
+        )
+        let info = Self.makeDiskInfo(from: result.statistics)
+        for issue in result.issues {
+            Logger.shared.log("Disk info unavailable: \(issue.message)", level: .warning)
+        }
+        return info
+    }
 
-            // Use URLResourceValues for accurate purgeable space detection
-            let rootURL = URL(fileURLWithPath: "/")
-            let values = try rootURL.resourceValues(forKeys: [
-                .volumeAvailableCapacityForImportantUsageKey,
-                .volumeAvailableCapacityKey
-            ])
-            if let importantCapacity = values.volumeAvailableCapacityForImportantUsage,
-               let freeCapacity = values.volumeAvailableCapacity {
-                // Purgeable = important capacity (free + purgeable) minus actual free
-                let purgeable = importantCapacity - Int64(freeCapacity)
-                if purgeable > 10 * 1024 * 1024 { // Only report if > 10 MB
-                    info.purgeableSpace = purgeable
-                }
-            }
-        } catch {
-            Logger.shared.log("Disk info unavailable: \(error.localizedDescription)", level: .warning)
+    /// Keeps the pre-existing dashboard/cleanup representation on top of the
+    /// shared read-only capacity calculation. Internal for regression tests.
+    static func makeDiskInfo(from statistics: VolumeCapacityStatistics) -> DiskInfo {
+        var info = DiskInfo()
+        info.totalSpace = statistics.totalCapacity ?? 0
+        info.freeSpace = statistics.availableCapacity ?? 0
+        info.usedSpace = statistics.usedCapacity ?? max(0, info.totalSpace - info.freeSpace)
+
+        // Preserve the existing UI/cleanup threshold. The shared provider
+        // owns only the estimate formula: important-usage capacity minus
+        // ordinary available capacity.
+        if let purgeable = statistics.purgeableEstimate,
+           purgeable > 10 * 1024 * 1024 {
+            info.purgeableSpace = purgeable
         }
         return info
     }

--- a/PureMac/Services/StorageAnalysisCoordinator.swift
+++ b/PureMac/Services/StorageAnalysisCoordinator.swift
@@ -12,60 +12,40 @@ struct StorageAnalysisCoordinator: Sendable {
     typealias CoverageDiscovery = @Sendable () async -> StorageCoverageDiscoveryResult
     typealias ProgressHandler = @Sendable (StorageAnalysisProgress) async -> Void
 
-    private let applicationSupportAnalysis: FilesystemAnalysis
-    private let containersAnalysis: FilesystemAnalysis
-    private let groupContainersAnalysis: FilesystemAnalysis
-    private let systemLibraryAnalysis: FilesystemAnalysis
-    private let privateStorageAnalysis: FilesystemAnalysis
-    private let dataVolumeHiddenStorageAnalysis: FilesystemAnalysis
-    private let developerSystemStorageAnalysis: DeveloperAnalysis
-    private let dockerStorageAnalysis: DockerAnalysis
-    private let apfsStorageAnalysis: APFSAnalysis
-    private let userHomeStorageAnalysis: UserHomeAnalysis
-    private let coverageExpansionAnalysis: CoverageExpansionAnalysis
-    private let coverageDiscovery: CoverageDiscovery
+    private let userHomeStorageAnalysis: UserHomeAnalysis?
+    private let applicationsAnalysis: FilesystemAnalysis?
+    private let applicationSupportAnalysis: FilesystemAnalysis?
+    private let containersAnalysis: FilesystemAnalysis?
+    private let groupContainersAnalysis: FilesystemAnalysis?
+    private let systemLibraryAnalysis: FilesystemAnalysis?
+    private let privateStorageAnalysis: FilesystemAnalysis?
+    private let dataVolumeHiddenStorageAnalysis: FilesystemAnalysis?
+    private let developerSystemStorageAnalysis: DeveloperAnalysis?
+    private let dockerStorageAnalysis: DockerAnalysis?
+    private let apfsStorageAnalysis: APFSAnalysis?
+    private let coverageExpansionAnalysis: CoverageExpansionAnalysis?
+    private let coverageDiscovery: CoverageDiscovery?
     private let maxConcurrentAnalyzers: Int
 
     init(
-        maxConcurrentAnalyzers: Int = 2,
-        userHomeStorageAnalysis: @escaping UserHomeAnalysis = {
-            await UserHomeStorageAnalyzer().analyze()
-        },
-        applicationSupportAnalysis: @escaping FilesystemAnalysis = {
-            await ApplicationSupportAnalyzer().analyze()
-        },
-        containersAnalysis: @escaping FilesystemAnalysis = {
-            await ContainersAnalyzer().analyze()
-        },
-        groupContainersAnalysis: @escaping FilesystemAnalysis = {
-            await GroupContainersAnalyzer().analyze()
-        },
-        systemLibraryAnalysis: @escaping FilesystemAnalysis = {
-            await SystemLibraryAnalyzer().analyze()
-        },
-        privateStorageAnalysis: @escaping FilesystemAnalysis = {
-            await PrivateStorageAnalyzer().analyze()
-        },
-        dataVolumeHiddenStorageAnalysis: @escaping FilesystemAnalysis = {
-            await DataVolumeHiddenStorageAnalyzer().analyze()
-        },
-        developerSystemStorageAnalysis: @escaping DeveloperAnalysis = {
-            await DeveloperSystemStorageAnalyzer().analyze()
-        },
-        dockerStorageAnalysis: @escaping DockerAnalysis = {
-            await DockerStorageAnalyzer().analyze()
-        },
-        apfsStorageAnalysis: @escaping APFSAnalysis = {
-            await APFSStorageAnalyzer().analyze()
-        },
-        coverageExpansionAnalysis: @escaping CoverageExpansionAnalysis = {
-            await CoverageExpansionAnalyzer().analyze()
-        },
-        coverageDiscovery: @escaping CoverageDiscovery = {
-            await StorageCoverageGapDiscovery().discover()
-        }
+        maxConcurrentAnalyzers: Int = min(max(ProcessInfo.processInfo.activeProcessorCount / 2, 4), 6),
+        userHomeStorageAnalysis: UserHomeAnalysis? = nil,
+        applicationsAnalysis: FilesystemAnalysis? = nil,
+        applicationSupportAnalysis: FilesystemAnalysis? = nil,
+        containersAnalysis: FilesystemAnalysis? = nil,
+        groupContainersAnalysis: FilesystemAnalysis? = nil,
+        systemLibraryAnalysis: FilesystemAnalysis? = nil,
+        privateStorageAnalysis: FilesystemAnalysis? = nil,
+        dataVolumeHiddenStorageAnalysis: FilesystemAnalysis? = nil,
+        developerSystemStorageAnalysis: DeveloperAnalysis? = nil,
+        dockerStorageAnalysis: DockerAnalysis? = nil,
+        apfsStorageAnalysis: APFSAnalysis? = nil,
+        coverageExpansionAnalysis: CoverageExpansionAnalysis? = nil,
+        coverageDiscovery: CoverageDiscovery? = nil
     ) {
-        self.maxConcurrentAnalyzers = min(max(maxConcurrentAnalyzers, 1), 3)
+        self.maxConcurrentAnalyzers = min(max(maxConcurrentAnalyzers, 1), 8)
+        self.userHomeStorageAnalysis = userHomeStorageAnalysis
+        self.applicationsAnalysis = applicationsAnalysis
         self.applicationSupportAnalysis = applicationSupportAnalysis
         self.containersAnalysis = containersAnalysis
         self.groupContainersAnalysis = groupContainersAnalysis
@@ -75,7 +55,6 @@ struct StorageAnalysisCoordinator: Sendable {
         self.developerSystemStorageAnalysis = developerSystemStorageAnalysis
         self.dockerStorageAnalysis = dockerStorageAnalysis
         self.apfsStorageAnalysis = apfsStorageAnalysis
-        self.userHomeStorageAnalysis = userHomeStorageAnalysis
         self.coverageExpansionAnalysis = coverageExpansionAnalysis
         self.coverageDiscovery = coverageDiscovery
     }
@@ -84,14 +63,20 @@ struct StorageAnalysisCoordinator: Sendable {
     /// task group to avoid launching every disk-intensive tree scan at once.
     func analyze(progress progressHandler: ProgressHandler? = nil) async -> StorageReconciliationReport {
         let startedAt = Date()
-        let operations = makeOperations()
+        let runCache = StorageAnalysisCache()
+        let operations = makeOperations(cache: runCache)
+        let discoveryStart = CFAbsoluteTimeGetCurrent()
         let discoveryTask = Task(priority: .utility) {
-            await coverageDiscovery()
+            if let custom = coverageDiscovery {
+                return await custom()
+            }
+            return await StorageCoverageGapDiscovery().discover()
         }
         var outputs: [StorageAnalyzerStage: StageOutput] = [:]
         var failures: [StorageAnalyzerStage: String] = [:]
         var completedStages: Set<StorageAnalyzerStage> = []
         var runningStages: Set<StorageAnalyzerStage> = []
+        var stageDurations: [StorageAnalyzerStage: Double] = [:]
 
         await progressHandler?(StorageAnalysisProgress(
             totalStages: operations.count,
@@ -105,7 +90,7 @@ struct StorageAnalysisCoordinator: Sendable {
                 let initialCount = min(maxConcurrentAnalyzers, operations.count)
                 for operation in operations.prefix(initialCount) {
                     runningStages.insert(operation.stage)
-                    group.addTask { await Self.execute(operation) }
+                    group.addTask { await Self.execute(operation, cache: runCache) }
                 }
 
                 await progressHandler?(Self.progress(
@@ -119,6 +104,7 @@ struct StorageAnalysisCoordinator: Sendable {
                 while let execution = await group.next() {
                     runningStages.remove(execution.stage)
                     completedStages.insert(execution.stage)
+                    stageDurations[execution.stage] = execution.duration
 
                     switch execution.result {
                     case let .success(output):
@@ -135,7 +121,7 @@ struct StorageAnalysisCoordinator: Sendable {
                         let operation = operations[nextIndex]
                         nextIndex += 1
                         runningStages.insert(operation.stage)
-                        group.addTask { await Self.execute(operation) }
+                        group.addTask { await Self.execute(operation, cache: runCache) }
                     }
 
                     await progressHandler?(Self.progress(
@@ -152,6 +138,7 @@ struct StorageAnalysisCoordinator: Sendable {
             discoveryTask.cancel()
         }
         let discovery = await discoveryTask.value
+        let discoveryDuration = CFAbsoluteTimeGetCurrent() - discoveryStart
 
         let completedAt = Date()
         let report = await Self.reconcile(
@@ -165,6 +152,18 @@ struct StorageAnalysisCoordinator: Sendable {
             totalStageCount: operations.count
         )
         await progressHandler?(report.progress)
+
+        #if DEBUG
+        let cacheMetrics = runCache.metrics
+        Self.emitDebugPerformanceReport(
+            report: report,
+            stageDurations: stageDurations,
+            discoveryDuration: discoveryDuration,
+            totalDuration: max(completedAt.timeIntervalSince(startedAt), 0),
+            cacheMetrics: cacheMetrics
+        )
+        #endif
+
         return report
     }
 }
@@ -173,6 +172,8 @@ struct StorageAnalysisCoordinator: Sendable {
 
 private extension StorageAnalysisCoordinator {
     enum StageOutput: Sendable {
+        case userHomeStorage(UserHomeStorageReport)
+        case applications(StorageAnalysisResult)
         case applicationSupport(StorageAnalysisResult)
         case containers(StorageAnalysisResult)
         case groupContainers(StorageAnalysisResult)
@@ -182,7 +183,6 @@ private extension StorageAnalysisCoordinator {
         case developerSystemStorage(DeveloperSystemStorageReport)
         case dockerStorage(DockerStorageReport)
         case apfsStorage(APFSStorageReport)
-        case userHomeStorage(UserHomeStorageReport)
         case coverageExpansion(StorageCoverageExpansionReport)
     }
 
@@ -195,6 +195,7 @@ private extension StorageAnalysisCoordinator {
     struct StageExecution: Sendable {
         let stage: StorageAnalyzerStage
         let result: StageExecutionResult
+        let duration: Double
     }
 
     struct StageOperation: Sendable {
@@ -202,60 +203,131 @@ private extension StorageAnalysisCoordinator {
         let operation: @Sendable () async throws -> StageOutput
     }
 
-    func makeOperations() -> [StageOperation] {
-        [
+    func makeOperations(cache: StorageAnalysisCache) -> [StageOperation] {
+        let scanner = FileTreeScanner(cache: cache)
+        return [
             StageOperation(stage: .apfsVolume) {
-                .apfsStorage(try await apfsStorageAnalysis())
-            },
-            StageOperation(stage: .userHomeStorage) {
-                .userHomeStorage(try await userHomeStorageAnalysis())
-            },
-            StageOperation(stage: .applicationSupport) {
-                .applicationSupport(try await applicationSupportAnalysis())
+                if let custom = apfsStorageAnalysis {
+                    return .apfsStorage(try await custom())
+                }
+                return .apfsStorage(await APFSStorageAnalyzer().analyze())
             },
             StageOperation(stage: .containers) {
-                .containers(try await containersAnalysis())
+                if let custom = containersAnalysis {
+                    return .containers(try await custom())
+                }
+                return .containers(await ContainersAnalyzer(scanner: scanner, cache: cache).analyze())
             },
             StageOperation(stage: .groupContainers) {
-                .groupContainers(try await groupContainersAnalysis())
+                if let custom = groupContainersAnalysis {
+                    return .groupContainers(try await custom())
+                }
+                return .groupContainers(await GroupContainersAnalyzer(scanner: scanner, cache: cache).analyze())
+            },
+            StageOperation(stage: .applicationSupport) {
+                if let custom = applicationSupportAnalysis {
+                    return .applicationSupport(try await custom())
+                }
+                return .applicationSupport(await ApplicationSupportAnalyzer(scanner: scanner, cache: cache).analyze())
+            },
+            StageOperation(stage: .applications) {
+                if let custom = applicationsAnalysis {
+                    return .applications(try await custom())
+                }
+                return .applications(await ApplicationsStorageAnalyzer(scanner: scanner, cache: cache).analyze())
             },
             StageOperation(stage: .systemLibrary) {
-                .systemLibrary(try await systemLibraryAnalysis())
+                if let custom = systemLibraryAnalysis {
+                    return .systemLibrary(try await custom())
+                }
+                return .systemLibrary(await SystemLibraryAnalyzer(scanner: scanner, cache: cache).analyze())
+            },
+            StageOperation(stage: .userHomeStorage) {
+                if let custom = userHomeStorageAnalysis {
+                    return .userHomeStorage(try await custom())
+                }
+                return .userHomeStorage(await UserHomeStorageAnalyzer(scanner: scanner).analyze())
             },
             StageOperation(stage: .privateStorage) {
-                .privateStorage(try await privateStorageAnalysis())
+                if let custom = privateStorageAnalysis {
+                    return .privateStorage(try await custom())
+                }
+                return .privateStorage(await PrivateStorageAnalyzer(scanner: scanner, cache: cache).analyze())
             },
             StageOperation(stage: .dataVolumeHiddenStorage) {
-                .dataVolumeHiddenStorage(try await dataVolumeHiddenStorageAnalysis())
+                if let custom = dataVolumeHiddenStorageAnalysis {
+                    return .dataVolumeHiddenStorage(try await custom())
+                }
+                return .dataVolumeHiddenStorage(await DataVolumeHiddenStorageAnalyzer(scanner: scanner).analyze())
             },
             StageOperation(stage: .developerSystemStorage) {
-                .developerSystemStorage(try await developerSystemStorageAnalysis())
+                if let custom = developerSystemStorageAnalysis {
+                    return .developerSystemStorage(try await custom())
+                }
+                return .developerSystemStorage(await DeveloperSystemStorageAnalyzer(scanner: scanner, cache: cache).analyze())
             },
             StageOperation(stage: .dockerStorage) {
-                .dockerStorage(try await dockerStorageAnalysis())
+                if let custom = dockerStorageAnalysis {
+                    return .dockerStorage(try await custom())
+                }
+                return .dockerStorage(await DockerStorageAnalyzer(scanner: scanner, cache: cache).analyze())
             },
             StageOperation(stage: .coverageExpansion) {
-                .coverageExpansion(try await coverageExpansionAnalysis())
+                if let custom = coverageExpansionAnalysis {
+                    return .coverageExpansion(try await custom())
+                }
+                return .coverageExpansion(await CoverageExpansionAnalyzer(scanner: scanner, cache: cache).analyze())
             },
         ]
     }
 
-    static func execute(_ operation: StageOperation) async -> StageExecution {
+    static func execute(_ operation: StageOperation, cache: StorageAnalysisCache) async -> StageExecution {
         guard !Task.isCancelled else {
-            return StageExecution(stage: operation.stage, result: .cancelled)
+            return StageExecution(stage: operation.stage, result: .cancelled, duration: 0)
         }
+        let startTime = CFAbsoluteTimeGetCurrent()
         do {
             let output = try await operation.operation()
+            let duration = CFAbsoluteTimeGetCurrent() - startTime
+            if !Task.isCancelled {
+                switch output {
+                case let .applications(res),
+                     let .applicationSupport(res),
+                     let .containers(res),
+                     let .groupContainers(res),
+                     let .systemLibrary(res),
+                     let .privateStorage(res),
+                     let .dataVolumeHiddenStorage(res):
+                    cache.store(res, isFullSubtree: true)
+                case let .developerSystemStorage(rep):
+                    cache.store(rep.opt.result, isFullSubtree: true)
+                    cache.store(rep.usrLocal.result, isFullSubtree: true)
+                case let .dockerStorage(rep):
+                    for loc in rep.hostFootprint.locations {
+                        cache.store(loc, isFullSubtree: true)
+                    }
+                case let .coverageExpansion(rep):
+                    for res in rep.treeResults {
+                        cache.store(res, isFullSubtree: true)
+                    }
+                case .userHomeStorage, .apfsStorage:
+                    break
+                }
+            }
             return StageExecution(
                 stage: operation.stage,
-                result: Task.isCancelled ? .cancelled : .success(output)
+                result: Task.isCancelled ? .cancelled : .success(output),
+                duration: duration
             )
         } catch is CancellationError {
-            return StageExecution(stage: operation.stage, result: .cancelled)
+            let duration = CFAbsoluteTimeGetCurrent() - startTime
+            return StageExecution(stage: operation.stage, result: .cancelled, duration: duration)
         } catch {
+            let duration = CFAbsoluteTimeGetCurrent() - startTime
             return StageExecution(
                 stage: operation.stage,
-                result: .failure(String(describing: error))
+                result: .failure(String(describing: error)),
+                duration: duration
             )
         }
     }
@@ -431,7 +503,7 @@ private extension StorageAnalysisCoordinator {
 
         let attribution = await StorageAttributionAnalyzer().analyze(reconciliationReport: initialReport)
 
-        return StorageReconciliationReport(
+        let intermediateReport = StorageReconciliationReport(
             totalCapacityBytes: initialReport.totalCapacityBytes,
             usedCapacityBytes: initialReport.usedCapacityBytes,
             availableCapacityBytes: initialReport.availableCapacityBytes,
@@ -449,11 +521,43 @@ private extension StorageAnalysisCoordinator {
             analyzerResults: initialReport.analyzerResults,
             coverageDiagnostic: initialReport.coverageDiagnostic,
             attributionReport: attribution,
+            physicalReconciliation: nil,
             startedAt: initialReport.startedAt,
             completedAt: initialReport.completedAt,
             duration: initialReport.duration,
             progress: initialReport.progress,
             wasCancelled: initialReport.wasCancelled
+        )
+
+        let physicalReconciliation = await APFSPhysicalReconciliationAnalyzer().analyze(reconciliationReport: intermediateReport)
+
+        var finalResults = intermediateReport.analyzerResults
+        finalResults.physicalReconciliation = physicalReconciliation
+
+        return StorageReconciliationReport(
+            totalCapacityBytes: intermediateReport.totalCapacityBytes,
+            usedCapacityBytes: intermediateReport.usedCapacityBytes,
+            availableCapacityBytes: intermediateReport.availableCapacityBytes,
+            purgeableEstimateBytes: intermediateReport.purgeableEstimateBytes,
+            explainedAllocatedBytes: intermediateReport.explainedAllocatedBytes,
+            unexplainedBytes: intermediateReport.unexplainedBytes,
+            inaccessibleKnownLowerBoundBytes: intermediateReport.inaccessibleKnownLowerBoundBytes,
+            unreadablePathCount: intermediateReport.unreadablePathCount,
+            incompleteCoverage: intermediateReport.incompleteCoverage,
+            coverageStatus: intermediateReport.coverageStatus,
+            canonicalRootCoverage: intermediateReport.canonicalRootCoverage,
+            filesystemContributions: intermediateReport.filesystemContributions,
+            hardLinkAccountingStatus: intermediateReport.hardLinkAccountingStatus,
+            analysisIssues: intermediateReport.analysisIssues,
+            analyzerResults: finalResults,
+            coverageDiagnostic: intermediateReport.coverageDiagnostic,
+            attributionReport: attribution,
+            physicalReconciliation: physicalReconciliation,
+            startedAt: intermediateReport.startedAt,
+            completedAt: intermediateReport.completedAt,
+            duration: intermediateReport.duration,
+            progress: intermediateReport.progress,
+            wasCancelled: intermediateReport.wasCancelled
         )
     }
 
@@ -462,6 +566,7 @@ private extension StorageAnalysisCoordinator {
     ) -> StorageAnalyzerResults {
         var results = StorageAnalyzerResults(
             userHomeStorage: nil,
+            applications: nil,
             applicationSupport: nil,
             containers: nil,
             groupContainers: nil,
@@ -471,11 +576,13 @@ private extension StorageAnalysisCoordinator {
             developerSystemStorage: nil,
             dockerStorage: nil,
             apfsStorage: nil,
-            coverageExpansion: nil
+            coverageExpansion: nil,
+            physicalReconciliation: nil
         )
         for output in outputs.values {
             switch output {
             case let .userHomeStorage(value): results.userHomeStorage = value
+            case let .applications(value): results.applications = value
             case let .applicationSupport(value): results.applicationSupport = value
             case let .containers(value): results.containers = value
             case let .groupContainers(value): results.groupContainers = value
@@ -506,6 +613,7 @@ private extension StorageAnalysisCoordinator {
                 ))
             }
         }
+        append(results.applications, source: .applications, to: &candidates)
         append(results.applicationSupport, source: .applicationSupport, to: &candidates)
         append(results.containers, source: .containers, to: &candidates)
         append(results.groupContainers, source: .groupContainers, to: &candidates)
@@ -528,7 +636,7 @@ private extension StorageAnalysisCoordinator {
         }
 
         if let expansion = results.coverageExpansion {
-            for candidate in expansion.candidates where candidate.status == .measured && candidate.contributesToExplainedBytes {
+            for candidate in expansion.candidates where candidate.status.isMeasuredOrPartial && candidate.contributesToExplainedBytes {
                 candidates.append(Candidate(
                     source: .additionalCoverageGap,
                     path: candidate.originalPath,
@@ -690,6 +798,13 @@ private extension StorageAnalysisCoordinator {
         coverage.append(coverageForUserHome(
             results.userHomeStorage,
             failed: failures[.userHomeStorage] != nil,
+            cancelled: cancelled
+        ))
+        coverage.append(coverageForResult(
+            results.applications,
+            root: .applications,
+            fallbackPath: ApplicationsStorageAnalyzer.defaultApplicationsURL.path,
+            failed: failures[.applications] != nil,
             cancelled: cancelled
         ))
         coverage.append(coverageForResult(
@@ -945,12 +1060,12 @@ private extension StorageAnalysisCoordinator {
     }
 
     static func candidateOwnershipSort(_ left: Candidate, _ right: Candidate) -> Bool {
-        let leftIsUserHome = left.source == .userHomeVisibleStorage
-        let rightIsUserHome = right.source == .userHomeVisibleStorage
-        if leftIsUserHome != rightIsUserHome { return !leftIsUserHome }
         let leftIsCoverage = left.source == .additionalCoverageGap
         let rightIsCoverage = right.source == .additionalCoverageGap
         if leftIsCoverage != rightIsCoverage { return !leftIsCoverage }
+        let leftIsUserHome = left.source == .userHomeVisibleStorage
+        let rightIsUserHome = right.source == .userHomeVisibleStorage
+        if leftIsUserHome != rightIsUserHome { return !leftIsUserHome }
         let leftPath = normalize(left.path)
         let rightPath = normalize(right.path)
         let leftDepth = leftPath.split(separator: "/").count
@@ -977,6 +1092,7 @@ private extension StorageAnalysisCoordinator {
     static func accountingSource(for root: StorageCanonicalRoot) -> StorageAccountingSource {
         switch root {
         case .userHomeVisibleStorage: return .userHomeVisibleStorage
+        case .applications: return .applications
         case .applicationSupport: return .applicationSupport
         case .containers: return .containers
         case .groupContainers: return .groupContainers
@@ -992,6 +1108,7 @@ private extension StorageAnalysisCoordinator {
     static func stage(for source: StorageAccountingSource) -> StorageAnalyzerStage {
         switch source {
         case .userHomeVisibleStorage: return .userHomeStorage
+        case .applications: return .applications
         case .applicationSupport: return .applicationSupport
         case .containers: return .containers
         case .groupContainers: return .groupContainers
@@ -1006,6 +1123,7 @@ private extension StorageAnalysisCoordinator {
 
     static func resultsContainCancellation(_ results: StorageAnalyzerResults) -> Bool {
         results.userHomeStorage?.wasCancelled == true
+            || results.applications?.wasCancelled == true
             || results.applicationSupport?.wasCancelled == true
             || results.containers?.wasCancelled == true
             || results.groupContainers?.wasCancelled == true
@@ -1034,6 +1152,110 @@ private extension StorageAnalysisCoordinator {
         let (value, overflow) = left.addingReportingOverflow(right)
         return overflow ? Int64.max : value
     }
+
+    #if DEBUG
+    static func emitDebugPerformanceReport(
+        report: StorageReconciliationReport,
+        stageDurations: [StorageAnalyzerStage: Double],
+        discoveryDuration: Double,
+        totalDuration: Double,
+        cacheMetrics: StorageAnalysisCacheMetrics? = nil
+    ) {
+        var stageRecords: [StagePerformanceRecord] = []
+        let results = report.analyzerResults
+
+        func record(stage: StorageAnalyzerStage, name: String, nodes: [StorageNode]?, note: String? = nil) {
+            let dur = stageDurations[stage] ?? 0
+            let metrics = nodes.map { StorageScanMetrics.compute(from: $0) }
+            stageRecords.append(StagePerformanceRecord(
+                stageName: name,
+                durationSeconds: dur,
+                metrics: metrics,
+                customNote: note
+            ))
+        }
+
+        record(stage: .userHomeStorage, name: "User Files", nodes: results.userHomeStorage?.roots.map(\.node))
+        record(stage: .applications, name: "Applications", nodes: results.applications.map { [$0.root] })
+        record(stage: .applicationSupport, name: "Application Support", nodes: results.applicationSupport.map { [$0.root] })
+        record(stage: .containers, name: "Containers", nodes: results.containers.map { [$0.root] })
+        record(stage: .groupContainers, name: "Group Containers", nodes: results.groupContainers.map { [$0.root] })
+        record(stage: .systemLibrary, name: "System Library", nodes: results.systemLibrary.map { [$0.root] })
+        record(stage: .privateStorage, name: "Private / System State", nodes: results.privateStorage.map { [$0.root] })
+        record(stage: .dataVolumeHiddenStorage, name: "Hidden Data-Volume Storage", nodes: results.dataVolumeHiddenStorage.map { [$0.root] })
+        record(
+            stage: .developerSystemStorage,
+            name: "Developer & Third-Party",
+            nodes: results.developerSystemStorage.map { [$0.opt.result.root, $0.usrLocal.result.root] }
+        )
+        record(
+            stage: .dockerStorage,
+            name: "Docker Host Storage",
+            nodes: results.dockerStorage?.hostFootprint.locations.map(\.root)
+        )
+        record(
+            stage: .coverageExpansion,
+            name: "Coverage Expansion",
+            nodes: results.coverageExpansion?.treeResults.map(\.root),
+            note: results.coverageExpansion.map { "\($0.candidates.count) discovered, \($0.measuredCandidateCount) roots scanned" }
+        )
+        record(stage: .apfsVolume, name: "APFS Volume Analysis", nodes: nil)
+
+        stageRecords.append(StagePerformanceRecord(
+            stageName: "Coverage Discovery",
+            durationSeconds: discoveryDuration,
+            metrics: nil,
+            customNote: "\(report.coverageDiagnostic.coverageGaps.count) gaps discovered"
+        ))
+
+        let duplicates = StorageAnalysisPerformanceDiagnostics.analyzeDuplicates(
+            results: results,
+            expansionReport: results.coverageExpansion
+        )
+
+        var allScannedRoots: [StorageNode] = []
+        if let userHome = results.userHomeStorage {
+            allScannedRoots.append(contentsOf: userHome.roots.map(\.node))
+        }
+        if let apps = results.applications {
+            allScannedRoots.append(apps.root)
+        }
+        if let appSupport = results.applicationSupport {
+            allScannedRoots.append(appSupport.root)
+        }
+        if let containers = results.containers {
+            allScannedRoots.append(containers.root)
+        }
+        if let groupContainers = results.groupContainers {
+            allScannedRoots.append(groupContainers.root)
+        }
+        if let sysLib = results.systemLibrary {
+            allScannedRoots.append(sysLib.root)
+        }
+        if let priv = results.privateStorage {
+            allScannedRoots.append(priv.root)
+        }
+        if let dev = results.developerSystemStorage {
+            allScannedRoots.append(dev.opt.result.root)
+            allScannedRoots.append(dev.usrLocal.result.root)
+        }
+
+        let heaviestSubtrees = StorageAnalysisPerformanceDiagnostics.findHeaviestSubtrees(
+            from: allScannedRoots,
+            limit: 20
+        )
+
+        let perfReport = StorageAnalysisPerformanceReport(
+            totalDurationSeconds: totalDuration,
+            stageRecords: stageRecords,
+            duplicateObservations: duplicates,
+            cacheMetrics: cacheMetrics,
+            heaviestSubtrees: heaviestSubtrees
+        )
+
+        StorageAnalysisPerformanceDiagnostics.printDebugReport(perfReport)
+    }
+    #endif
 }
 
 private extension Array where Element: Hashable {

--- a/PureMac/Services/StorageAnalysisCoordinator.swift
+++ b/PureMac/Services/StorageAnalysisCoordinator.swift
@@ -1,0 +1,1044 @@
+import Foundation
+
+/// Coordinates the existing read-only storage analyzers and reconciles their
+/// results without coupling storage intelligence to cleanup behavior.
+struct StorageAnalysisCoordinator: Sendable {
+    typealias FilesystemAnalysis = @Sendable () async throws -> StorageAnalysisResult
+    typealias DeveloperAnalysis = @Sendable () async throws -> DeveloperSystemStorageReport
+    typealias DockerAnalysis = @Sendable () async throws -> DockerStorageReport
+    typealias APFSAnalysis = @Sendable () async throws -> APFSStorageReport
+    typealias UserHomeAnalysis = @Sendable () async throws -> UserHomeStorageReport
+    typealias CoverageExpansionAnalysis = @Sendable () async throws -> StorageCoverageExpansionReport
+    typealias CoverageDiscovery = @Sendable () async -> StorageCoverageDiscoveryResult
+    typealias ProgressHandler = @Sendable (StorageAnalysisProgress) async -> Void
+
+    private let applicationSupportAnalysis: FilesystemAnalysis
+    private let containersAnalysis: FilesystemAnalysis
+    private let groupContainersAnalysis: FilesystemAnalysis
+    private let systemLibraryAnalysis: FilesystemAnalysis
+    private let privateStorageAnalysis: FilesystemAnalysis
+    private let dataVolumeHiddenStorageAnalysis: FilesystemAnalysis
+    private let developerSystemStorageAnalysis: DeveloperAnalysis
+    private let dockerStorageAnalysis: DockerAnalysis
+    private let apfsStorageAnalysis: APFSAnalysis
+    private let userHomeStorageAnalysis: UserHomeAnalysis
+    private let coverageExpansionAnalysis: CoverageExpansionAnalysis
+    private let coverageDiscovery: CoverageDiscovery
+    private let maxConcurrentAnalyzers: Int
+
+    init(
+        maxConcurrentAnalyzers: Int = 2,
+        userHomeStorageAnalysis: @escaping UserHomeAnalysis = {
+            await UserHomeStorageAnalyzer().analyze()
+        },
+        applicationSupportAnalysis: @escaping FilesystemAnalysis = {
+            await ApplicationSupportAnalyzer().analyze()
+        },
+        containersAnalysis: @escaping FilesystemAnalysis = {
+            await ContainersAnalyzer().analyze()
+        },
+        groupContainersAnalysis: @escaping FilesystemAnalysis = {
+            await GroupContainersAnalyzer().analyze()
+        },
+        systemLibraryAnalysis: @escaping FilesystemAnalysis = {
+            await SystemLibraryAnalyzer().analyze()
+        },
+        privateStorageAnalysis: @escaping FilesystemAnalysis = {
+            await PrivateStorageAnalyzer().analyze()
+        },
+        dataVolumeHiddenStorageAnalysis: @escaping FilesystemAnalysis = {
+            await DataVolumeHiddenStorageAnalyzer().analyze()
+        },
+        developerSystemStorageAnalysis: @escaping DeveloperAnalysis = {
+            await DeveloperSystemStorageAnalyzer().analyze()
+        },
+        dockerStorageAnalysis: @escaping DockerAnalysis = {
+            await DockerStorageAnalyzer().analyze()
+        },
+        apfsStorageAnalysis: @escaping APFSAnalysis = {
+            await APFSStorageAnalyzer().analyze()
+        },
+        coverageExpansionAnalysis: @escaping CoverageExpansionAnalysis = {
+            await CoverageExpansionAnalyzer().analyze()
+        },
+        coverageDiscovery: @escaping CoverageDiscovery = {
+            await StorageCoverageGapDiscovery().discover()
+        }
+    ) {
+        self.maxConcurrentAnalyzers = min(max(maxConcurrentAnalyzers, 1), 3)
+        self.applicationSupportAnalysis = applicationSupportAnalysis
+        self.containersAnalysis = containersAnalysis
+        self.groupContainersAnalysis = groupContainersAnalysis
+        self.systemLibraryAnalysis = systemLibraryAnalysis
+        self.privateStorageAnalysis = privateStorageAnalysis
+        self.dataVolumeHiddenStorageAnalysis = dataVolumeHiddenStorageAnalysis
+        self.developerSystemStorageAnalysis = developerSystemStorageAnalysis
+        self.dockerStorageAnalysis = dockerStorageAnalysis
+        self.apfsStorageAnalysis = apfsStorageAnalysis
+        self.userHomeStorageAnalysis = userHomeStorageAnalysis
+        self.coverageExpansionAnalysis = coverageExpansionAnalysis
+        self.coverageDiscovery = coverageDiscovery
+    }
+
+    /// Runs away from the main actor. Independent stages use a small bounded
+    /// task group to avoid launching every disk-intensive tree scan at once.
+    func analyze(progress progressHandler: ProgressHandler? = nil) async -> StorageReconciliationReport {
+        let startedAt = Date()
+        let operations = makeOperations()
+        let discoveryTask = Task(priority: .utility) {
+            await coverageDiscovery()
+        }
+        var outputs: [StorageAnalyzerStage: StageOutput] = [:]
+        var failures: [StorageAnalyzerStage: String] = [:]
+        var completedStages: Set<StorageAnalyzerStage> = []
+        var runningStages: Set<StorageAnalyzerStage> = []
+
+        await progressHandler?(StorageAnalysisProgress(
+            totalStages: operations.count,
+            completedStages: 0,
+            runningStages: [],
+            state: Task.isCancelled ? .cancelled : .running
+        ))
+
+        if !Task.isCancelled {
+            await withTaskGroup(of: StageExecution.self) { group in
+                let initialCount = min(maxConcurrentAnalyzers, operations.count)
+                for operation in operations.prefix(initialCount) {
+                    runningStages.insert(operation.stage)
+                    group.addTask { await Self.execute(operation) }
+                }
+
+                await progressHandler?(Self.progress(
+                    total: operations.count,
+                    completed: completedStages,
+                    running: runningStages,
+                    state: .running
+                ))
+
+                var nextIndex = initialCount
+                while let execution = await group.next() {
+                    runningStages.remove(execution.stage)
+                    completedStages.insert(execution.stage)
+
+                    switch execution.result {
+                    case let .success(output):
+                        outputs[execution.stage] = output
+                    case let .failure(message):
+                        failures[execution.stage] = message
+                    case .cancelled:
+                        failures[execution.stage] = "Analysis was cancelled."
+                    }
+
+                    if Task.isCancelled {
+                        group.cancelAll()
+                    } else if nextIndex < operations.count {
+                        let operation = operations[nextIndex]
+                        nextIndex += 1
+                        runningStages.insert(operation.stage)
+                        group.addTask { await Self.execute(operation) }
+                    }
+
+                    await progressHandler?(Self.progress(
+                        total: operations.count,
+                        completed: completedStages,
+                        running: runningStages,
+                        state: Task.isCancelled ? .cancelled : .running
+                    ))
+                }
+            }
+        }
+
+        if Task.isCancelled {
+            discoveryTask.cancel()
+        }
+        let discovery = await discoveryTask.value
+
+        let completedAt = Date()
+        let report = await Self.reconcile(
+            outputs: outputs,
+            failures: failures,
+            startedAt: startedAt,
+            completedAt: completedAt,
+            discovery: discovery,
+            coordinatorWasCancelled: Task.isCancelled,
+            completedStageCount: completedStages.count,
+            totalStageCount: operations.count
+        )
+        await progressHandler?(report.progress)
+        return report
+    }
+}
+
+// MARK: - Stage Execution
+
+private extension StorageAnalysisCoordinator {
+    enum StageOutput: Sendable {
+        case applicationSupport(StorageAnalysisResult)
+        case containers(StorageAnalysisResult)
+        case groupContainers(StorageAnalysisResult)
+        case systemLibrary(StorageAnalysisResult)
+        case privateStorage(StorageAnalysisResult)
+        case dataVolumeHiddenStorage(StorageAnalysisResult)
+        case developerSystemStorage(DeveloperSystemStorageReport)
+        case dockerStorage(DockerStorageReport)
+        case apfsStorage(APFSStorageReport)
+        case userHomeStorage(UserHomeStorageReport)
+        case coverageExpansion(StorageCoverageExpansionReport)
+    }
+
+    enum StageExecutionResult: Sendable {
+        case success(StageOutput)
+        case failure(String)
+        case cancelled
+    }
+
+    struct StageExecution: Sendable {
+        let stage: StorageAnalyzerStage
+        let result: StageExecutionResult
+    }
+
+    struct StageOperation: Sendable {
+        let stage: StorageAnalyzerStage
+        let operation: @Sendable () async throws -> StageOutput
+    }
+
+    func makeOperations() -> [StageOperation] {
+        [
+            StageOperation(stage: .apfsVolume) {
+                .apfsStorage(try await apfsStorageAnalysis())
+            },
+            StageOperation(stage: .userHomeStorage) {
+                .userHomeStorage(try await userHomeStorageAnalysis())
+            },
+            StageOperation(stage: .applicationSupport) {
+                .applicationSupport(try await applicationSupportAnalysis())
+            },
+            StageOperation(stage: .containers) {
+                .containers(try await containersAnalysis())
+            },
+            StageOperation(stage: .groupContainers) {
+                .groupContainers(try await groupContainersAnalysis())
+            },
+            StageOperation(stage: .systemLibrary) {
+                .systemLibrary(try await systemLibraryAnalysis())
+            },
+            StageOperation(stage: .privateStorage) {
+                .privateStorage(try await privateStorageAnalysis())
+            },
+            StageOperation(stage: .dataVolumeHiddenStorage) {
+                .dataVolumeHiddenStorage(try await dataVolumeHiddenStorageAnalysis())
+            },
+            StageOperation(stage: .developerSystemStorage) {
+                .developerSystemStorage(try await developerSystemStorageAnalysis())
+            },
+            StageOperation(stage: .dockerStorage) {
+                .dockerStorage(try await dockerStorageAnalysis())
+            },
+            StageOperation(stage: .coverageExpansion) {
+                .coverageExpansion(try await coverageExpansionAnalysis())
+            },
+        ]
+    }
+
+    static func execute(_ operation: StageOperation) async -> StageExecution {
+        guard !Task.isCancelled else {
+            return StageExecution(stage: operation.stage, result: .cancelled)
+        }
+        do {
+            let output = try await operation.operation()
+            return StageExecution(
+                stage: operation.stage,
+                result: Task.isCancelled ? .cancelled : .success(output)
+            )
+        } catch is CancellationError {
+            return StageExecution(stage: operation.stage, result: .cancelled)
+        } catch {
+            return StageExecution(
+                stage: operation.stage,
+                result: .failure(String(describing: error))
+            )
+        }
+    }
+
+    static func progress(
+        total: Int,
+        completed: Set<StorageAnalyzerStage>,
+        running: Set<StorageAnalyzerStage>,
+        state: StorageCoordinatorRunState
+    ) -> StorageAnalysisProgress {
+        StorageAnalysisProgress(
+            totalStages: total,
+            completedStages: completed.count,
+            runningStages: running.sorted(by: stageSort),
+            state: state
+        )
+    }
+
+    static func stageSort(_ left: StorageAnalyzerStage, _ right: StorageAnalyzerStage) -> Bool {
+        stageIndex(left) < stageIndex(right)
+    }
+
+    static func stageIndex(_ stage: StorageAnalyzerStage) -> Int {
+        StorageAnalyzerStage.allCases.firstIndex(of: stage) ?? Int.max
+    }
+}
+
+// MARK: - Reconciliation
+
+private extension StorageAnalysisCoordinator {
+    struct Candidate {
+        let source: StorageAccountingSource
+        let path: String
+        let observedAllocatedBytes: Int64
+    }
+
+    static func reconcile(
+        outputs: [StorageAnalyzerStage: StageOutput],
+        failures: [StorageAnalyzerStage: String],
+        startedAt: Date,
+        completedAt: Date,
+        discovery: StorageCoverageDiscoveryResult,
+        coordinatorWasCancelled: Bool,
+        completedStageCount: Int,
+        totalStageCount: Int
+    ) async -> StorageReconciliationReport {
+        let results = analyzerResults(from: outputs)
+        var issues = normalizedIssues(from: results)
+        issues.append(contentsOf: failures.map { stage, message in
+            StorageReconciliationIssue(
+                kind: message == "Analysis was cancelled." ? .cancelled : .analyzerFailure,
+                stage: stage,
+                path: nil,
+                message: message == "Analysis was cancelled."
+                    ? message
+                    : "The \(stage.rawValue) analyzer failed: \(message)"
+            )
+        })
+
+        var coverage = canonicalCoverage(from: results, failures: failures, cancelled: coordinatorWasCancelled)
+        coverage.sort { rootIndex($0.root) < rootIndex($1.root) }
+
+        var canonicalCandidates = candidates(from: results)
+        canonicalCandidates.sort(by: candidateOwnershipSort)
+        var contributions = assignCanonicalOwnership(
+            canonicalCandidates,
+            developerReport: results.developerSystemStorage,
+            issues: &issues
+        )
+
+        if let docker = results.dockerStorage {
+            contributions.append(contentsOf: assignDockerOwnership(
+                docker.hostFootprint.locations,
+                existing: contributions,
+                issues: &issues
+            ))
+        }
+
+        contributions.sort(by: contributionSort)
+        let explained = contributions
+            .filter { $0.relationship == .canonicalUnique || $0.relationship == .externalSpecializedUnique }
+            .reduce(Int64(0)) { saturatedAdd($0, $1.accountedAllocatedBytes) }
+
+        let capacity = results.apfsStorage?.volume.capacity
+        let used = capacity?.usedCapacity.map { max($0, 0) }
+        let unexplained = used.map { max($0 - min(explained, $0), 0) }
+        if let used, explained > used {
+            issues.append(StorageReconciliationIssue(
+                kind: .accountingAnomaly,
+                stage: nil,
+                path: nil,
+                message: "Explained allocated bytes exceed the volume's reported used capacity; unexplained bytes were clamped to zero."
+            ))
+        }
+
+        issues.append(StorageReconciliationIssue(
+            kind: .crossAnalyzerHardLinkDeduplicationUnavailable,
+            stage: nil,
+            path: nil,
+            message: "Hard links are deduplicated within analyzer scopes, but inode identity is not currently available for global deduplication across independent analyzer trees."
+        ))
+        issues = issues.uniqued().sorted(by: issueSort)
+
+        let resultWasCancelled = coordinatorWasCancelled || resultsContainCancellation(results)
+        let diagnostic = StorageCoverageDiagnosticBuilder().build(
+            analyzerResults: results,
+            canonicalRootCoverage: coverage,
+            filesystemContributions: contributions,
+            analysisIssues: issues,
+            discovery: discovery,
+            unexplainedBytes: unexplained,
+            purgeableEstimateBytes: capacity?.purgeableEstimate.map { max($0, 0) },
+            incompleteCoverage: true,
+            wasCancelled: resultWasCancelled
+        )
+        let permissionIncomplete = diagnostic.permissionDeniedIssueCount > 0
+        let failureIncomplete = !failures.isEmpty
+        let measurementIncomplete = coverage.contains { $0.state == .partiallyCompleted }
+            || diagnostic.measurementIssues.categoryCounts.contains {
+                $0.count > 0 && $0.category != .missingOptionalRoot
+            }
+        let coverageStatus: StorageCoverageStatus
+        if resultWasCancelled {
+            coverageStatus = .partialDueToCancellation
+        } else if failureIncomplete {
+            coverageStatus = .partialDueToAnalyzerFailure
+        } else if permissionIncomplete {
+            coverageStatus = .partialDueToPermissions
+        } else if measurementIncomplete {
+            coverageStatus = .partialDueToMeasurementIssues
+        } else {
+            coverageStatus = .completeForConfiguredRoots
+        }
+
+        let partialSources = Set(coverage.filter {
+            $0.state == .partiallyCompleted || $0.state == .failed
+        }.map { accountingSource(for: $0.root) })
+        let inaccessibleLowerBound = contributions
+            .filter { partialSources.contains($0.source) }
+            .reduce(Int64(0)) { saturatedAdd($0, $1.accountedAllocatedBytes) }
+        let unreadableCount = coverage.reduce(0) { $0 + $1.unreadablePathCount }
+        let finalProgress = StorageAnalysisProgress(
+            totalStages: totalStageCount,
+            completedStages: completedStageCount,
+            runningStages: [],
+            state: resultWasCancelled ? .cancelled : .completed
+        )
+
+        let initialReport = StorageReconciliationReport(
+            totalCapacityBytes: capacity?.totalCapacity.map { max($0, 0) },
+            usedCapacityBytes: used,
+            availableCapacityBytes: capacity?.availableCapacity.map { max($0, 0) },
+            purgeableEstimateBytes: capacity?.purgeableEstimate.map { max($0, 0) },
+            explainedAllocatedBytes: explained,
+            unexplainedBytes: unexplained,
+            inaccessibleKnownLowerBoundBytes: inaccessibleLowerBound,
+            unreadablePathCount: unreadableCount,
+            incompleteCoverage: true,
+            coverageStatus: coverageStatus,
+            canonicalRootCoverage: coverage,
+            filesystemContributions: contributions,
+            hardLinkAccountingStatus: .deduplicatedWithinAnalyzerScopesOnly,
+            analysisIssues: issues,
+            analyzerResults: results,
+            coverageDiagnostic: diagnostic,
+            attributionReport: nil,
+            startedAt: startedAt,
+            completedAt: completedAt,
+            duration: max(completedAt.timeIntervalSince(startedAt), 0),
+            progress: finalProgress,
+            wasCancelled: resultWasCancelled
+        )
+
+        let attribution = await StorageAttributionAnalyzer().analyze(reconciliationReport: initialReport)
+
+        return StorageReconciliationReport(
+            totalCapacityBytes: initialReport.totalCapacityBytes,
+            usedCapacityBytes: initialReport.usedCapacityBytes,
+            availableCapacityBytes: initialReport.availableCapacityBytes,
+            purgeableEstimateBytes: initialReport.purgeableEstimateBytes,
+            explainedAllocatedBytes: initialReport.explainedAllocatedBytes,
+            unexplainedBytes: initialReport.unexplainedBytes,
+            inaccessibleKnownLowerBoundBytes: initialReport.inaccessibleKnownLowerBoundBytes,
+            unreadablePathCount: initialReport.unreadablePathCount,
+            incompleteCoverage: initialReport.incompleteCoverage,
+            coverageStatus: initialReport.coverageStatus,
+            canonicalRootCoverage: initialReport.canonicalRootCoverage,
+            filesystemContributions: initialReport.filesystemContributions,
+            hardLinkAccountingStatus: initialReport.hardLinkAccountingStatus,
+            analysisIssues: initialReport.analysisIssues,
+            analyzerResults: initialReport.analyzerResults,
+            coverageDiagnostic: initialReport.coverageDiagnostic,
+            attributionReport: attribution,
+            startedAt: initialReport.startedAt,
+            completedAt: initialReport.completedAt,
+            duration: initialReport.duration,
+            progress: initialReport.progress,
+            wasCancelled: initialReport.wasCancelled
+        )
+    }
+
+    static func analyzerResults(
+        from outputs: [StorageAnalyzerStage: StageOutput]
+    ) -> StorageAnalyzerResults {
+        var results = StorageAnalyzerResults(
+            userHomeStorage: nil,
+            applicationSupport: nil,
+            containers: nil,
+            groupContainers: nil,
+            systemLibrary: nil,
+            privateStorage: nil,
+            dataVolumeHiddenStorage: nil,
+            developerSystemStorage: nil,
+            dockerStorage: nil,
+            apfsStorage: nil,
+            coverageExpansion: nil
+        )
+        for output in outputs.values {
+            switch output {
+            case let .userHomeStorage(value): results.userHomeStorage = value
+            case let .applicationSupport(value): results.applicationSupport = value
+            case let .containers(value): results.containers = value
+            case let .groupContainers(value): results.groupContainers = value
+            case let .systemLibrary(value): results.systemLibrary = value
+            case let .privateStorage(value): results.privateStorage = value
+            case let .dataVolumeHiddenStorage(value): results.dataVolumeHiddenStorage = value
+            case let .developerSystemStorage(value): results.developerSystemStorage = value
+            case let .dockerStorage(value): results.dockerStorage = value
+            case let .apfsStorage(value): results.apfsStorage = value
+            case let .coverageExpansion(value): results.coverageExpansion = value
+            }
+        }
+        return results
+    }
+}
+
+// MARK: - Canonical Roots
+
+private extension StorageAnalysisCoordinator {
+    static func candidates(from results: StorageAnalyzerResults) -> [Candidate] {
+        var candidates: [Candidate] = []
+        if let userHome = results.userHomeStorage {
+            for root in userHome.roots {
+                candidates.append(Candidate(
+                    source: .userHomeVisibleStorage,
+                    path: root.node.absolutePath,
+                    observedAllocatedBytes: max(root.node.allocatedSize, 0)
+                ))
+            }
+        }
+        append(results.applicationSupport, source: .applicationSupport, to: &candidates)
+        append(results.containers, source: .containers, to: &candidates)
+        append(results.groupContainers, source: .groupContainers, to: &candidates)
+        append(results.systemLibrary, source: .systemLibrary, to: &candidates)
+        append(results.privateStorage, source: .privateStorage, to: &candidates)
+
+        if let hidden = results.dataVolumeHiddenStorage {
+            for child in hidden.root.children {
+                candidates.append(Candidate(
+                    source: .dataVolumeHiddenStorage,
+                    path: child.absolutePath,
+                    observedAllocatedBytes: max(child.allocatedSize, 0)
+                ))
+            }
+        }
+
+        if let developer = results.developerSystemStorage {
+            append(developer.opt.result, source: .opt, to: &candidates)
+            append(developer.usrLocal.result, source: .usrLocal, to: &candidates)
+        }
+
+        if let expansion = results.coverageExpansion {
+            for candidate in expansion.candidates where candidate.status == .measured && candidate.contributesToExplainedBytes {
+                candidates.append(Candidate(
+                    source: .additionalCoverageGap,
+                    path: candidate.originalPath,
+                    observedAllocatedBytes: max(candidate.allocatedBytes ?? 0, 0)
+                ))
+            }
+        }
+        return candidates
+    }
+
+    static func append(
+        _ result: StorageAnalysisResult?,
+        source: StorageAccountingSource,
+        to candidates: inout [Candidate]
+    ) {
+        guard let result else { return }
+        candidates.append(Candidate(
+            source: source,
+            path: result.root.absolutePath,
+            observedAllocatedBytes: max(result.root.allocatedSize, 0)
+        ))
+    }
+
+    static func assignCanonicalOwnership(
+        _ candidates: [Candidate],
+        developerReport: DeveloperSystemStorageReport?,
+        issues: inout [StorageReconciliationIssue]
+    ) -> [StorageFilesystemContribution] {
+        var includedPaths: [String] = []
+        var contributions: [StorageFilesystemContribution] = []
+
+        for candidate in candidates {
+            let normalized = normalize(candidate.path)
+            let owner = includedPaths.first { included in
+                candidate.source == .userHomeVisibleStorage
+                    ? pathsOverlap(included, normalized)
+                    : containsPath(parent: included, child: normalized)
+            }
+            if let owner {
+                let duplicate = owner == normalized
+                contributions.append(StorageFilesystemContribution(
+                    source: candidate.source,
+                    absolutePath: candidate.path,
+                    normalizedPath: normalized,
+                    observedAllocatedBytes: candidate.observedAllocatedBytes,
+                    accountedAllocatedBytes: 0,
+                    relationship: duplicate ? .excludedDuplicatePath : .excludedNestedPath,
+                    owningPath: owner
+                ))
+                issues.append(StorageReconciliationIssue(
+                    kind: duplicate ? .duplicateRootExcluded : .nestedRootExcluded,
+                    stage: stage(for: candidate.source),
+                    path: candidate.path,
+                    message: duplicate
+                        ? "A duplicate canonical accounting root was excluded."
+                        : "A canonical root nested inside \(owner) was retained as metadata but excluded from byte totals."
+                ))
+            } else {
+                includedPaths.append(normalized)
+                contributions.append(StorageFilesystemContribution(
+                    source: candidate.source,
+                    absolutePath: candidate.path,
+                    normalizedPath: normalized,
+                    observedAllocatedBytes: candidate.observedAllocatedBytes,
+                    accountedAllocatedBytes: candidate.observedAllocatedBytes,
+                    relationship: .canonicalUnique,
+                    owningPath: nil
+                ))
+            }
+        }
+
+        if let developerReport {
+            let developerIndices = contributions.indices.filter {
+                contributions[$0].relationship == .canonicalUnique
+                    && (contributions[$0].source == .opt || contributions[$0].source == .usrLocal)
+            }.sorted { contributions[$0].source.rawValue < contributions[$1].source.rawValue }
+
+            if developerIndices.count == 2 {
+                var remaining = max(developerReport.combinedUniqueAllocatedSize, 0)
+                for index in developerIndices {
+                    let contribution = contributions[index]
+                    let assigned = min(contribution.observedAllocatedBytes, remaining)
+                    remaining -= assigned
+                    contributions[index] = StorageFilesystemContribution(
+                        source: contribution.source,
+                        absolutePath: contribution.absolutePath,
+                        normalizedPath: contribution.normalizedPath,
+                        observedAllocatedBytes: contribution.observedAllocatedBytes,
+                        accountedAllocatedBytes: assigned,
+                        relationship: contribution.relationship,
+                        owningPath: contribution.owningPath
+                    )
+                }
+            }
+        }
+        return contributions
+    }
+
+    static func assignDockerOwnership(
+        _ locations: [StorageAnalysisResult],
+        existing: [StorageFilesystemContribution],
+        issues: inout [StorageReconciliationIssue]
+    ) -> [StorageFilesystemContribution] {
+        let owners = existing.filter { $0.relationship == .canonicalUnique }
+        var acceptedDockerPaths: [String] = []
+        var additions: [StorageFilesystemContribution] = []
+
+        for location in locations.sorted(by: { normalize($0.root.absolutePath) < normalize($1.root.absolutePath) }) {
+            let path = location.root.absolutePath
+            let normalized = normalize(path)
+            if let owner = owners.first(where: {
+                pathsOverlap($0.normalizedPath, normalized)
+            }) {
+                additions.append(StorageFilesystemContribution(
+                    source: .dockerHostOutsideCanonicalRoots,
+                    absolutePath: path,
+                    normalizedPath: normalized,
+                    observedAllocatedBytes: max(location.root.allocatedSize, 0),
+                    accountedAllocatedBytes: 0,
+                    relationship: owner.normalizedPath == normalized ? .excludedDuplicatePath : .excludedNestedPath,
+                    owningPath: owner.normalizedPath
+                ))
+            } else if let owner = acceptedDockerPaths.first(where: { pathsOverlap($0, normalized) }) {
+                additions.append(StorageFilesystemContribution(
+                    source: .dockerHostOutsideCanonicalRoots,
+                    absolutePath: path,
+                    normalizedPath: normalized,
+                    observedAllocatedBytes: max(location.root.allocatedSize, 0),
+                    accountedAllocatedBytes: 0,
+                    relationship: owner == normalized ? .excludedDuplicatePath : .excludedNestedPath,
+                    owningPath: owner
+                ))
+            } else {
+                acceptedDockerPaths.append(normalized)
+                additions.append(StorageFilesystemContribution(
+                    source: .dockerHostOutsideCanonicalRoots,
+                    absolutePath: path,
+                    normalizedPath: normalized,
+                    observedAllocatedBytes: max(location.root.allocatedSize, 0),
+                    accountedAllocatedBytes: max(location.root.allocatedSize, 0),
+                    relationship: .externalSpecializedUnique,
+                    owningPath: nil
+                ))
+            }
+        }
+        return additions
+    }
+}
+
+// MARK: - Coverage and Issues
+
+private extension StorageAnalysisCoordinator {
+    static func canonicalCoverage(
+        from results: StorageAnalyzerResults,
+        failures: [StorageAnalyzerStage: String],
+        cancelled: Bool
+    ) -> [StorageCanonicalRootCoverage] {
+        var coverage: [StorageCanonicalRootCoverage] = []
+        coverage.append(coverageForUserHome(
+            results.userHomeStorage,
+            failed: failures[.userHomeStorage] != nil,
+            cancelled: cancelled
+        ))
+        coverage.append(coverageForResult(
+            results.applicationSupport,
+            root: .applicationSupport,
+            fallbackPath: ApplicationSupportAnalyzer.currentUserApplicationSupportURL.path,
+            failed: failures[.applicationSupport] != nil,
+            cancelled: cancelled
+        ))
+        coverage.append(coverageForResult(
+            results.containers,
+            root: .containers,
+            fallbackPath: ContainersAnalyzer.currentUserContainersURL.path,
+            failed: failures[.containers] != nil,
+            cancelled: cancelled
+        ))
+        coverage.append(coverageForResult(
+            results.groupContainers,
+            root: .groupContainers,
+            fallbackPath: GroupContainersAnalyzer.currentUserGroupContainersURL.path,
+            failed: failures[.groupContainers] != nil,
+            cancelled: cancelled
+        ))
+        coverage.append(coverageForResult(
+            results.systemLibrary,
+            root: .systemLibrary,
+            fallbackPath: SystemLibraryAnalyzer.defaultSystemLibraryURL.path,
+            failed: failures[.systemLibrary] != nil,
+            cancelled: cancelled
+        ))
+        coverage.append(coverageForResult(
+            results.privateStorage,
+            root: .privateStorage,
+            fallbackPath: PrivateStorageAnalyzer.defaultPrivateURL.path,
+            failed: failures[.privateStorage] != nil,
+            cancelled: cancelled
+        ))
+        coverage.append(coverageForResult(
+            results.dataVolumeHiddenStorage,
+            root: .dataVolumeHiddenStorage,
+            fallbackPath: DataVolumeHiddenStorageAnalyzer.defaultDataVolumeURL.path,
+            failed: failures[.dataVolumeHiddenStorage] != nil,
+            cancelled: cancelled
+        ))
+
+        if let developer = results.developerSystemStorage {
+            coverage.append(coverageForDeveloperRoot(developer.opt, root: .opt))
+            coverage.append(coverageForDeveloperRoot(developer.usrLocal, root: .usrLocal))
+        } else {
+            let state: StorageCanonicalRootState = cancelled ? .cancelled : failures[.developerSystemStorage] == nil ? .missingOptional : .failed
+            coverage.append(StorageCanonicalRootCoverage(
+                root: .opt,
+                configuredPath: DeveloperSystemStorageAnalyzer.defaultOptURL.path,
+                state: state,
+                knownAllocatedBytes: 0,
+                unreadablePathCount: 0
+            ))
+            coverage.append(StorageCanonicalRootCoverage(
+                root: .usrLocal,
+                configuredPath: DeveloperSystemStorageAnalyzer.defaultUsrLocalURL.path,
+                state: state,
+                knownAllocatedBytes: 0,
+                unreadablePathCount: 0
+            ))
+        }
+
+        if let expansion = results.coverageExpansion {
+            let unreadable = expansion.candidates.filter { $0.status == .inaccessible || $0.status == .failed }.count
+            coverage.append(StorageCanonicalRootCoverage(
+                root: .additionalCoverageGap,
+                configuredPath: "Additional Coverage Gaps",
+                state: expansion.wasCancelled ? .cancelled : (unreadable > 0 ? .partiallyCompleted : .completed),
+                knownAllocatedBytes: expansion.totalNewlyMeasuredBytes,
+                unreadablePathCount: unreadable
+            ))
+        }
+        return coverage
+    }
+
+    static func coverageForUserHome(
+        _ report: UserHomeStorageReport?,
+        failed: Bool,
+        cancelled: Bool
+    ) -> StorageCanonicalRootCoverage {
+        guard let report else {
+            return StorageCanonicalRootCoverage(
+                root: .userHomeVisibleStorage,
+                configuredPath: UserHomeStorageAnalyzer.currentUserHomeURL.path,
+                state: cancelled ? .cancelled : .failed,
+                knownAllocatedBytes: 0,
+                unreadablePathCount: 0
+            )
+        }
+        return StorageCanonicalRootCoverage(
+            root: .userHomeVisibleStorage,
+            configuredPath: report.homeDirectoryPath,
+            state: rootState(report.result, forcedFailure: failed),
+            knownAllocatedBytes: max(report.combinedUniqueAllocatedSize, 0),
+            unreadablePathCount: unreadableCount(in: report.result)
+        )
+    }
+
+    static func coverageForResult(
+        _ result: StorageAnalysisResult?,
+        root: StorageCanonicalRoot,
+        fallbackPath: String,
+        failed: Bool,
+        cancelled: Bool
+    ) -> StorageCanonicalRootCoverage {
+        guard let result else {
+            return StorageCanonicalRootCoverage(
+                root: root,
+                configuredPath: fallbackPath,
+                state: cancelled ? .cancelled : .failed,
+                knownAllocatedBytes: 0,
+                unreadablePathCount: 0
+            )
+        }
+        return StorageCanonicalRootCoverage(
+            root: root,
+            configuredPath: result.root.absolutePath,
+            state: rootState(result, forcedFailure: failed),
+            knownAllocatedBytes: max(result.root.allocatedSize, 0),
+            unreadablePathCount: unreadableCount(in: result)
+        )
+    }
+
+    static func coverageForDeveloperRoot(
+        _ analysis: DeveloperSystemRootAnalysis,
+        root: StorageCanonicalRoot
+    ) -> StorageCanonicalRootCoverage {
+        let state: StorageCanonicalRootState
+        switch analysis.state {
+        case .present: state = .completed
+        case .missing: state = .missingOptional
+        case .inaccessible, .invalid: state = .failed
+        case .partiallyReadable: state = .partiallyCompleted
+        case .cancelled: state = .cancelled
+        }
+        return StorageCanonicalRootCoverage(
+            root: root,
+            configuredPath: analysis.configuredPath,
+            state: state,
+            knownAllocatedBytes: max(analysis.result.root.allocatedSize, 0),
+            unreadablePathCount: unreadableCount(in: analysis.result)
+        )
+    }
+
+    static func rootState(
+        _ result: StorageAnalysisResult,
+        forcedFailure: Bool
+    ) -> StorageCanonicalRootState {
+        if forcedFailure { return .failed }
+        if result.wasCancelled || result.root.accessibility == .cancelled { return .cancelled }
+        switch result.root.accessibility {
+        case .accessible: return .completed
+        case .partiallyAccessible, .skippedDifferentVolume: return .partiallyCompleted
+        case .inaccessible: return .failed
+        case .cancelled: return .cancelled
+        }
+    }
+
+    static func unreadableCount(in result: StorageAnalysisResult) -> Int {
+        Set(result.issues.filter {
+            $0.kind == .permissionDenied
+                || $0.kind == .unreadable
+                || $0.kind == .directoryEnumerationFailed
+                || $0.kind == .metadataUnavailable
+        }.map(\.path)).count
+    }
+
+    static func normalizedIssues(from results: StorageAnalyzerResults) -> [StorageReconciliationIssue] {
+        var issues: [StorageReconciliationIssue] = []
+        appendIssues(results.userHomeStorage?.result, stage: .userHomeStorage, to: &issues)
+        appendIssues(results.applicationSupport, stage: .applicationSupport, to: &issues)
+        appendIssues(results.containers, stage: .containers, to: &issues)
+        appendIssues(results.groupContainers, stage: .groupContainers, to: &issues)
+        appendIssues(results.systemLibrary, stage: .systemLibrary, to: &issues)
+        appendIssues(results.privateStorage, stage: .privateStorage, to: &issues)
+        appendIssues(results.dataVolumeHiddenStorage, stage: .dataVolumeHiddenStorage, to: &issues)
+        if let developer = results.developerSystemStorage {
+            for issue in developer.issues {
+                issues.append(reconciliationIssue(issue, stage: .developerSystemStorage))
+            }
+        }
+        if let docker = results.dockerStorage {
+            for issue in docker.issues {
+                issues.append(StorageReconciliationIssue(
+                    kind: issue.kind == .cancelled ? .cancelled : .analyzerIssue,
+                    stage: .dockerStorage,
+                    path: issue.path,
+                    message: issue.message
+                ))
+            }
+        }
+        if let apfs = results.apfsStorage {
+            for issue in apfs.issues {
+                issues.append(StorageReconciliationIssue(
+                    kind: issue.kind == .cancelled ? .cancelled : .analyzerIssue,
+                    stage: .apfsVolume,
+                    path: nil,
+                    message: issue.message
+                ))
+            }
+        }
+        return issues
+    }
+
+    static func appendIssues(
+        _ result: StorageAnalysisResult?,
+        stage: StorageAnalyzerStage,
+        to issues: inout [StorageReconciliationIssue]
+    ) {
+        guard let result else { return }
+        issues.append(contentsOf: result.issues.map { reconciliationIssue($0, stage: stage) })
+    }
+
+    static func reconciliationIssue(
+        _ issue: StorageScanIssue,
+        stage: StorageAnalyzerStage
+    ) -> StorageReconciliationIssue {
+        let kind: StorageReconciliationIssueKind
+        switch issue.kind {
+        case .permissionDenied, .unreadable, .directoryEnumerationFailed, .metadataUnavailable:
+            kind = .permissionIncomplete
+        case .cancelled:
+            kind = .cancelled
+        default:
+            kind = .analyzerIssue
+        }
+        return StorageReconciliationIssue(
+            kind: kind,
+            stage: stage,
+            path: issue.path,
+            message: issue.message
+        )
+    }
+}
+
+// MARK: - Helpers
+
+private extension StorageAnalysisCoordinator {
+    static func normalize(_ path: String) -> String {
+        StoragePathNormalizer.normalize(path)
+    }
+
+    static func containsPath(parent: String, child: String) -> Bool {
+        StoragePathNormalizer.contains(parent: parent, child: child)
+    }
+
+    static func pathsOverlap(_ left: String, _ right: String) -> Bool {
+        StoragePathNormalizer.pathsOverlap(left, right)
+    }
+
+    static func candidateOwnershipSort(_ left: Candidate, _ right: Candidate) -> Bool {
+        let leftIsUserHome = left.source == .userHomeVisibleStorage
+        let rightIsUserHome = right.source == .userHomeVisibleStorage
+        if leftIsUserHome != rightIsUserHome { return !leftIsUserHome }
+        let leftIsCoverage = left.source == .additionalCoverageGap
+        let rightIsCoverage = right.source == .additionalCoverageGap
+        if leftIsCoverage != rightIsCoverage { return !leftIsCoverage }
+        let leftPath = normalize(left.path)
+        let rightPath = normalize(right.path)
+        let leftDepth = leftPath.split(separator: "/").count
+        let rightDepth = rightPath.split(separator: "/").count
+        if leftDepth != rightDepth { return leftDepth < rightDepth }
+        if leftPath != rightPath { return leftPath < rightPath }
+        return left.source.rawValue < right.source.rawValue
+    }
+
+    static func contributionSort(
+        _ left: StorageFilesystemContribution,
+        _ right: StorageFilesystemContribution
+    ) -> Bool {
+        if left.source.rawValue != right.source.rawValue {
+            return left.source.rawValue < right.source.rawValue
+        }
+        return left.normalizedPath < right.normalizedPath
+    }
+
+    static func rootIndex(_ root: StorageCanonicalRoot) -> Int {
+        StorageCanonicalRoot.allCases.firstIndex(of: root) ?? Int.max
+    }
+
+    static func accountingSource(for root: StorageCanonicalRoot) -> StorageAccountingSource {
+        switch root {
+        case .userHomeVisibleStorage: return .userHomeVisibleStorage
+        case .applicationSupport: return .applicationSupport
+        case .containers: return .containers
+        case .groupContainers: return .groupContainers
+        case .systemLibrary: return .systemLibrary
+        case .privateStorage: return .privateStorage
+        case .dataVolumeHiddenStorage: return .dataVolumeHiddenStorage
+        case .opt: return .opt
+        case .usrLocal: return .usrLocal
+        case .additionalCoverageGap: return .additionalCoverageGap
+        }
+    }
+
+    static func stage(for source: StorageAccountingSource) -> StorageAnalyzerStage {
+        switch source {
+        case .userHomeVisibleStorage: return .userHomeStorage
+        case .applicationSupport: return .applicationSupport
+        case .containers: return .containers
+        case .groupContainers: return .groupContainers
+        case .systemLibrary: return .systemLibrary
+        case .privateStorage: return .privateStorage
+        case .dataVolumeHiddenStorage: return .dataVolumeHiddenStorage
+        case .opt, .usrLocal: return .developerSystemStorage
+        case .dockerHostOutsideCanonicalRoots: return .dockerStorage
+        case .additionalCoverageGap: return .coverageExpansion
+        }
+    }
+
+    static func resultsContainCancellation(_ results: StorageAnalyzerResults) -> Bool {
+        results.userHomeStorage?.wasCancelled == true
+            || results.applicationSupport?.wasCancelled == true
+            || results.containers?.wasCancelled == true
+            || results.groupContainers?.wasCancelled == true
+            || results.systemLibrary?.wasCancelled == true
+            || results.privateStorage?.wasCancelled == true
+            || results.dataVolumeHiddenStorage?.wasCancelled == true
+            || results.developerSystemStorage?.wasCancelled == true
+            || results.dockerStorage?.wasCancelled == true
+            || results.apfsStorage?.wasCancelled == true
+            || results.coverageExpansion?.wasCancelled == true
+    }
+
+    static func issueSort(
+        _ left: StorageReconciliationIssue,
+        _ right: StorageReconciliationIssue
+    ) -> Bool {
+        if left.kind.rawValue != right.kind.rawValue { return left.kind.rawValue < right.kind.rawValue }
+        if left.stage?.rawValue != right.stage?.rawValue {
+            return (left.stage?.rawValue ?? "") < (right.stage?.rawValue ?? "")
+        }
+        if left.path != right.path { return (left.path ?? "") < (right.path ?? "") }
+        return left.message < right.message
+    }
+
+    static func saturatedAdd(_ left: Int64, _ right: Int64) -> Int64 {
+        let (value, overflow) = left.addingReportingOverflow(right)
+        return overflow ? Int64.max : value
+    }
+}
+
+private extension Array where Element: Hashable {
+    func uniqued() -> [Element] {
+        var seen: Set<Element> = []
+        return filter { seen.insert($0).inserted }
+    }
+}

--- a/PureMac/ViewModels/AppState.swift
+++ b/PureMac/ViewModels/AppState.swift
@@ -6,6 +6,7 @@ import AppKit
 // InstalledApp is defined in AppInfoFetcher.swift
 
 enum AppSection: Hashable {
+    case storageIntelligence
     case apps
     case orphans
     case cleaning(CleaningCategory)

--- a/PureMac/ViewModels/StorageIntelligenceState.swift
+++ b/PureMac/ViewModels/StorageIntelligenceState.swift
@@ -1,0 +1,931 @@
+import AppKit
+import Combine
+import Foundation
+
+enum StorageIntelligenceLifecycle: Equatable {
+    case idle
+    case running
+    case completed
+    case cancelled
+    case failed
+}
+
+enum StorageIntelligenceSortOrder: String, CaseIterable, Identifiable, Sendable {
+    case sizeDescending
+    case name
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .sizeDescending: return "Size"
+        case .name: return "Name"
+        }
+    }
+}
+
+enum StorageIntelligenceAction: String, CaseIterable, Sendable {
+    case analyze
+    case cancel
+    case search
+    case sort
+    case navigate
+    case revealInFinder
+    case permissionGuidance
+    case viewDiagnostics
+}
+
+enum StorageIntelligenceCategoryID: String, CaseIterable, Identifiable, Sendable {
+    case userFiles
+    case applicationSupport
+    case containers
+    case groupContainers
+    case systemLibrary
+    case privateSystemState
+    case hiddenData
+    case developerThirdParty
+    case docker
+    case apfs
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .userFiles: return "User Files"
+        case .applicationSupport: return "Application Support"
+        case .containers: return "Containers"
+        case .groupContainers: return "Group Containers"
+        case .systemLibrary: return "System Library"
+        case .privateSystemState: return "Private / System State"
+        case .hiddenData: return "Hidden Data"
+        case .developerThirdParty: return "Developer & Third-Party"
+        case .docker: return "Docker"
+        case .apfs: return "APFS / Snapshots"
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .userFiles: return "Visible files and folders in your home directory."
+        case .applicationSupport: return "Application-owned support files and local data."
+        case .containers: return "Sandboxed application data stored by macOS."
+        case .groupContainers: return "Data shared by related sandboxed applications."
+        case .systemLibrary: return "System-wide application and service data in /Library."
+        case .privateSystemState: return "Logs, databases, temporary state, and virtual memory under /private."
+        case .hiddenData: return "Hidden storage at the top of the writable Data volume."
+        case .developerThirdParty: return "Developer tools and third-party installations under /opt and /usr/local."
+        case .docker: return "Docker files stored on this Mac, with runtime details kept separate."
+        case .apfs: return "Volume capacity and snapshot metadata that is not additive to file totals."
+        }
+    }
+}
+
+struct StorageSummaryPresentation: Equatable, Sendable {
+    let totalCapacityBytes: Int64?
+    let usedBytes: Int64?
+    let freeBytes: Int64?
+    let explainedAllocatedBytes: Int64
+    let unexplainedBytes: Int64?
+    let purgeableEstimateBytes: Int64?
+
+    var usedFraction: Double? {
+        guard let totalCapacityBytes, let usedBytes, totalCapacityBytes > 0 else { return nil }
+        return min(max(Double(usedBytes) / Double(totalCapacityBytes), 0), 1)
+    }
+
+    var explainedFractionOfUsed: Double? {
+        guard let usedBytes, usedBytes > 0 else { return nil }
+        return min(max(Double(explainedAllocatedBytes) / Double(usedBytes), 0), 1)
+    }
+}
+
+struct StorageCoveragePresentation: Equatable, Sendable {
+    let status: StorageCoverageStatus
+    let title: String
+    let detail: String
+    let isPartial: Bool
+    let unreadablePathCount: Int
+    let knownLowerBoundBytes: Int64
+    let unexplainedBytes: Int64?
+    let measurementIssueCount: Int
+    let categoryCounts: [StorageCoverageDiagnosticCategoryCount]
+}
+
+enum StoragePermissionGuidanceKind: Equatable, Sendable {
+    case fullDiskAccessMayHelp
+    case permissionDenialsRemainWithFullDiskAccess
+}
+
+struct StoragePermissionGuidance: Equatable, Sendable {
+    let kind: StoragePermissionGuidanceKind
+    let permissionDeniedCount: Int
+    let message: String
+}
+
+struct StorageCategoryPresentation: Identifiable, Hashable, Sendable {
+    let id: StorageIntelligenceCategoryID
+    /// Unique bytes this category contributes to reconciliation.
+    let allocatedBytes: Int64
+    /// Bytes visible in the analyzer's own tree before cross-analyzer ownership.
+    let observedAllocatedBytes: Int64
+    let roots: [StorageNode]
+    let isFilesystemAdditive: Bool
+    let issueCount: Int
+    let prominentNode: StorageNodePresentation?
+
+    var isOwnedElsewhere: Bool {
+        observedAllocatedBytes > 0 && allocatedBytes == 0 && isFilesystemAdditive
+    }
+}
+
+struct StorageNodePresentation: Identifiable, Hashable, Sendable {
+    let id: String
+    let name: String
+    let absolutePath: String
+    let allocatedSize: Int64
+    let logicalSize: Int64
+    let accessibility: StorageAccessibility
+    let storageCategory: String?
+    let ownerDisplayName: String?
+    let isUnusuallyLarge: Bool
+    let isVirtualDisk: Bool
+    let isSparseVirtualDisk: Bool
+    let hasMaterialLogicalDifference: Bool
+    let hasIncompleteMeasurement: Bool
+    let issueCount: Int
+
+    init(node: StorageNode) {
+        id = node.absolutePath
+        name = node.name
+        absolutePath = node.absolutePath
+        allocatedSize = max(node.allocatedSize, 0)
+        logicalSize = max(node.logicalSize, 0)
+        accessibility = node.accessibility
+        storageCategory = node.metadata.storageCategoryIdentifier
+        ownerDisplayName = node.metadata.owningApplicationName
+        isUnusuallyLarge = node.metadata.isUnusuallyLarge == true
+        isVirtualDisk = Self.virtualDiskExtensions.contains(
+            URL(fileURLWithPath: node.absolutePath).pathExtension.lowercased()
+        )
+        isSparseVirtualDisk = isVirtualDisk && logicalSize > allocatedSize
+        hasMaterialLogicalDifference = Self.materiallyDifferent(
+            logical: logicalSize,
+            allocated: allocatedSize
+        )
+        hasIncompleteMeasurement = node.accessibility != .accessible || !node.scanIssues.isEmpty
+        issueCount = node.scanIssues.count
+    }
+
+    private static let virtualDiskExtensions: Set<String> = [
+        "img", "raw", "qcow2", "vmdk", "sparsebundle",
+    ]
+
+    private static func materiallyDifferent(logical: Int64, allocated: Int64) -> Bool {
+        guard logical != allocated else { return false }
+        let difference = abs(logical - allocated)
+        return difference >= max(1_048_576, max(logical, allocated) / 10)
+    }
+}
+
+struct StorageSearchResult: Identifiable, Hashable, Sendable {
+    let categoryID: StorageIntelligenceCategoryID
+    let node: StorageNodePresentation
+
+    var id: String { node.absolutePath }
+}
+
+struct StorageDockerRuntimeCategoryPresentation: Identifiable, Equatable, Sendable {
+    let category: DockerRuntimeStorageCategory
+    let totalBytes: Int64?
+    let objectCount: Int?
+
+    var id: String { category.rawValue }
+
+    var title: String {
+        switch category {
+        case .images: return "Images"
+        case .containers: return "Containers"
+        case .localVolumes: return "Volumes"
+        case .buildCache: return "Build Cache"
+        }
+    }
+}
+
+struct StorageDockerPresentation: Equatable, Sendable {
+    let localFootprintBytes: Int64
+    let runtimeReportedBytes: Int64?
+    let runtimeLocation: DockerRuntimeLocation
+    let contextName: String?
+    let relationshipMessage: String
+    let runtimeIsNonAdditive: Bool
+    let runtimeCategories: [StorageDockerRuntimeCategoryPresentation]
+}
+
+struct StorageSnapshotPresentation: Identifiable, Equatable, Sendable {
+    let id: String
+    let name: String
+    let type: APFSSnapshotType
+    let creationDate: Date?
+    let sizeBytes: Int64?
+    let sizeIsReliable: Bool
+    let isNonAdditive: Bool
+}
+
+struct StorageAPFSPresentation: Equatable, Sendable {
+    let filesystemType: String?
+    let volumeName: String?
+    let totalCapacityBytes: Int64?
+    let freeBytes: Int64?
+    let purgeableEstimateBytes: Int64?
+    let snapshots: [StorageSnapshotPresentation]
+    let snapshotsAreNonAdditive: Bool
+}
+
+struct StorageAdditionalCoveragePresentation: Equatable, Sendable {
+    let totalNewlyMeasuredBytes: Int64
+    let measuredRegionCount: Int
+    let remainingUnexplainedBytes: Int64?
+    let largestDiscoveredRegions: [StorageCoverageCandidate]
+    let candidates: [StorageCoverageCandidate]
+}
+
+struct StorageAttributionPresentation: Equatable, Sendable {
+    let volumeUsedBytes: Int64?
+    let explainedAllocatedBytes: Int64
+    let unexplainedBytes: Int64?
+    let residualUnattributedBytes: Int64?
+    let dataVolumeRoots: [DataVolumeRootAttribution]
+    let attributionItems: [StorageAttributionItem]
+    let vmFootprintBytes: Int64?
+    let sleepImageBytes: Int64?
+    let snapshotFootprintBytes: Int64?
+    let purgeableEstimateBytes: Int64?
+}
+
+@MainActor
+final class StorageIntelligenceState: ObservableObject {
+    typealias ProgressHandler = @Sendable (StorageAnalysisProgress) async -> Void
+    typealias AnalysisRunner = @Sendable (_ progress: @escaping ProgressHandler) async throws -> StorageReconciliationReport
+    typealias PathExists = @Sendable (_ path: String) -> Bool
+    typealias RevealHandler = @MainActor @Sendable (_ path: String) -> Void
+
+    @Published private(set) var lifecycle: StorageIntelligenceLifecycle = .idle
+    @Published private(set) var progress: StorageAnalysisProgress?
+    @Published private(set) var report: StorageReconciliationReport?
+    @Published private(set) var summary: StorageSummaryPresentation?
+    @Published private(set) var coverage: StorageCoveragePresentation?
+    @Published private(set) var additionalCoverage: StorageAdditionalCoveragePresentation?
+    @Published private(set) var attributionPresentation: StorageAttributionPresentation?
+    @Published private(set) var coverageDiagnostic: StorageCoverageDiagnostic?
+    @Published private(set) var categories: [StorageCategoryPresentation] = []
+    @Published private(set) var dockerPresentation: StorageDockerPresentation?
+    @Published private(set) var apfsPresentation: StorageAPFSPresentation?
+    @Published private(set) var searchText = ""
+    @Published private(set) var searchResults: [StorageSearchResult] = []
+    @Published private(set) var sortOrder: StorageIntelligenceSortOrder = .sizeDescending
+    @Published var selectedCategory: StorageIntelligenceCategoryID?
+    @Published var selectedNodePath: String?
+    @Published var isShowingDiagnostics = false
+    @Published private(set) var errorMessage: String?
+
+    let availableActions: Set<StorageIntelligenceAction> = Set(StorageIntelligenceAction.allCases)
+
+    var isRunning: Bool { lifecycle == .running }
+    var canAnalyze: Bool { !isRunning }
+    var canCancel: Bool { isRunning }
+    var hasCompletedReport: Bool { report != nil }
+
+    private let analysisRunner: AnalysisRunner
+    private let pathExists: PathExists
+    private let revealHandler: RevealHandler
+    private var analysisTask: Task<Void, Never>?
+    private var preparationTask: Task<Void, Never>?
+    private var searchTask: Task<Void, Never>?
+    private var searchIndex: [IndexedNode] = []
+    private var scanIdentifier = UUID()
+    private var presentationIdentifier = UUID()
+    private var searchIdentifier = UUID()
+
+    init(
+        analysisRunner: @escaping AnalysisRunner = { progress in
+            await StorageAnalysisCoordinator().analyze(progress: progress)
+        },
+        pathExists: @escaping PathExists = { FileManager.default.fileExists(atPath: $0) },
+        revealHandler: @escaping RevealHandler = { path in
+            NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
+        }
+    ) {
+        self.analysisRunner = analysisRunner
+        self.pathExists = pathExists
+        self.revealHandler = revealHandler
+    }
+
+    func analyze() {
+        guard !isRunning else { return }
+        analysisTask?.cancel()
+        preparationTask?.cancel()
+        searchTask?.cancel()
+
+        let identifier = UUID()
+        scanIdentifier = identifier
+        lifecycle = .running
+        errorMessage = nil
+        progress = StorageAnalysisProgress(
+            totalStages: StorageAnalyzerStage.allCases.count,
+            completedStages: 0,
+            runningStages: [],
+            state: .running
+        )
+        let runner = analysisRunner
+
+        analysisTask = Task { [weak self] in
+            do {
+                let result = try await runner { update in
+                    await MainActor.run {
+                        guard let self,
+                              self.scanIdentifier == identifier,
+                              self.lifecycle == .running else { return }
+                        self.progress = update
+                    }
+                }
+                let callerWasCancelled = Task.isCancelled
+                let prepared = await Task.detached(priority: .utility) {
+                    Self.prepare(report: result, sortOrder: .sizeDescending)
+                }.value
+
+                guard let self, self.scanIdentifier == identifier else { return }
+                self.apply(result, prepared: prepared)
+                self.lifecycle = result.wasCancelled || callerWasCancelled ? .cancelled : .completed
+                self.progress = result.progress
+            } catch is CancellationError {
+                guard let self, self.scanIdentifier == identifier else { return }
+                self.lifecycle = .cancelled
+                self.progress = Self.cancelledProgress(from: self.progress)
+            } catch {
+                guard let self, self.scanIdentifier == identifier else { return }
+                self.lifecycle = .failed
+                self.progress = nil
+                self.errorMessage = "Storage analysis could not finish. \(error.localizedDescription)"
+            }
+        }
+    }
+
+    func cancel() {
+        guard isRunning else { return }
+        analysisTask?.cancel()
+        lifecycle = .cancelled
+        progress = Self.cancelledProgress(from: progress)
+    }
+
+    func updateSortOrder(_ order: StorageIntelligenceSortOrder) {
+        guard sortOrder != order else { return }
+        sortOrder = order
+        guard let report else {
+            sortSearchResults()
+            return
+        }
+
+        preparationTask?.cancel()
+        let identifier = UUID()
+        presentationIdentifier = identifier
+        preparationTask = Task { [weak self] in
+            let prepared = await Task.detached(priority: .utility) {
+                Self.prepare(report: report, sortOrder: order)
+            }.value
+            guard let self, self.presentationIdentifier == identifier else { return }
+            self.applyPresentation(prepared)
+        }
+    }
+
+    func updateSearch(_ text: String) {
+        searchText = text
+        scheduleSearch()
+    }
+
+    func selectCategory(_ category: StorageIntelligenceCategoryID) {
+        selectedCategory = category
+        selectedNodePath = nil
+    }
+
+    func selectNode(_ node: StorageNodePresentation) {
+        selectedNodePath = node.absolutePath
+    }
+
+    func showDiagnostics() {
+        guard coverageDiagnostic != nil else { return }
+        isShowingDiagnostics = true
+    }
+
+    func dismissDiagnostics() {
+        isShowingDiagnostics = false
+    }
+
+    func permissionGuidance(fullDiskAccessGranted: Bool) -> StoragePermissionGuidance? {
+        let count = coverageDiagnostic?.permissionDeniedIssueCount ?? 0
+        guard count > 0 else { return nil }
+        if fullDiskAccessGranted {
+            return StoragePermissionGuidance(
+                kind: .permissionDenialsRemainWithFullDiskAccess,
+                permissionDeniedCount: count,
+                message: "macOS denied access to \(count) location\(count == 1 ? "" : "s") even though Full Disk Access is currently detected."
+            )
+        }
+        return StoragePermissionGuidance(
+            kind: .fullDiskAccessMayHelp,
+            permissionDeniedCount: count,
+            message: "macOS denied access to \(count) location\(count == 1 ? "" : "s"). Full Disk Access may improve coverage."
+        )
+    }
+
+    func canRevealInFinder(_ node: StorageNodePresentation) -> Bool {
+        node.accessibility != .skippedDifferentVolume && pathExists(node.absolutePath)
+    }
+
+    func revealInFinder(_ node: StorageNodePresentation) {
+        guard canRevealInFinder(node) else { return }
+        revealHandler(node.absolutePath)
+    }
+
+    func waitForAnalysis() async {
+        await analysisTask?.value
+    }
+
+    func waitForPresentation() async {
+        await preparationTask?.value
+    }
+
+    func waitForSearch() async {
+        await searchTask?.value
+    }
+}
+
+private extension StorageIntelligenceState {
+    struct IndexedNode: Sendable {
+        let result: StorageSearchResult
+        let searchableText: String
+    }
+
+    struct PreparedPresentation: Sendable {
+        let summary: StorageSummaryPresentation
+        let coverage: StorageCoveragePresentation
+        let additionalCoverage: StorageAdditionalCoveragePresentation?
+        let attribution: StorageAttributionPresentation?
+        let categories: [StorageCategoryPresentation]
+        let docker: StorageDockerPresentation?
+        let apfs: StorageAPFSPresentation?
+        let diagnostic: StorageCoverageDiagnostic
+        let searchIndex: [IndexedNode]
+    }
+
+    func apply(_ report: StorageReconciliationReport, prepared: PreparedPresentation) {
+        self.report = report
+        sortOrder = .sizeDescending
+        applyPresentation(prepared)
+    }
+
+    func applyPresentation(_ prepared: PreparedPresentation) {
+        summary = prepared.summary
+        coverage = prepared.coverage
+        additionalCoverage = prepared.additionalCoverage
+        attributionPresentation = prepared.attribution
+        coverageDiagnostic = prepared.diagnostic
+        categories = prepared.categories
+        dockerPresentation = prepared.docker
+        apfsPresentation = prepared.apfs
+        searchIndex = prepared.searchIndex
+        scheduleSearch()
+    }
+
+    func scheduleSearch() {
+        searchTask?.cancel()
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else {
+            searchResults = []
+            return
+        }
+
+        let index = searchIndex
+        let order = sortOrder
+        let identifier = UUID()
+        searchIdentifier = identifier
+        searchTask = Task { [weak self] in
+            let matches = await Task.detached(priority: .utility) {
+                index
+                    .filter { $0.searchableText.contains(query) }
+                    .map(\.result)
+                    .sorted { Self.searchSort($0, $1, order: order) }
+            }.value
+            guard let self, self.searchIdentifier == identifier else { return }
+            self.searchResults = matches
+        }
+    }
+
+    func sortSearchResults() {
+        searchResults.sort { Self.searchSort($0, $1, order: sortOrder) }
+    }
+
+    nonisolated static func prepare(
+        report: StorageReconciliationReport,
+        sortOrder: StorageIntelligenceSortOrder
+    ) -> PreparedPresentation {
+        let summary = StorageSummaryPresentation(
+            totalCapacityBytes: report.totalCapacityBytes,
+            usedBytes: report.usedCapacityBytes,
+            freeBytes: report.availableCapacityBytes,
+            explainedAllocatedBytes: max(report.explainedAllocatedBytes, 0),
+            unexplainedBytes: report.unexplainedBytes,
+            purgeableEstimateBytes: report.purgeableEstimateBytes
+        )
+        let coverage = coveragePresentation(report)
+        let additionalCoverage: StorageAdditionalCoveragePresentation?
+        if let expansion = report.analyzerResults.coverageExpansion,
+           !expansion.candidates.isEmpty || expansion.totalNewlyMeasuredBytes > 0 {
+            additionalCoverage = StorageAdditionalCoveragePresentation(
+                totalNewlyMeasuredBytes: expansion.totalNewlyMeasuredBytes,
+                measuredRegionCount: expansion.measuredCandidateCount,
+                remainingUnexplainedBytes: report.unexplainedBytes,
+                largestDiscoveredRegions: expansion.largestDiscoveredRegions,
+                candidates: expansion.candidates
+            )
+        } else {
+            additionalCoverage = nil
+        }
+        let attributionPresentation: StorageAttributionPresentation?
+        if let attr = report.attributionReport {
+            attributionPresentation = StorageAttributionPresentation(
+                volumeUsedBytes: attr.volumeUsedBytes,
+                explainedAllocatedBytes: attr.explainedAllocatedBytes,
+                unexplainedBytes: attr.unexplainedBytes,
+                residualUnattributedBytes: attr.residualUnattributedBytes,
+                dataVolumeRoots: attr.dataVolumeRoots,
+                attributionItems: attr.attributionItems,
+                vmFootprintBytes: attr.vmFootprintBytes,
+                sleepImageBytes: attr.sleepImageBytes,
+                snapshotFootprintBytes: attr.snapshotFootprintBytes,
+                purgeableEstimateBytes: attr.purgeableEstimateBytes
+            )
+        } else {
+            attributionPresentation = nil
+        }
+        let unsortedCategories = makeCategories(report)
+        let categories = unsortedCategories
+            .map { category in
+                StorageCategoryPresentation(
+                    id: category.id,
+                    allocatedBytes: category.allocatedBytes,
+                    observedAllocatedBytes: category.observedAllocatedBytes,
+                    roots: category.roots
+                        .map { sortedTree($0, order: sortOrder) }
+                        .sorted { nodeSort($0, $1, order: sortOrder) },
+                    isFilesystemAdditive: category.isFilesystemAdditive,
+                    issueCount: category.issueCount,
+                    prominentNode: category.prominentNode
+                )
+            }
+            .sorted(by: categorySort)
+        return PreparedPresentation(
+            summary: summary,
+            coverage: coverage,
+            additionalCoverage: additionalCoverage,
+            attribution: attributionPresentation,
+            categories: categories,
+            docker: dockerPresentation(report.analyzerResults.dockerStorage),
+            apfs: apfsPresentation(report.analyzerResults.apfsStorage),
+            diagnostic: report.coverageDiagnostic,
+            searchIndex: makeSearchIndex(categories)
+        )
+    }
+
+    nonisolated static func coveragePresentation(
+        _ report: StorageReconciliationReport
+    ) -> StorageCoveragePresentation {
+        let title: String
+        let reason: String
+        switch report.coverageStatus {
+        case .completeForConfiguredRoots:
+            title = "Complete for configured locations"
+            reason = report.incompleteCoverage
+                ? "Configured locations were measured, but APFS and inaccessible edge storage may remain unattributed."
+                : "All configured locations were measured."
+        case .partialDueToPermissions:
+            title = "Partial due to permissions"
+            reason = "macOS denied access to one or more measured locations."
+        case .partialDueToMeasurementIssues:
+            title = "Partial due to measurement issues"
+            reason = "Some locations could not be fully measured for non-permission reasons."
+        case .partialDueToCancellation:
+            title = "Partial because analysis was cancelled"
+            reason = "Displayed values include only locations measured before cancellation."
+        case .partialDueToAnalyzerFailure:
+            title = "Partial due to analyzer errors"
+            reason = "One or more storage sources failed, while successful results were preserved."
+        }
+        let unreadable = report.unreadablePathCount
+        let detail = unreadable > 0
+            ? "\(reason) \(unreadable) location\(unreadable == 1 ? "" : "s") could not be fully read."
+            : reason
+        return StorageCoveragePresentation(
+            status: report.coverageStatus,
+            title: title,
+            detail: detail,
+            isPartial: report.coverageStatus != .completeForConfiguredRoots,
+            unreadablePathCount: unreadable,
+            knownLowerBoundBytes: max(report.inaccessibleKnownLowerBoundBytes, 0),
+            unexplainedBytes: report.unexplainedBytes,
+            measurementIssueCount: report.coverageDiagnostic.measurementIssues.totalIssueCount,
+            categoryCounts: report.coverageDiagnostic.measurementIssues.categoryCounts
+        )
+    }
+
+    nonisolated static func makeCategories(
+        _ report: StorageReconciliationReport
+    ) -> [StorageCategoryPresentation] {
+        let results = report.analyzerResults
+        let contributions = report.filesystemContributions
+
+        func accounted(_ sources: Set<StorageAccountingSource>) -> Int64 {
+            contributions
+                .filter { sources.contains($0.source) }
+                .reduce(Int64(0)) { saturatedAdd($0, max($1.accountedAllocatedBytes, 0)) }
+        }
+
+        func issueCount(_ result: StorageAnalysisResult?) -> Int {
+            result?.issues.count ?? 0
+        }
+
+        func category(
+            _ id: StorageIntelligenceCategoryID,
+            sources: Set<StorageAccountingSource>,
+            observed: Int64,
+            roots: [StorageNode],
+            issues: Int,
+            additive: Bool = true
+        ) -> StorageCategoryPresentation {
+            let prominent = roots
+                .flatMap { [$0] + $0.children }
+                .map(StorageNodePresentation.init)
+                .filter(\.isUnusuallyLarge)
+                .max { $0.allocatedSize < $1.allocatedSize }
+            return StorageCategoryPresentation(
+                id: id,
+                allocatedBytes: additive ? accounted(sources) : 0,
+                observedAllocatedBytes: max(observed, 0),
+                roots: roots,
+                isFilesystemAdditive: additive,
+                issueCount: issues,
+                prominentNode: prominent
+            )
+        }
+
+        let userRoots = results.userHomeStorage?.roots.map(\.node) ?? []
+        let applicationRoots = results.applicationSupport?.root.children ?? []
+        let containerRoots = results.containers?.root.children ?? []
+        let groupRoots = results.groupContainers?.root.children ?? []
+        let libraryRoots = results.systemLibrary?.root.children ?? []
+        let privateRoots = results.privateStorage?.root.children ?? []
+        let hiddenRoots = results.dataVolumeHiddenStorage?.root.children ?? []
+        let developerRoots = [
+            results.developerSystemStorage?.opt.result.root,
+            results.developerSystemStorage?.usrLocal.result.root,
+        ].compactMap { $0 }
+        let dockerRoots = results.dockerStorage?.hostFootprint.locations.map(\.root) ?? []
+
+        return [
+            category(
+                .userFiles,
+                sources: [.userHomeVisibleStorage],
+                observed: results.userHomeStorage?.combinedUniqueAllocatedSize ?? 0,
+                roots: userRoots,
+                issues: results.userHomeStorage?.issues.count ?? 0
+            ),
+            category(
+                .applicationSupport,
+                sources: [.applicationSupport],
+                observed: results.applicationSupport?.root.allocatedSize ?? 0,
+                roots: applicationRoots,
+                issues: issueCount(results.applicationSupport)
+            ),
+            category(
+                .containers,
+                sources: [.containers],
+                observed: results.containers?.root.allocatedSize ?? 0,
+                roots: containerRoots,
+                issues: issueCount(results.containers)
+            ),
+            category(
+                .groupContainers,
+                sources: [.groupContainers],
+                observed: results.groupContainers?.root.allocatedSize ?? 0,
+                roots: groupRoots,
+                issues: issueCount(results.groupContainers)
+            ),
+            category(
+                .systemLibrary,
+                sources: [.systemLibrary],
+                observed: results.systemLibrary?.root.allocatedSize ?? 0,
+                roots: libraryRoots,
+                issues: issueCount(results.systemLibrary)
+            ),
+            category(
+                .privateSystemState,
+                sources: [.privateStorage],
+                observed: results.privateStorage?.root.allocatedSize ?? 0,
+                roots: privateRoots,
+                issues: issueCount(results.privateStorage)
+            ),
+            category(
+                .hiddenData,
+                sources: [.dataVolumeHiddenStorage],
+                observed: results.dataVolumeHiddenStorage?.root.allocatedSize ?? 0,
+                roots: hiddenRoots,
+                issues: issueCount(results.dataVolumeHiddenStorage)
+            ),
+            category(
+                .developerThirdParty,
+                sources: [.opt, .usrLocal],
+                observed: results.developerSystemStorage?.combinedUniqueAllocatedSize ?? 0,
+                roots: developerRoots,
+                issues: results.developerSystemStorage?.issues.count ?? 0
+            ),
+            category(
+                .docker,
+                sources: [.dockerHostOutsideCanonicalRoots],
+                observed: results.dockerStorage?.hostFootprint.allocatedSize ?? 0,
+                roots: dockerRoots,
+                issues: results.dockerStorage?.issues.count ?? 0
+            ),
+            category(
+                .apfs,
+                sources: [],
+                observed: 0,
+                roots: [],
+                issues: results.apfsStorage?.issues.count ?? 0,
+                additive: false
+            ),
+        ]
+    }
+
+    nonisolated static func dockerPresentation(_ report: DockerStorageReport?) -> StorageDockerPresentation? {
+        guard let report else { return nil }
+        let message: String
+        switch report.hostRuntimeRelationship {
+        case .localRuntimeMayExplainHostFootprint:
+            message = "Local Docker runtime details may explain the host files below, but are not added again."
+        case .remoteRuntimeNotRelatedToHostFootprint:
+            message = "Remote Docker context. Runtime storage is not stored on this Mac."
+        case .unknownRelationship:
+            message = "Docker runtime location is unknown, so runtime values are kept separate from this Mac."
+        }
+        return StorageDockerPresentation(
+            localFootprintBytes: max(report.macDiskUsageBytes, 0),
+            runtimeReportedBytes: report.totalRuntimeReportedBytes,
+            runtimeLocation: report.runtimeContext.location,
+            contextName: report.runtimeContext.name,
+            relationshipMessage: message,
+            runtimeIsNonAdditive: true,
+            runtimeCategories: report.runtimeAccounting?.categories.map {
+                StorageDockerRuntimeCategoryPresentation(
+                    category: $0.category,
+                    totalBytes: $0.totalBytes,
+                    objectCount: $0.objectCount
+                )
+            } ?? []
+        )
+    }
+
+    nonisolated static func apfsPresentation(_ report: APFSStorageReport?) -> StorageAPFSPresentation? {
+        guard let report else { return nil }
+        return StorageAPFSPresentation(
+            filesystemType: report.volume.filesystemType,
+            volumeName: report.volume.name,
+            totalCapacityBytes: report.volume.capacity.totalCapacity,
+            freeBytes: report.volume.capacity.availableCapacity,
+            purgeableEstimateBytes: report.volume.capacity.purgeableEstimate,
+            snapshots: report.snapshots.map {
+                StorageSnapshotPresentation(
+                    id: $0.identifier,
+                    name: $0.name ?? $0.identifier,
+                    type: $0.type,
+                    creationDate: $0.creationDate,
+                    sizeBytes: $0.sizeKnowledge == .reportedBySystem ? $0.size : nil,
+                    sizeIsReliable: $0.sizeKnowledge == .reportedBySystem && $0.size != nil,
+                    isNonAdditive: true
+                )
+            },
+            snapshotsAreNonAdditive: true
+        )
+    }
+
+    nonisolated static func makeSearchIndex(
+        _ categories: [StorageCategoryPresentation]
+    ) -> [IndexedNode] {
+        var index: [IndexedNode] = []
+        var seenPaths: Set<String> = []
+        for category in categories where !category.roots.isEmpty {
+            var pending = category.roots
+            while let node = pending.popLast() {
+                pending.append(contentsOf: node.children)
+                guard seenPaths.insert(node.absolutePath).inserted else { continue }
+                let presentation = StorageNodePresentation(node: node)
+                let text = [
+                    presentation.name,
+                    presentation.absolutePath,
+                    presentation.ownerDisplayName ?? "",
+                ].joined(separator: "\n").lowercased()
+                index.append(IndexedNode(
+                    result: StorageSearchResult(categoryID: category.id, node: presentation),
+                    searchableText: text
+                ))
+            }
+        }
+        return index
+    }
+
+    nonisolated static func sortedTree(
+        _ node: StorageNode,
+        order: StorageIntelligenceSortOrder
+    ) -> StorageNode {
+        let children = node.children
+            .map { sortedTree($0, order: order) }
+            .sorted { nodeSort($0, $1, order: order) }
+        return StorageNode(
+            name: node.name,
+            absolutePath: node.absolutePath,
+            logicalSize: node.logicalSize,
+            allocatedSize: node.allocatedSize,
+            ownLogicalSize: node.ownLogicalSize,
+            ownAllocatedSize: node.ownAllocatedSize,
+            itemType: node.itemType,
+            children: children,
+            accessibility: node.accessibility,
+            scanIssues: node.scanIssues,
+            isHidden: node.isHidden,
+            isSymbolicLink: node.isSymbolicLink,
+            isCountedInParentTotals: node.isCountedInParentTotals,
+            metadata: node.metadata
+        )
+    }
+
+    nonisolated static func nodeSort(
+        _ left: StorageNode,
+        _ right: StorageNode,
+        order: StorageIntelligenceSortOrder
+    ) -> Bool {
+        switch order {
+        case .sizeDescending:
+            if left.allocatedSize != right.allocatedSize {
+                return left.allocatedSize > right.allocatedSize
+            }
+        case .name:
+            let comparison = left.name.localizedStandardCompare(right.name)
+            if comparison != .orderedSame { return comparison == .orderedAscending }
+        }
+        return left.absolutePath < right.absolutePath
+    }
+
+    nonisolated static func categorySort(
+        _ left: StorageCategoryPresentation,
+        _ right: StorageCategoryPresentation
+    ) -> Bool {
+        if left.isFilesystemAdditive != right.isFilesystemAdditive {
+            return left.isFilesystemAdditive
+        }
+        if left.allocatedBytes != right.allocatedBytes {
+            return left.allocatedBytes > right.allocatedBytes
+        }
+        return left.id.title < right.id.title
+    }
+
+    nonisolated static func searchSort(
+        _ left: StorageSearchResult,
+        _ right: StorageSearchResult,
+        order: StorageIntelligenceSortOrder
+    ) -> Bool {
+        switch order {
+        case .sizeDescending:
+            if left.node.allocatedSize != right.node.allocatedSize {
+                return left.node.allocatedSize > right.node.allocatedSize
+            }
+        case .name:
+            let comparison = left.node.name.localizedStandardCompare(right.node.name)
+            if comparison != .orderedSame { return comparison == .orderedAscending }
+        }
+        return left.node.absolutePath < right.node.absolutePath
+    }
+
+    nonisolated static func cancelledProgress(
+        from progress: StorageAnalysisProgress?
+    ) -> StorageAnalysisProgress {
+        StorageAnalysisProgress(
+            totalStages: progress?.totalStages ?? StorageAnalyzerStage.allCases.count,
+            completedStages: progress?.completedStages ?? 0,
+            runningStages: [],
+            state: .cancelled
+        )
+    }
+
+    nonisolated static func saturatedAdd(_ left: Int64, _ right: Int64) -> Int64 {
+        let (value, overflow) = left.addingReportingOverflow(right)
+        return overflow ? Int64.max : value
+    }
+}

--- a/PureMac/ViewModels/StorageIntelligenceState.swift
+++ b/PureMac/ViewModels/StorageIntelligenceState.swift
@@ -37,6 +37,7 @@ enum StorageIntelligenceAction: String, CaseIterable, Sendable {
 
 enum StorageIntelligenceCategoryID: String, CaseIterable, Identifiable, Sendable {
     case userFiles
+    case applications
     case applicationSupport
     case containers
     case groupContainers
@@ -52,6 +53,7 @@ enum StorageIntelligenceCategoryID: String, CaseIterable, Identifiable, Sendable
     var title: String {
         switch self {
         case .userFiles: return "User Files"
+        case .applications: return "Applications"
         case .applicationSupport: return "Application Support"
         case .containers: return "Containers"
         case .groupContainers: return "Group Containers"
@@ -67,6 +69,7 @@ enum StorageIntelligenceCategoryID: String, CaseIterable, Identifiable, Sendable
     var explanation: String {
         switch self {
         case .userFiles: return "Visible files and folders in your home directory."
+        case .applications: return "Installed applications and utilities in /Applications."
         case .applicationSupport: return "Application-owned support files and local data."
         case .containers: return "Sandboxed application data stored by macOS."
         case .groupContainers: return "Data shared by related sandboxed applications."
@@ -262,6 +265,10 @@ struct StorageAttributionPresentation: Equatable, Sendable {
     let purgeableEstimateBytes: Int64?
 }
 
+struct APFSPhysicalReconciliationPresentation: Equatable, Sendable {
+    let report: APFSPhysicalReconciliationReport
+}
+
 @MainActor
 final class StorageIntelligenceState: ObservableObject {
     typealias ProgressHandler = @Sendable (StorageAnalysisProgress) async -> Void
@@ -276,6 +283,7 @@ final class StorageIntelligenceState: ObservableObject {
     @Published private(set) var coverage: StorageCoveragePresentation?
     @Published private(set) var additionalCoverage: StorageAdditionalCoveragePresentation?
     @Published private(set) var attributionPresentation: StorageAttributionPresentation?
+    @Published private(set) var physicalReconciliationPresentation: APFSPhysicalReconciliationPresentation?
     @Published private(set) var coverageDiagnostic: StorageCoverageDiagnostic?
     @Published private(set) var categories: [StorageCategoryPresentation] = []
     @Published private(set) var dockerPresentation: StorageDockerPresentation?
@@ -349,14 +357,32 @@ final class StorageIntelligenceState: ObservableObject {
                     }
                 }
                 let callerWasCancelled = Task.isCancelled
+                let postScanStart = CFAbsoluteTimeGetCurrent()
                 let prepared = await Task.detached(priority: .utility) {
                     Self.prepare(report: result, sortOrder: .sizeDescending)
                 }.value
 
                 guard let self, self.scanIdentifier == identifier else { return }
+                let publishStart = CFAbsoluteTimeGetCurrent()
                 self.apply(result, prepared: prepared)
                 self.lifecycle = result.wasCancelled || callerWasCancelled ? .cancelled : .completed
                 self.progress = result.progress
+                let publishDuration = CFAbsoluteTimeGetCurrent() - publishStart
+                let totalPostScan = CFAbsoluteTimeGetCurrent() - postScanStart
+
+                #if DEBUG
+                Self.emitPostScanPerformanceReport(
+                    reconciliationDuration: result.duration,
+                    treePrepDuration: prepared.treePrepDuration,
+                    searchIndexDuration: prepared.searchIndexDuration,
+                    diagnosticsPrepDuration: prepared.diagnosticsPrepDuration,
+                    mainActorPublishDuration: publishDuration,
+                    totalPostScanDuration: totalPostScan,
+                    storageNodeCountReceived: prepared.storageNodeCountReceived,
+                    presentationNodeCountCreated: prepared.presentationNodeCountCreated,
+                    visibleRowsInitiallyRendered: prepared.categories.count
+                )
+                #endif
             } catch is CancellationError {
                 guard let self, self.scanIdentifier == identifier else { return }
                 self.lifecycle = .cancelled
@@ -446,6 +472,10 @@ final class StorageIntelligenceState: ObservableObject {
         revealHandler(node.absolutePath)
     }
 
+    func sortedChildren(of node: StorageNode) -> [StorageNode] {
+        node.children.sorted { Self.nodeSort($0, $1, order: sortOrder) }
+    }
+
     func waitForAnalysis() async {
         await analysisTask?.value
     }
@@ -459,7 +489,7 @@ final class StorageIntelligenceState: ObservableObject {
     }
 }
 
-private extension StorageIntelligenceState {
+extension StorageIntelligenceState {
     struct IndexedNode: Sendable {
         let result: StorageSearchResult
         let searchableText: String
@@ -470,11 +500,17 @@ private extension StorageIntelligenceState {
         let coverage: StorageCoveragePresentation
         let additionalCoverage: StorageAdditionalCoveragePresentation?
         let attribution: StorageAttributionPresentation?
+        let physicalReconciliation: APFSPhysicalReconciliationPresentation?
         let categories: [StorageCategoryPresentation]
         let docker: StorageDockerPresentation?
         let apfs: StorageAPFSPresentation?
         let diagnostic: StorageCoverageDiagnostic
         let searchIndex: [IndexedNode]
+        let treePrepDuration: Double
+        let searchIndexDuration: Double
+        let diagnosticsPrepDuration: Double
+        let storageNodeCountReceived: Int
+        let presentationNodeCountCreated: Int
     }
 
     func apply(_ report: StorageReconciliationReport, prepared: PreparedPresentation) {
@@ -488,6 +524,7 @@ private extension StorageIntelligenceState {
         coverage = prepared.coverage
         additionalCoverage = prepared.additionalCoverage
         attributionPresentation = prepared.attribution
+        physicalReconciliationPresentation = prepared.physicalReconciliation
         coverageDiagnostic = prepared.diagnostic
         categories = prepared.categories
         dockerPresentation = prepared.docker
@@ -504,18 +541,41 @@ private extension StorageIntelligenceState {
             return
         }
 
-        let index = searchIndex
+        let categories = categories
         let order = sortOrder
         let identifier = UUID()
         searchIdentifier = identifier
         searchTask = Task { [weak self] in
-            let matches = await Task.detached(priority: .utility) {
-                index
-                    .filter { $0.searchableText.contains(query) }
-                    .map(\.result)
-                    .sorted { Self.searchSort($0, $1, order: order) }
+            let matches = await Task.detached(priority: .utility) { () -> [StorageSearchResult] in
+                var results: [StorageSearchResult] = []
+                var seenPaths: Set<String> = []
+
+                for category in categories where !category.roots.isEmpty {
+                    var pending = category.roots
+                    while let node = pending.popLast() {
+                        if Task.isCancelled { return [] }
+                        pending.append(contentsOf: node.children)
+                        guard seenPaths.insert(node.absolutePath).inserted else { continue }
+
+                        let nameMatch = node.name.localizedCaseInsensitiveContains(query)
+                        let pathMatch = node.absolutePath.localizedCaseInsensitiveContains(query)
+                        let appMatch = node.metadata.owningApplicationName?.localizedCaseInsensitiveContains(query) == true
+
+                        if nameMatch || pathMatch || appMatch {
+                            results.append(StorageSearchResult(
+                                categoryID: category.id,
+                                node: StorageNodePresentation(node: node)
+                            ))
+                            if results.count >= 500 {
+                                break
+                            }
+                        }
+                    }
+                }
+                return results.sorted { Self.searchSort($0, $1, order: order) }
             }.value
-            guard let self, self.searchIdentifier == identifier else { return }
+
+            guard let self, self.searchIdentifier == identifier, !Task.isCancelled else { return }
             self.searchResults = matches
         }
     }
@@ -528,6 +588,7 @@ private extension StorageIntelligenceState {
         report: StorageReconciliationReport,
         sortOrder: StorageIntelligenceSortOrder
     ) -> PreparedPresentation {
+        let diagStart = CFAbsoluteTimeGetCurrent()
         let summary = StorageSummaryPresentation(
             totalCapacityBytes: report.totalCapacityBytes,
             usedBytes: report.usedCapacityBytes,
@@ -567,6 +628,15 @@ private extension StorageIntelligenceState {
         } else {
             attributionPresentation = nil
         }
+        let physicalPresentation: APFSPhysicalReconciliationPresentation?
+        if let phys = report.physicalReconciliation ?? report.analyzerResults.physicalReconciliation {
+            physicalPresentation = APFSPhysicalReconciliationPresentation(report: phys)
+        } else {
+            physicalPresentation = nil
+        }
+        let diagDuration = CFAbsoluteTimeGetCurrent() - diagStart
+
+        let treeStart = CFAbsoluteTimeGetCurrent()
         let unsortedCategories = makeCategories(report)
         let categories = unsortedCategories
             .map { category in
@@ -574,25 +644,36 @@ private extension StorageIntelligenceState {
                     id: category.id,
                     allocatedBytes: category.allocatedBytes,
                     observedAllocatedBytes: category.observedAllocatedBytes,
-                    roots: category.roots
-                        .map { sortedTree($0, order: sortOrder) }
-                        .sorted { nodeSort($0, $1, order: sortOrder) },
+                    roots: category.roots.sorted { nodeSort($0, $1, order: sortOrder) },
                     isFilesystemAdditive: category.isFilesystemAdditive,
                     issueCount: category.issueCount,
                     prominentNode: category.prominentNode
                 )
             }
             .sorted(by: categorySort)
+        let treeDuration = CFAbsoluteTimeGetCurrent() - treeStart
+
+        let initialPresentationNodes = categories.reduce(0) { count, cat in
+            count + (cat.prominentNode != nil ? 1 : 0) + cat.roots.count
+        }
+        let totalNodesReceived = countStorageNodes(in: categories)
+
         return PreparedPresentation(
             summary: summary,
             coverage: coverage,
             additionalCoverage: additionalCoverage,
             attribution: attributionPresentation,
+            physicalReconciliation: physicalPresentation,
             categories: categories,
             docker: dockerPresentation(report.analyzerResults.dockerStorage),
             apfs: apfsPresentation(report.analyzerResults.apfsStorage),
             diagnostic: report.coverageDiagnostic,
-            searchIndex: makeSearchIndex(categories)
+            searchIndex: [],
+            treePrepDuration: treeDuration,
+            searchIndexDuration: 0,
+            diagnosticsPrepDuration: diagDuration,
+            storageNodeCountReceived: totalNodesReceived,
+            presentationNodeCountCreated: initialPresentationNodes
         )
     }
 
@@ -678,6 +759,7 @@ private extension StorageIntelligenceState {
         }
 
         let userRoots = results.userHomeStorage?.roots.map(\.node) ?? []
+        let appRoots = results.applications?.root.children ?? []
         let applicationRoots = results.applicationSupport?.root.children ?? []
         let containerRoots = results.containers?.root.children ?? []
         let groupRoots = results.groupContainers?.root.children ?? []
@@ -697,6 +779,13 @@ private extension StorageIntelligenceState {
                 observed: results.userHomeStorage?.combinedUniqueAllocatedSize ?? 0,
                 roots: userRoots,
                 issues: results.userHomeStorage?.issues.count ?? 0
+            ),
+            category(
+                .applications,
+                sources: [.applications],
+                observed: results.applications?.root.allocatedSize ?? 0,
+                roots: appRoots,
+                issues: issueCount(results.applications)
             ),
             category(
                 .applicationSupport,
@@ -928,4 +1017,54 @@ private extension StorageIntelligenceState {
         let (value, overflow) = left.addingReportingOverflow(right)
         return overflow ? Int64.max : value
     }
+
+    nonisolated static func countStorageNodes(in categories: [StorageCategoryPresentation]) -> Int {
+        var count = 0
+        for category in categories {
+            for root in category.roots {
+                count += countNodes(in: root)
+            }
+        }
+        return count
+    }
+
+    private nonisolated static func countNodes(in node: StorageNode) -> Int {
+        var count = 1
+        for child in node.children {
+            count += countNodes(in: child)
+        }
+        return count
+    }
+
+    #if DEBUG
+    static func emitPostScanPerformanceReport(
+        reconciliationDuration: Double,
+        treePrepDuration: Double,
+        searchIndexDuration: Double,
+        diagnosticsPrepDuration: Double,
+        mainActorPublishDuration: Double,
+        totalPostScanDuration: Double,
+        storageNodeCountReceived: Int,
+        presentationNodeCountCreated: Int,
+        visibleRowsInitiallyRendered: Int
+    ) {
+        func formatDuration(_ duration: Double) -> String {
+            (String(format: "%.2f", duration) + "s").leftPadded(toLength: 7)
+        }
+
+        var output = "\n=== PureMac Post-Scan Presentation Performance ===\n"
+        output += "Reconciliation:          \(formatDuration(reconciliationDuration))\n"
+        output += "Tree preparation:        \(formatDuration(treePrepDuration))\n"
+        output += "Search index:            \(formatDuration(searchIndexDuration))\n"
+        output += "Diagnostics preparation: \(formatDuration(diagnosticsPrepDuration))\n"
+        output += "MainActor publish:       \(formatDuration(mainActorPublishDuration))\n"
+        output += "Total post-scan:         \(formatDuration(totalPostScanDuration))\n\n"
+        output += "Metrics:\n"
+        output += "  StorageNode count received:      \(storageNodeCountReceived)\n"
+        output += "  Presentation node count created: \(presentationNodeCountCreated)\n"
+        output += "  Visible rows initially rendered: \(visibleRowsInitiallyRendered)\n"
+        output += "==================================================\n"
+        print(output)
+    }
+    #endif
 }

--- a/PureMac/Views/DashboardView.swift
+++ b/PureMac/Views/DashboardView.swift
@@ -86,8 +86,13 @@ struct DashboardView: View {
         .coordinateSpace(name: dashboardSpace)
         .background(
             GeometryReader { geo in
-                Color.clear.onAppear { dashboardSize = geo.size }
-                    .onChange(of: geo.size) { dashboardSize = $0 }
+                Color.clear
+                    .onAppear {
+                        if dashboardSize != geo.size { dashboardSize = geo.size }
+                    }
+                    .onChange(of: geo.size) { newSize in
+                        if dashboardSize != newSize { dashboardSize = newSize }
+                    }
             }
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)

--- a/PureMac/Views/MainWindow.swift
+++ b/PureMac/Views/MainWindow.swift
@@ -4,6 +4,7 @@ struct MainWindow: View {
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var theme: ThemeManager
     @ObservedObject private var permission = PermissionCoordinator.shared
+    @StateObject private var storageIntelligenceState = StorageIntelligenceState()
     @State private var selectedSection: AppSection? = .cleaning(.smartScan)
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
     @State private var advancedToolsExpanded = false
@@ -99,6 +100,11 @@ struct MainWindow: View {
                        secondaryTint: SidebarPalette.smartCareSecondary,
                        badge: dashboardBadge,
                        isFeatured: true)
+                navRow(section: .storageIntelligence, label: "Storage Intelligence",
+                       icon: "chart.bar.fill",
+                       tint: SidebarPalette.storageIntelligencePrimary,
+                       secondaryTint: SidebarPalette.storageIntelligenceSecondary,
+                       badge: nil)
             } header: { sectionLabel("Overview") }
 
             Section {
@@ -207,7 +213,7 @@ struct MainWindow: View {
     }
 
     private var visibleSections: [AppSection] {
-        var sections: [AppSection] = [.cleaning(.smartScan)]
+        var sections: [AppSection] = [.cleaning(.smartScan), .storageIntelligence]
         sections.append(contentsOf: Self.cleanupCategories.map(AppSection.cleaning))
         sections.append(contentsOf: [.apps, .orphans])
         if advancedToolsExpanded {
@@ -429,6 +435,8 @@ struct MainWindow: View {
     @ViewBuilder
     private var detailView: some View {
         switch selectedSection {
+        case .storageIntelligence:
+            StorageIntelligenceView(state: storageIntelligenceState)
         case .apps:
             AppListView()
         case .orphans:
@@ -635,6 +643,8 @@ private struct SidebarNavRow: View {
 private enum SidebarPalette {
     static let smartCarePrimary = Tint.purple
     static let smartCareSecondary = Tint.blue
+    static let storageIntelligencePrimary = Tint.blue
+    static let storageIntelligenceSecondary = Tint.cyan
     static let cleanupPrimary = Tint.blue
     static let cleanupSecondary = Tint.cyan
     static let applicationsPrimary = Tint.purple

--- a/PureMac/Views/StorageIntelligence/StorageIntelligenceView.swift
+++ b/PureMac/Views/StorageIntelligence/StorageIntelligenceView.swift
@@ -1,0 +1,1513 @@
+import SwiftUI
+
+struct StorageIntelligenceView: View {
+    @ObservedObject var state: StorageIntelligenceState
+    @EnvironmentObject private var appState: AppState
+    @ObservedObject private var permission = PermissionCoordinator.shared
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 16) {
+                    pageHeader
+
+                    if state.isRunning {
+                        progressCard
+                    }
+
+                    if state.lifecycle == .failed {
+                        errorCard
+                    }
+
+                    if let summary = state.summary {
+                        summarySection(summary)
+                        if let coverage = state.coverage {
+                            coverageCard(coverage)
+                        }
+                        if let additional = state.additionalCoverage, additional.measuredRegionCount > 0 || additional.totalNewlyMeasuredBytes > 0 {
+                            additionalCoverageCard(additional)
+                        }
+                        searchAndSortBar
+                        if state.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                            categorySection
+                        } else {
+                            searchResultsSection
+                        }
+                        explanatoryDetails
+                    } else if !state.isRunning && state.lifecycle != .failed {
+                        idleCard
+                    }
+                }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 18)
+                .frame(maxWidth: 1240, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .top)
+            }
+            .navigationTitle("Storage Intelligence")
+        }
+        .sheet(isPresented: $state.isShowingDiagnostics) {
+            if let diagnostic = state.coverageDiagnostic {
+                StorageCoverageDiagnosticsView(
+                    diagnostic: diagnostic,
+                    summary: state.summary,
+                    attribution: state.attributionPresentation,
+                    fullDiskAccessGranted: appState.hasFullDiskAccess,
+                    dismiss: state.dismissDiagnostics
+                )
+            }
+        }
+    }
+
+    private var pageHeader: some View {
+        HStack(alignment: .top, spacing: 18) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Storage Intelligence")
+                    .font(.system(size: 24, weight: .bold))
+                    .tracking(-0.45)
+                    .accessibilityAddTraits(.isHeader)
+                Text("See where your Mac storage is actually being used—without changing any files.")
+                    .font(.system(size: 12.5))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 20)
+
+            if state.isRunning {
+                Button("Cancel") { state.cancel() }
+                    .buttonStyle(.bordered)
+                    .accessibilityHint("Stops storage analysis and keeps any partial measurements returned")
+            } else {
+                Button {
+                    state.analyze()
+                } label: {
+                    Label(state.hasCompletedReport ? "Analyze Again" : "Analyze Storage",
+                          systemImage: "chart.bar.doc.horizontal")
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Tint.blue)
+                .accessibilityHint("Measures storage without modifying files")
+            }
+        }
+    }
+
+    private var idleCard: some View {
+        CardSurface(padding: 24, elevation: .raised, tint: Tint.blue) {
+            HStack(spacing: 20) {
+                IconTile(systemName: "internaldrive.fill", tint: Tint.blue,
+                         size: 52, corner: 14, vivid: true)
+                VStack(alignment: .leading, spacing: 7) {
+                    Text("Understand your storage")
+                        .font(.system(size: 19, weight: .semibold))
+                    Text("PureMac will measure visible files, application data, system locations, Docker storage, and APFS metadata. Results are for explanation and attribution only.")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Label("Analysis starts only when you request it", systemImage: "hand.tap")
+                        .font(.system(size: 11.5, weight: .medium))
+                        .foregroundStyle(Tint.blue)
+                        .padding(.top, 3)
+                }
+                Spacer()
+            }
+        }
+    }
+
+    private var progressCard: some View {
+        CardSurface(padding: 16, tint: Tint.blue) {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Label("Analyzing storage", systemImage: "chart.bar.doc.horizontal")
+                        .font(.system(size: 14, weight: .semibold))
+                    Spacer()
+                    if let progress = state.progress {
+                        Text("\(progress.completedStages) of \(progress.totalStages) sources")
+                            .font(.system(size: 11.5, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+                }
+                ProgressView(
+                    value: Double(state.progress?.completedStages ?? 0),
+                    total: Double(max(state.progress?.totalStages ?? 1, 1))
+                )
+                .accessibilityLabel("Storage analysis progress")
+                .accessibilityValue(progressAccessibilityValue)
+
+                if let stages = state.progress?.runningStages, !stages.isEmpty {
+                    Text("Currently checking: \(stages.map(\.displayName).joined(separator: ", "))")
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                Text("Progress tracks analysis sources, not bytes, because directory workloads vary.")
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    private var progressAccessibilityValue: String {
+        guard let progress = state.progress else { return "Starting" }
+        return "\(progress.completedStages) of \(progress.totalStages) sources complete"
+    }
+
+    private var errorCard: some View {
+        CardSurface(padding: 16, tint: Tint.orange) {
+            HStack(alignment: .top, spacing: 12) {
+                IconTile(systemName: "exclamationmark.triangle.fill", tint: Tint.orange, size: 34)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Analysis could not finish")
+                        .font(.system(size: 14, weight: .semibold))
+                    Text(state.errorMessage ?? "An unexpected analysis error occurred.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func summarySection(_ summary: StorageSummaryPresentation) -> some View {
+        SectionHeader("Storage summary")
+            .accessibilityAddTraits(.isHeader)
+
+        CardSurface(padding: 16) {
+            VStack(spacing: 16) {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 130), spacing: 12)], spacing: 12) {
+                    summaryMetric("Total capacity", value: summary.totalCapacityBytes,
+                                  icon: "internaldrive", tint: Tint.blue)
+                    summaryMetric("Used", value: summary.usedBytes,
+                                  icon: "chart.pie.fill", tint: Tint.purple)
+                    summaryMetric("Free", value: summary.freeBytes,
+                                  icon: "square.dashed", tint: Tint.green)
+                    summaryMetric("Explained", value: summary.explainedAllocatedBytes,
+                                  icon: "checkmark.circle.fill", tint: Tint.blue,
+                                  note: state.coverage?.isPartial == true ? "Measured lower bound" : "Allocated on disk")
+                    summaryMetric("Unexplained", value: summary.unexplainedBytes,
+                                  icon: "questionmark.circle.fill", tint: Tint.orange,
+                                  note: "Not classified as junk")
+                    summaryMetric("Purgeable estimate", value: summary.purgeableEstimateBytes,
+                                  icon: "gauge.with.dots.needle.50percent", tint: Tint.cyan,
+                                  note: "Estimate, not guaranteed")
+                }
+
+                StorageAccountingBar(summary: summary)
+            }
+        }
+    }
+
+    private func summaryMetric(
+        _ title: String,
+        value: Int64?,
+        icon: String,
+        tint: Color,
+        note: String? = nil
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .foregroundStyle(tint)
+                Text(title)
+                    .foregroundStyle(.secondary)
+            }
+            .font(.system(size: 10.5, weight: .semibold))
+            Text(StorageValueFormatter.string(value))
+                .font(.system(size: 17, weight: .semibold, design: .rounded))
+                .monospacedDigit()
+            if let note {
+                Text(note)
+                    .font(.system(size: 9.5))
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 58, alignment: .leading)
+        .padding(10)
+        .background(Color.primary.opacity(0.035), in: RoundedRectangle(cornerRadius: 10))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title), \(StorageValueFormatter.string(value))\(note.map { ", \($0)" } ?? "")")
+    }
+
+    private func coverageCard(_ coverage: StorageCoveragePresentation) -> some View {
+        let tint = coverage.isPartial ? Tint.orange : Tint.blue
+        return CardSurface(padding: 14, tint: tint) {
+            HStack(alignment: .top, spacing: 12) {
+                IconTile(
+                    systemName: coverage.isPartial ? "exclamationmark.shield.fill" : "checkmark.shield.fill",
+                    tint: tint,
+                    size: 34
+                )
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Storage coverage: \(coverage.isPartial ? "Partial" : "Configured roots complete")")
+                        .font(.system(size: 13.5, weight: .semibold))
+                    Text(coverage.detail)
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    if let unexplained = coverage.unexplainedBytes {
+                        Text("\(StorageValueFormatter.string(unexplained)) is not yet attributed by the current scan coverage.")
+                            .font(.system(size: 11.5, weight: .medium))
+                            .foregroundStyle(.secondary)
+                    }
+                    if coverage.measurementIssueCount > 0 {
+                        Text("\(coverage.measurementIssueCount) measurement issue\(coverage.measurementIssueCount == 1 ? "" : "s")")
+                            .font(.system(size: 10.5, weight: .semibold))
+                            .padding(.top, 3)
+                        ForEach(topDiagnosticCounts(coverage.categoryCounts)) { item in
+                            Text("• \(item.count) \(item.category.displayName.lowercased())")
+                                .font(.system(size: 10.5))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    if coverage.isPartial && coverage.knownLowerBoundBytes > 0 {
+                        Text("Known measured storage in incomplete roots: \(StorageValueFormatter.string(coverage.knownLowerBoundBytes))")
+                            .font(.system(size: 10.5, weight: .medium))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+                VStack(alignment: .trailing, spacing: 7) {
+                    Button("View diagnostics") {
+                        state.showDiagnostics()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    if let guidance = state.permissionGuidance(
+                        fullDiskAccessGranted: appState.hasFullDiskAccess
+                    ) {
+                        if guidance.kind == .fullDiskAccessMayHelp {
+                            Button("Review Access") {
+                                permission.requestAccess(context: .general) {
+                                    appState.checkFullDiskAccess()
+                                }
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            .help("Review Full Disk Access guidance")
+                        } else {
+                            Text("Permission denials remain despite Full Disk Access")
+                                .font(.system(size: 9.5, weight: .medium))
+                                .foregroundStyle(.secondary)
+                                .multilineTextAlignment(.trailing)
+                                .frame(maxWidth: 165, alignment: .trailing)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func additionalCoverageCard(_ additional: StorageAdditionalCoveragePresentation) -> some View {
+        CardSurface(padding: 14, tint: Tint.blue) {
+            VStack(alignment: .leading, spacing: 9) {
+                HStack(alignment: .top) {
+                    IconTile(systemName: "sparkles", tint: Tint.blue, size: 30)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Additional Storage Coverage")
+                            .font(.system(size: 13, weight: .semibold))
+                        Text("\(StorageValueFormatter.string(additional.totalNewlyMeasuredBytes)) newly measured across \(additional.measuredRegionCount) region\(additional.measuredRegionCount == 1 ? "" : "s").")
+                            .font(.system(size: 11.5))
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if let unexplained = additional.remainingUnexplainedBytes {
+                        VStack(alignment: .trailing, spacing: 1) {
+                            Text(StorageValueFormatter.string(unexplained))
+                                .font(.system(size: 13, weight: .semibold))
+                                .monospacedDigit()
+                            Text("remaining unmeasured")
+                                .font(.system(size: 9.5))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                if !additional.largestDiscoveredRegions.isEmpty {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Largest newly discovered regions:")
+                            .font(.system(size: 10.5, weight: .medium))
+                            .foregroundStyle(.secondary)
+                        ForEach(additional.largestDiscoveredRegions.prefix(4)) { candidate in
+                            HStack {
+                                Text(candidate.name)
+                                    .font(.system(size: 11, weight: .medium))
+                                Text(candidate.normalizedPath)
+                                    .font(.system(size: 10).monospaced())
+                                    .foregroundStyle(.tertiary)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                                Spacer()
+                                Text(StorageValueFormatter.string(candidate.allocatedBytes))
+                                    .font(.system(size: 11, weight: .medium))
+                                    .monospacedDigit()
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .padding(.top, 2)
+                }
+            }
+        }
+    }
+
+    private func topDiagnosticCounts(
+        _ counts: [StorageCoverageDiagnosticCategoryCount]
+    ) -> [StorageCoverageDiagnosticCategoryCount] {
+        Array(counts.sorted {
+            if $0.count != $1.count { return $0.count > $1.count }
+            return $0.category.rawValue < $1.category.rawValue
+        }.prefix(4))
+    }
+
+    private var searchAndSortBar: some View {
+        HStack(spacing: 10) {
+            HStack(spacing: 7) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField("Search names, paths, or applications", text: Binding(
+                    get: { state.searchText },
+                    set: { state.updateSearch($0) }
+                ))
+                .textFieldStyle(.plain)
+                if !state.searchText.isEmpty {
+                    Button {
+                        state.updateSearch("")
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Clear search")
+                }
+            }
+            .padding(.horizontal, 10)
+            .frame(height: 30)
+            .background(Color.primary.opacity(0.045), in: RoundedRectangle(cornerRadius: 8))
+
+            Picker("Sort", selection: Binding(
+                get: { state.sortOrder },
+                set: { state.updateSortOrder($0) }
+            )) {
+                ForEach(StorageIntelligenceSortOrder.allCases) { order in
+                    Text(order.label).tag(order)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(width: 150)
+            .accessibilityLabel("Storage item sorting")
+        }
+    }
+
+    private var categorySection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            SectionHeader("Where storage is used")
+                .accessibilityAddTraits(.isHeader)
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 250), spacing: 12)], spacing: 12) {
+                ForEach(state.categories) { category in
+                    NavigationLink {
+                        StorageCategoryDetailView(category: category, state: state)
+                            .onAppear { state.selectCategory(category.id) }
+                    } label: {
+                        StorageCategoryCard(category: category)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private var searchResultsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                SectionHeader("Search results")
+                Spacer()
+                Text("\(state.searchResults.count) matches")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+
+            if state.searchResults.isEmpty {
+                CardSurface(padding: 18) {
+                    Label("No matching storage entries", systemImage: "magnifyingglass")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+            } else {
+                LazyVStack(spacing: 8) {
+                    ForEach(state.searchResults) { result in
+                        NavigationLink {
+                            StorageNodeInspectorView(node: result.node, state: state)
+                                .onAppear { state.selectNode(result.node) }
+                        } label: {
+                            StorageSearchResultRow(result: result)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var explanatoryDetails: some View {
+        if state.dockerPresentation != nil || state.apfsPresentation != nil {
+            SectionHeader("Non-additive explanations")
+                .accessibilityAddTraits(.isHeader)
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 360), spacing: 12)], spacing: 12) {
+                if let docker = state.dockerPresentation {
+                    DockerStorageCard(docker: docker)
+                }
+                if let apfs = state.apfsPresentation {
+                    APFSStorageCard(apfs: apfs)
+                }
+            }
+        }
+    }
+}
+
+private struct StorageAccountingBar: View {
+    let summary: StorageSummaryPresentation
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            GeometryReader { proxy in
+                let total = max(summary.totalCapacityBytes ?? 0, 1)
+                let explained = min(max(summary.explainedAllocatedBytes, 0), total)
+                let unexplained = min(max(summary.unexplainedBytes ?? 0, 0), total - explained)
+                HStack(spacing: 1) {
+                    Rectangle()
+                        .fill(Tint.blue)
+                        .frame(width: proxy.size.width * CGFloat(Double(explained) / Double(total)))
+                    Rectangle()
+                        .fill(Tint.orange.opacity(0.75))
+                        .frame(width: proxy.size.width * CGFloat(Double(unexplained) / Double(total)))
+                    Rectangle().fill(Color.primary.opacity(0.08))
+                }
+                .clipShape(Capsule())
+            }
+            .frame(height: 9)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(
+                "Storage accounting: \(StorageValueFormatter.string(summary.explainedAllocatedBytes)) explained, \(StorageValueFormatter.string(summary.unexplainedBytes)) unexplained, and \(StorageValueFormatter.string(summary.freeBytes)) free"
+            )
+
+            HStack(spacing: 14) {
+                legend("Explained", color: Tint.blue,
+                       value: summary.explainedAllocatedBytes)
+                legend("Unexplained", color: Tint.orange.opacity(0.75),
+                       value: summary.unexplainedBytes)
+                legend("Free", color: Color.primary.opacity(0.18), value: summary.freeBytes)
+            }
+        }
+    }
+
+    private func legend(_ title: String, color: Color, value: Int64?) -> some View {
+        HStack(spacing: 5) {
+            Circle().fill(color).frame(width: 7, height: 7)
+            Text("\(title) \(StorageValueFormatter.string(value))")
+        }
+        .font(.system(size: 10.5, weight: .medium))
+        .foregroundStyle(.secondary)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct StorageCategoryCard: View {
+    let category: StorageCategoryPresentation
+
+    var body: some View {
+        CardSurface(padding: 14, elevation: .standard, tint: category.id.tint) {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top) {
+                    IconTile(systemName: category.id.icon, tint: category.id.tint, size: 36)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                }
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(category.id.title)
+                        .font(.system(size: 14, weight: .semibold))
+                    if category.isFilesystemAdditive {
+                        Text(StorageValueFormatter.string(category.allocatedBytes))
+                            .font(.system(size: 20, weight: .semibold, design: .rounded))
+                            .monospacedDigit()
+                        Text(category.isOwnedElsewhere
+                             ? "Host files counted under another category"
+                             : "Allocated on this Mac")
+                            .font(.system(size: 10.5))
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("Volume metadata")
+                            .font(.system(size: 17, weight: .semibold))
+                        Text("Not additive to file totals")
+                            .font(.system(size: 10.5))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if let prominent = category.prominentNode {
+                    HStack(spacing: 5) {
+                        Image(systemName: "exclamationmark.circle.fill")
+                        Text("Large: \(prominent.name)")
+                            .lineLimit(1)
+                        Spacer()
+                        Text(StorageValueFormatter.string(prominent.allocatedSize))
+                            .monospacedDigit()
+                    }
+                    .font(.system(size: 10.5, weight: .medium))
+                    .foregroundStyle(category.id.tint)
+                } else if category.issueCount > 0 {
+                    Label("\(category.issueCount) measurement issue\(category.issueCount == 1 ? "" : "s")",
+                          systemImage: "exclamationmark.triangle")
+                        .font(.system(size: 10.5, weight: .medium))
+                        .foregroundStyle(Tint.orange)
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: 132, alignment: .topLeading)
+        }
+        .contentShape(RoundedRectangle(cornerRadius: 14))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(category.id.title), \(category.isFilesystemAdditive ? StorageValueFormatter.string(category.allocatedBytes) : "non-additive volume metadata")")
+    }
+}
+
+private struct StorageCategoryDetailView: View {
+    let category: StorageCategoryPresentation
+    @ObservedObject var state: StorageIntelligenceState
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 14) {
+                HStack(spacing: 12) {
+                    IconTile(systemName: category.id.icon, tint: category.id.tint, size: 44)
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(category.id.title)
+                            .font(.system(size: 22, weight: .bold))
+                        Text(category.id.explanation)
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if category.isFilesystemAdditive {
+                        VStack(alignment: .trailing, spacing: 2) {
+                            Text(StorageValueFormatter.string(category.allocatedBytes))
+                                .font(.system(size: 20, weight: .semibold, design: .rounded))
+                                .monospacedDigit()
+                            Text(category.isOwnedElsewhere ? "Counted elsewhere" : "Allocated on disk")
+                                .font(.system(size: 10.5))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                if category.id == .docker, let docker = state.dockerPresentation {
+                    DockerStorageCard(docker: docker)
+                }
+                if category.id == .apfs, let apfs = state.apfsPresentation {
+                    APFSStorageCard(apfs: apfs)
+                }
+
+                if category.roots.isEmpty && category.id != .apfs {
+                    CardSurface(padding: 18) {
+                        Label("No filesystem entries were reported for this category.",
+                              systemImage: "tray")
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    }
+                } else if !category.roots.isEmpty {
+                    Text("Storage tree")
+                        .font(.system(size: 15, weight: .semibold))
+                        .accessibilityAddTraits(.isHeader)
+                    LazyVStack(spacing: 6) {
+                        ForEach(category.roots) { node in
+                            StorageTreeNodeView(node: node, state: state)
+                        }
+                    }
+                }
+            }
+            .padding(24)
+            .frame(maxWidth: 1080, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .top)
+        }
+        .navigationTitle(category.id.title)
+        .background(AmbientBackdrop())
+    }
+}
+
+private struct StorageTreeNodeView: View {
+    let node: StorageNode
+    @ObservedObject var state: StorageIntelligenceState
+    @State private var isExpanded = false
+
+    private var presentation: StorageNodePresentation {
+        StorageNodePresentation(node: node)
+    }
+
+    var body: some View {
+        if node.children.isEmpty {
+            row
+        } else {
+            DisclosureGroup(isExpanded: $isExpanded) {
+                LazyVStack(spacing: 5) {
+                    ForEach(node.children) { child in
+                        StorageTreeNodeView(node: child, state: state)
+                    }
+                }
+                .padding(.leading, 18)
+                .padding(.top, 5)
+            } label: {
+                row
+            }
+            .tint(.secondary)
+        }
+    }
+
+    private var row: some View {
+        StorageNodeRow(node: presentation, state: state)
+            .onTapGesture { state.selectNode(presentation) }
+    }
+}
+
+private struct StorageNodeRow: View {
+    let node: StorageNodePresentation
+    @ObservedObject var state: StorageIntelligenceState
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: node.isVirtualDisk ? "externaldrive.fill" : "doc.fill")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(node.isVirtualDisk ? Tint.purple : Tint.blue)
+                .frame(width: 18)
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 6) {
+                    Text(node.name)
+                        .font(.system(size: 12.5, weight: .medium))
+                        .lineLimit(1)
+                    if node.isUnusuallyLarge {
+                        nodeBadge("Large", icon: "exclamationmark.circle.fill", tint: Tint.orange)
+                    }
+                    if node.isSparseVirtualDisk {
+                        nodeBadge("Sparse disk", icon: "externaldrive.badge.timemachine", tint: Tint.purple)
+                    }
+                    if node.hasIncompleteMeasurement {
+                        nodeBadge("Incomplete", icon: "lock.trianglebadge.exclamationmark", tint: Tint.orange)
+                    }
+                }
+                Text(node.ownerDisplayName ?? node.absolutePath)
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            Spacer(minLength: 12)
+
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(StorageValueFormatter.string(node.allocatedSize))
+                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+                    .monospacedDigit()
+                if node.hasMaterialLogicalDifference {
+                    Text("Logical \(StorageValueFormatter.string(node.logicalSize))")
+                        .font(.system(size: 9.5))
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+            }
+
+            Button {
+                state.revealInFinder(node)
+            } label: {
+                Image(systemName: "folder")
+                    .font(.system(size: 11, weight: .medium))
+                    .frame(width: 22, height: 22)
+            }
+            .buttonStyle(.plain)
+            .disabled(!state.canRevealInFinder(node))
+            .help("Reveal in Finder")
+            .accessibilityLabel("Reveal \(node.name) in Finder")
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(Color.primary.opacity(0.035), in: RoundedRectangle(cornerRadius: 9))
+        .contextMenu {
+            Button("Reveal in Finder") { state.revealInFinder(node) }
+                .disabled(!state.canRevealInFinder(node))
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(nodeAccessibilityLabel)
+    }
+
+    private func nodeBadge(_ title: String, icon: String, tint: Color) -> some View {
+        Label(title, systemImage: icon)
+            .font(.system(size: 8.5, weight: .semibold))
+            .foregroundStyle(tint)
+            .labelStyle(.titleAndIcon)
+    }
+
+    private var nodeAccessibilityLabel: String {
+        var parts = [node.name, "used on disk \(StorageValueFormatter.string(node.allocatedSize))"]
+        if node.hasMaterialLogicalDifference {
+            parts.append("logical capacity \(StorageValueFormatter.string(node.logicalSize))")
+        }
+        if let owner = node.ownerDisplayName { parts.append("owned by \(owner)") }
+        if node.hasIncompleteMeasurement { parts.append("measurement incomplete") }
+        return parts.joined(separator: ", ")
+    }
+}
+
+private struct StorageSearchResultRow: View {
+    let result: StorageSearchResult
+
+    var body: some View {
+        CardSurface(padding: 10, elevation: .flat) {
+            HStack(spacing: 10) {
+                IconTile(systemName: result.categoryID.icon, tint: result.categoryID.tint, size: 30)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(result.node.name)
+                        .font(.system(size: 12.5, weight: .semibold))
+                    Text(result.node.absolutePath)
+                        .font(.system(size: 10.5))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                Spacer()
+                Text(StorageValueFormatter.string(result.node.allocatedSize))
+                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+                    .monospacedDigit()
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+}
+
+private struct StorageNodeInspectorView: View {
+    let node: StorageNodePresentation
+    @ObservedObject var state: StorageIntelligenceState
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack(spacing: 14) {
+                    IconTile(systemName: node.isVirtualDisk ? "externaldrive.fill" : "doc.fill",
+                             tint: node.isVirtualDisk ? Tint.purple : Tint.blue,
+                             size: 46)
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(node.name).font(.system(size: 21, weight: .bold))
+                        Text(node.absolutePath)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
+                }
+
+                CardSurface(padding: 16) {
+                    VStack(alignment: .leading, spacing: 11) {
+                        inspectorRow("Used on disk", StorageValueFormatter.string(node.allocatedSize))
+                        inspectorRow("Logical size", StorageValueFormatter.string(node.logicalSize))
+                        inspectorRow("Accessibility", node.accessibility.displayName)
+                        if let category = node.storageCategory {
+                            inspectorRow("Informational category", category)
+                        }
+                        if let owner = node.ownerDisplayName {
+                            inspectorRow("Owning application", owner)
+                        }
+                        if node.isVirtualDisk {
+                            inspectorRow("Virtual disk", node.isSparseVirtualDisk ? "Sparse" : "Detected")
+                        }
+                        if node.hasIncompleteMeasurement {
+                            inspectorRow("Measurement", "Incomplete (\(node.issueCount) issue\(node.issueCount == 1 ? "" : "s"))")
+                        }
+                    }
+                }
+
+                Button {
+                    state.revealInFinder(node)
+                } label: {
+                    Label("Reveal in Finder", systemImage: "folder")
+                }
+                .buttonStyle(.bordered)
+                .disabled(!state.canRevealInFinder(node))
+            }
+            .padding(24)
+            .frame(maxWidth: 760, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .top)
+        }
+        .navigationTitle(node.name)
+        .background(AmbientBackdrop())
+    }
+
+    private func inspectorRow(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label).foregroundStyle(.secondary)
+            Spacer()
+            Text(value).multilineTextAlignment(.trailing).textSelection(.enabled)
+        }
+        .font(.system(size: 12))
+    }
+}
+
+private struct DockerStorageCard: View {
+    let docker: StorageDockerPresentation
+
+    var body: some View {
+        CardSurface(padding: 16, tint: Tint.purple) {
+            VStack(alignment: .leading, spacing: 13) {
+                HStack {
+                    Label("Docker storage", systemImage: "shippingbox.fill")
+                        .font(.system(size: 14, weight: .semibold))
+                    Spacer()
+                    StatusChip(
+                        label: docker.runtimeLocation == .remote ? "Remote context" : "Non-additive runtime",
+                        systemImage: docker.runtimeLocation == .remote ? "network" : "info.circle.fill",
+                        tint: docker.runtimeLocation == .remote ? Tint.orange : Tint.purple
+                    )
+                }
+
+                HStack(spacing: 18) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("Local Mac footprint")
+                            .font(.system(size: 10.5, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                        Text(StorageValueFormatter.string(docker.localFootprintBytes))
+                            .font(.system(size: 20, weight: .semibold, design: .rounded))
+                        Text("Host files on this Mac")
+                            .font(.system(size: 9.5))
+                            .foregroundStyle(.tertiary)
+                    }
+                    Divider().frame(height: 46)
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("Runtime breakdown")
+                            .font(.system(size: 10.5, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                        Text(StorageValueFormatter.string(docker.runtimeReportedBytes))
+                            .font(.system(size: 20, weight: .semibold, design: .rounded))
+                        Text("Never added to Mac usage")
+                            .font(.system(size: 9.5))
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+
+                if !docker.runtimeCategories.isEmpty {
+                    HStack(spacing: 8) {
+                        ForEach(docker.runtimeCategories) { item in
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(item.title)
+                                    .font(.system(size: 9.5, weight: .medium))
+                                    .foregroundStyle(.secondary)
+                                Text(StorageValueFormatter.string(item.totalBytes))
+                                    .font(.system(size: 11, weight: .semibold))
+                                    .monospacedDigit()
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                }
+
+                Text(docker.relationshipMessage)
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(docker.runtimeLocation == .remote ? Tint.orange : .secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Docker local Mac footprint \(StorageValueFormatter.string(docker.localFootprintBytes)). \(docker.relationshipMessage)")
+    }
+}
+
+private struct APFSStorageCard: View {
+    let apfs: StorageAPFSPresentation
+
+    var body: some View {
+        CardSurface(padding: 16, tint: Tint.cyan) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Label("APFS volume", systemImage: "internaldrive.fill")
+                        .font(.system(size: 14, weight: .semibold))
+                    Spacer()
+                    StatusChip(label: "Non-additive metadata", systemImage: "info.circle.fill", tint: Tint.cyan)
+                }
+
+                HStack(spacing: 16) {
+                    apfsMetric("Capacity", apfs.totalCapacityBytes)
+                    apfsMetric("Free", apfs.freeBytes)
+                    apfsMetric("Purgeable estimate", apfs.purgeableEstimateBytes)
+                }
+
+                Divider()
+
+                HStack {
+                    Text("Snapshots")
+                        .font(.system(size: 11.5, weight: .semibold))
+                    Spacer()
+                    Text("Shared extents; not added to file totals")
+                        .font(.system(size: 9.5))
+                        .foregroundStyle(.tertiary)
+                }
+
+                if apfs.snapshots.isEmpty {
+                    Text("No local snapshots were reported.")
+                        .font(.system(size: 10.5))
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(apfs.snapshots.prefix(5)) { snapshot in
+                        HStack {
+                            VStack(alignment: .leading, spacing: 1) {
+                                Text(snapshot.name)
+                                    .font(.system(size: 10.5, weight: .medium))
+                                    .lineLimit(1)
+                                Text(snapshot.type.displayName)
+                                    .font(.system(size: 9))
+                                    .foregroundStyle(.tertiary)
+                            }
+                            Spacer()
+                            Text(snapshot.sizeIsReliable
+                                 ? StorageValueFormatter.string(snapshot.sizeBytes)
+                                 : "Unknown")
+                                .font(.system(size: 10.5, weight: .semibold))
+                                .monospacedDigit()
+                        }
+                    }
+                    if apfs.snapshots.count > 5 {
+                        Text("\(apfs.snapshots.count - 5) additional snapshots")
+                            .font(.system(size: 9.5))
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("APFS capacity \(StorageValueFormatter.string(apfs.totalCapacityBytes)), free \(StorageValueFormatter.string(apfs.freeBytes)), purgeable estimate \(StorageValueFormatter.string(apfs.purgeableEstimateBytes)), \(apfs.snapshots.count) snapshots, snapshot storage is non-additive")
+    }
+
+    private func apfsMetric(_ title: String, _ value: Int64?) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.system(size: 9.5, weight: .medium))
+                .foregroundStyle(.secondary)
+                             Text(StorageValueFormatter.string(value))
+                .font(.system(size: 12, weight: .semibold))
+                .monospacedDigit()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct StorageCoverageDiagnosticsView: View {
+    let diagnostic: StorageCoverageDiagnostic
+    let summary: StorageSummaryPresentation?
+    let attribution: StorageAttributionPresentation?
+    let fullDiskAccessGranted: Bool
+    let dismiss: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if let attribution {
+                    Section("Unexplained storage attribution") {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Evidence-based attribution explaining volume storage composition and the remaining unexplained gap.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("Used")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                    Text(StorageValueFormatter.string(attribution.volumeUsedBytes))
+                                        .font(.caption.weight(.semibold))
+                                }
+                                Spacer()
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("Explained")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                    Text(StorageValueFormatter.string(attribution.explainedAllocatedBytes))
+                                        .font(.caption.weight(.semibold))
+                                }
+                                Spacer()
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("Unexplained")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                    Text(StorageValueFormatter.string(attribution.unexplainedBytes))
+                                        .font(.caption.weight(.semibold))
+                                }
+                                Spacer()
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("Residual")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                    Text(StorageValueFormatter.string(attribution.residualUnattributedBytes))
+                                        .font(.caption.weight(.semibold))
+                                }
+                            }
+                            .padding(8)
+                            .background(Color.secondary.opacity(0.08))
+                            .clipShape(RoundedRectangle(cornerRadius: 6))
+                        }
+                        .padding(.vertical, 2)
+
+                        ForEach(StorageAttributionCategory.allCases, id: \.self) { category in
+                            let items = attribution.attributionItems.filter { $0.category == category }
+                            if !items.isEmpty {
+                                DisclosureGroup {
+                                    VStack(alignment: .leading, spacing: 8) {
+                                        Text(category.explanation)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                        ForEach(items) { item in
+                                            VStack(alignment: .leading, spacing: 3) {
+                                                HStack(alignment: .firstTextBaseline) {
+                                                    Text(item.name)
+                                                        .fontWeight(.medium)
+                                                    Spacer()
+                                                    statusBadge(for: item.status)
+                                                    if let bytes = item.allocatedBytes {
+                                                        Text(StorageValueFormatter.string(bytes))
+                                                            .font(.caption.weight(.medium))
+                                                            .monospacedDigit()
+                                                    }
+                                                }
+                                                if let path = item.path {
+                                                    Text(path)
+                                                        .font(.caption2.monospaced())
+                                                        .foregroundStyle(.secondary)
+                                                        .textSelection(.enabled)
+                                                }
+                                                Text(item.explanation)
+                                                    .font(.caption)
+                                                    .foregroundStyle(.secondary)
+                                            }
+                                            .padding(.vertical, 2)
+                                        }
+                                    }
+                                } label: {
+                                    HStack {
+                                        Text(category.displayName)
+                                            .fontWeight(.medium)
+                                        Spacer()
+                                        Text("\(items.count) item\(items.count == 1 ? "" : "s")")
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
+                            }
+                        }
+
+                        if !attribution.dataVolumeRoots.isEmpty {
+                            DisclosureGroup {
+                                VStack(alignment: .leading, spacing: 8) {
+                                    Text("Top-level regions and firmlinked roots discovered on /System/Volumes/Data.")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                    ForEach(attribution.dataVolumeRoots) { root in
+                                        HStack(alignment: .firstTextBaseline) {
+                                            VStack(alignment: .leading, spacing: 2) {
+                                                HStack(spacing: 6) {
+                                                    Text(root.name)
+                                                        .fontWeight(.medium)
+                                                    classificationBadge(for: root.classification)
+                                                }
+                                                Text(root.normalizedPath)
+                                                    .font(.caption2.monospaced())
+                                                    .foregroundStyle(.secondary)
+                                                    .textSelection(.enabled)
+                                            }
+                                            Spacer()
+                                            if let bytes = root.allocatedBytes {
+                                                Text(StorageValueFormatter.string(bytes))
+                                                    .font(.caption.weight(.semibold))
+                                                    .monospacedDigit()
+                                            } else {
+                                                Text("—")
+                                                    .font(.caption)
+                                                    .foregroundStyle(.secondary)
+                                            }
+                                        }
+                                        .padding(.vertical, 2)
+                                    }
+                                }
+                            } label: {
+                                HStack {
+                                    Text("Data-volume root attribution")
+                                        .fontWeight(.medium)
+                                    Spacer()
+                                    Text("\(attribution.dataVolumeRoots.count) roots")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Section("Coverage gaps") {
+                    if diagnostic.coverageGaps.isEmpty {
+                        Text("No structural coverage gaps were discovered.")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(diagnostic.coverageGaps) { gap in
+                            VStack(alignment: .leading, spacing: 3) {
+                                HStack {
+                                    Text(gap.name).fontWeight(.medium)
+                                    Spacer()
+                                    Text(gap.confidence.displayName)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                if let path = gap.absolutePath {
+                                    Text(path)
+                                        .font(.caption.monospaced())
+                                        .foregroundStyle(.secondary)
+                                        .textSelection(.enabled)
+                                }
+                                Text(gap.explanation)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            .padding(.vertical, 2)
+                        }
+                    }
+                }
+
+                Section("Measurement issues") {
+                    if diagnostic.measurementIssues.totalIssueCount == 0 {
+                        Text("No measurement issues were recorded.")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("\(diagnostic.measurementIssues.totalIssueCount) unique issue\(diagnostic.measurementIssues.totalIssueCount == 1 ? "" : "s"), grouped by cause and source.")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                        ForEach(diagnostic.measurementIssues.groups) { group in
+                            DisclosureGroup {
+                                VStack(alignment: .leading, spacing: 7) {
+                                    Text(group.explanation)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                    if let errorCode = group.posixErrorCode {
+                                        Text("POSIX errno: \(errorCode)")
+                                            .font(.caption.monospaced())
+                                    }
+                                    if group.contributingSources.count > 1 {
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            Text("Observed by:")
+                                                .font(.caption.weight(.medium))
+                                                .foregroundStyle(.secondary)
+                                            ForEach(group.contributingSources, id: \.self) { source in
+                                                Text("• \(source.displayName)")
+                                                    .font(.caption)
+                                                    .foregroundStyle(.secondary)
+                                            }
+                                        }
+                                    }
+                                    if !group.representativePaths.isEmpty {
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            Text("Representative paths:")
+                                                .font(.caption.weight(.medium))
+                                                .foregroundStyle(.secondary)
+                                            ForEach(group.representativePaths, id: \.self) { path in
+                                                Text(path)
+                                                    .font(.caption.monospaced())
+                                                    .textSelection(.enabled)
+                                            }
+                                        }
+                                    }
+                                }
+                                .padding(.vertical, 4)
+                            } label: {
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(groupTitle(for: group))
+                                        if group.contributingSources.count > 1 {
+                                            Text("Observed by \(group.contributingSources.count) sources")
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        } else {
+                                            Text(group.source.displayName)
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        }
+                                    }
+                                    Spacer()
+                                    Text("\(group.count)")
+                                        .monospacedDigit()
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Section("Analyzer status") {
+                    ForEach(diagnostic.analyzerStatuses) { status in
+                        HStack {
+                            Text(status.analyzer.displayName)
+                            Spacer()
+                            VStack(alignment: .trailing, spacing: 1) {
+                                Text(status.state.displayName)
+                                    .font(.callout.weight(.medium))
+                                if status.issueCount > 0 {
+                                    Text("\(status.issueCount) issue\(status.issueCount == 1 ? "" : "s")")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Section("Unexplained-space explanation") {
+                    if let summary, let used = summary.usedBytes {
+                        Text("PureMac measured \(StorageValueFormatter.string(summary.explainedAllocatedBytes)) of the \(StorageValueFormatter.string(used)) currently used. \(StorageValueFormatter.string(summary.unexplainedBytes)) is not yet attributed by the current scan coverage.")
+                    }
+                    ForEach(diagnostic.unexplainedSpaceExplanations) { explanation in
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(explanation.title).fontWeight(.medium)
+                            Text(explanation.detail)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    if diagnostic.permissionDeniedIssueCount == 0 {
+                        Text("No recorded diagnostic supports recommending Full Disk Access for this result.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else if fullDiskAccessGranted {
+                        Text("Full Disk Access is detected, but macOS still protects certain system-managed locations (e.g. audit logs, document revisions, and system databases). See the measurement issues above for details.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("Full Disk Access is not detected. Granting Full Disk Access may allow PureMac to inspect additional application and system locations.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .navigationTitle("Storage Diagnostics")
+            .frame(minWidth: 720, minHeight: 620)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done", action: dismiss)
+                }
+            }
+        }
+    }
+
+    private func groupTitle(for group: StorageCoverageDiagnosticIssueGroup) -> String {
+        let categoryName = group.category.displayName
+        if let root = group.canonicalRoot {
+            return "\(categoryName) — \(root.displayName)"
+        }
+        if let first = group.representativePaths.first {
+            let parent = StoragePathNormalizer.parentPath(of: first)
+            if !parent.isEmpty && parent != "/" {
+                return "\(categoryName) — \(parent)"
+            }
+        }
+        return "\(categoryName) — \(group.source.displayName)"
+    }
+
+    private func statusBadge(for status: StorageAttributionStatus) -> some View {
+        Text(status.displayName)
+            .font(.caption2.weight(.medium))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(badgeBackground(for: status))
+            .foregroundColor(badgeForeground(for: status))
+            .clipShape(Capsule())
+    }
+
+    private func classificationBadge(for classification: DataVolumeRegionClassification) -> some View {
+        Text(classification.displayName)
+            .font(.caption2)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1.5)
+            .background(Color.secondary.opacity(0.12))
+            .foregroundStyle(.secondary)
+            .clipShape(Capsule())
+    }
+
+    private func badgeBackground(for status: StorageAttributionStatus) -> Color {
+        switch status {
+        case .measured: return Color.green.opacity(0.15)
+        case .partial: return Color.orange.opacity(0.15)
+        case .protectedUnreadable: return Color.purple.opacity(0.15)
+        case .estimate: return Color.blue.opacity(0.15)
+        case .nonAdditive: return Color.cyan.opacity(0.15)
+        case .unknown: return Color.secondary.opacity(0.15)
+        }
+    }
+
+    private func badgeForeground(for status: StorageAttributionStatus) -> Color {
+        switch status {
+        case .measured: return .green
+        case .partial: return .orange
+        case .protectedUnreadable: return .purple
+        case .estimate: return .blue
+        case .nonAdditive: return .cyan
+        case .unknown: return .secondary
+        }
+    }
+}
+
+private enum StorageValueFormatter {
+    static func string(_ bytes: Int64?) -> String {
+        guard let bytes else { return "Unknown" }
+        return ByteCountFormatter.string(fromByteCount: max(bytes, 0), countStyle: .file)
+    }
+}
+
+private extension StorageCoverageDiagnosticCategory {
+    var displayName: String {
+        switch self {
+        case .permissionDenied: return "Permission denied"
+        case .inaccessible: return "Inaccessible"
+        case .enumerationFailure: return "Enumeration failure"
+        case .metadataFailure: return "Metadata failure"
+        case .differentVolumeBoundary: return "Filesystem boundary"
+        case .cancelled: return "Cancelled"
+        case .missingOptionalRoot: return "Missing optional root"
+        case .failedAnalyzer: return "Failed analyzer"
+        case .uncoveredFilesystemRegion: return "Uncovered filesystem region"
+        case .nonAdditiveAPFSStorage: return "Non-additive APFS storage"
+        case .possibleSharedExtentAccounting: return "Possible shared extents"
+        case .concurrentFilesystemChange: return "Path changed during analysis"
+        case .unknown: return "Unknown"
+        }
+    }
+}
+
+private extension StorageCanonicalRoot {
+    var displayName: String {
+        switch self {
+        case .userHomeVisibleStorage: return "User Files"
+        case .applicationSupport: return "Application Support"
+        case .containers: return "Containers"
+        case .groupContainers: return "Group Containers"
+        case .systemLibrary: return "System Library"
+        case .privateStorage: return "Private / System State"
+        case .dataVolumeHiddenStorage: return "Data-volume metadata"
+        case .opt: return "/opt"
+        case .usrLocal: return "/usr/local"
+        case .additionalCoverageGap: return "Additional Storage Coverage"
+        }
+    }
+}
+
+private extension StorageCoverageDiagnosticSource {
+    var displayName: String {
+        switch self {
+        case let .analyzer(stage): return stage.displayName
+        case let .canonicalRoot(root): return root.displayName
+        case .coverageDiscovery: return "Coverage discovery"
+        case .reconciliation: return "Storage reconciliation"
+        case .apfs: return "APFS metadata"
+        }
+    }
+}
+
+private extension StorageMeasurementConfidence {
+    var displayName: String {
+        switch self {
+        case .completeMeasurement: return "Measured"
+        case .knownLowerBound: return "Known lower bound"
+        case .partialCoverage: return "Partial coverage"
+        case .nonAdditiveMetadata: return "Non-additive"
+        case .unmeasured: return "Unmeasured"
+        }
+    }
+}
+
+private extension StorageAnalyzerDiagnosticState {
+    var displayName: String {
+        switch self {
+        case .complete: return "Complete"
+        case .knownLowerBound: return "Known lower bound"
+        case .failed: return "Failed"
+        case .cancelled: return "Cancelled"
+        case .optionalRootMissing: return "Optional root missing"
+        case .nonAdditiveMetadata: return "Non-additive metadata"
+        }
+    }
+}
+
+private extension StorageIntelligenceCategoryID {
+    var icon: String {
+        switch self {
+        case .userFiles: return "person.crop.circle.fill"
+        case .applicationSupport: return "app.badge.fill"
+        case .containers: return "shippingbox.fill"
+        case .groupContainers: return "square.stack.3d.up.fill"
+        case .systemLibrary: return "building.columns.fill"
+        case .privateSystemState: return "gearshape.2.fill"
+        case .hiddenData: return "eye.slash.fill"
+        case .developerThirdParty: return "hammer.fill"
+        case .docker: return "shippingbox.and.arrow.backward.fill"
+        case .apfs: return "internaldrive.fill"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .userFiles: return Tint.blue
+        case .applicationSupport: return Tint.purple
+        case .containers: return Tint.cyan
+        case .groupContainers: return Tint.pink
+        case .systemLibrary: return Tint.orange
+        case .privateSystemState: return Tint.yellow
+        case .hiddenData: return Tint.orange
+        case .developerThirdParty: return Tint.green
+        case .docker: return Tint.purple
+        case .apfs: return Tint.cyan
+        }
+    }
+}
+
+private extension StorageAnalyzerStage {
+    var displayName: String {
+        switch self {
+        case .apfsVolume: return "APFS volume"
+        case .userHomeStorage: return "user files"
+        case .applicationSupport: return "Application Support"
+        case .containers: return "containers"
+        case .groupContainers: return "group containers"
+        case .systemLibrary: return "System Library"
+        case .privateStorage: return "private system state"
+        case .dataVolumeHiddenStorage: return "hidden Data-volume storage"
+        case .developerSystemStorage: return "developer and third-party storage"
+        case .dockerStorage: return "Docker"
+        case .coverageExpansion: return "additional storage coverage"
+        }
+    }
+}
+
+private extension StorageAccessibility {
+    var displayName: String {
+        switch self {
+        case .accessible: return "Accessible"
+        case .partiallyAccessible: return "Partially accessible"
+        case .inaccessible: return "Inaccessible"
+        case .skippedDifferentVolume: return "Different mounted volume"
+        case .cancelled: return "Analysis cancelled"
+        }
+    }
+}
+
+private extension APFSSnapshotType {
+    var displayName: String {
+        switch self {
+        case .timeMachine: return "Time Machine"
+        case .operatingSystemUpdate: return "macOS update"
+        case .otherAPFS: return "Other APFS"
+        case .unknown: return "Unknown type"
+        }
+    }
+}

--- a/PureMac/Views/StorageIntelligence/StorageIntelligenceView.swift
+++ b/PureMac/Views/StorageIntelligence/StorageIntelligenceView.swift
@@ -51,6 +51,7 @@ struct StorageIntelligenceView: View {
                     diagnostic: diagnostic,
                     summary: state.summary,
                     attribution: state.attributionPresentation,
+                    physicalReconciliation: state.physicalReconciliationPresentation,
                     fullDiskAccessGranted: appState.hasFullDiskAccess,
                     dismiss: state.dismissDiagnostics
                 )
@@ -652,13 +653,15 @@ private struct StorageTreeNodeView: View {
             row
         } else {
             DisclosureGroup(isExpanded: $isExpanded) {
-                LazyVStack(spacing: 5) {
-                    ForEach(node.children) { child in
-                        StorageTreeNodeView(node: child, state: state)
+                if isExpanded {
+                    LazyVStack(spacing: 5) {
+                        ForEach(state.sortedChildren(of: node)) { child in
+                            StorageTreeNodeView(node: child, state: state)
+                        }
                     }
+                    .padding(.leading, 18)
+                    .padding(.top, 5)
                 }
-                .padding(.leading, 18)
-                .padding(.top, 5)
             } label: {
                 row
             }
@@ -1004,12 +1007,19 @@ private struct StorageCoverageDiagnosticsView: View {
     let diagnostic: StorageCoverageDiagnostic
     let summary: StorageSummaryPresentation?
     let attribution: StorageAttributionPresentation?
+    let physicalReconciliation: APFSPhysicalReconciliationPresentation?
     let fullDiskAccessGranted: Bool
     let dismiss: () -> Void
 
     var body: some View {
         NavigationStack {
             List {
+                if let physicalReconciliation {
+                    Section("APFS physical reconciliation") {
+                        apfsPhysicalReconciliationBreakdown(physicalReconciliation)
+                    }
+                }
+
                 if let attribution {
                     Section("Unexplained storage attribution") {
                         VStack(alignment: .leading, spacing: 6) {
@@ -1154,27 +1164,7 @@ private struct StorageCoverageDiagnosticsView: View {
                         Text("No structural coverage gaps were discovered.")
                             .foregroundStyle(.secondary)
                     } else {
-                        ForEach(diagnostic.coverageGaps) { gap in
-                            VStack(alignment: .leading, spacing: 3) {
-                                HStack {
-                                    Text(gap.name).fontWeight(.medium)
-                                    Spacer()
-                                    Text(gap.confidence.displayName)
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                }
-                                if let path = gap.absolutePath {
-                                    Text(path)
-                                        .font(.caption.monospaced())
-                                        .foregroundStyle(.secondary)
-                                        .textSelection(.enabled)
-                                }
-                                Text(gap.explanation)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            .padding(.vertical, 2)
-                        }
+                        coverageGapsBreakdown(diagnostic.coverageGaps)
                     }
                 }
 
@@ -1335,6 +1325,559 @@ private struct StorageCoverageDiagnosticsView: View {
             .clipShape(Capsule())
     }
 
+    private func coverageGapsBreakdown(_ gaps: [StorageCoverageGap]) -> some View {
+        let totalDiscovered = gaps.count
+        let measuredGaps = gaps.filter { $0.state == .measured && ($0.allocatedBytes ?? 0) > 0 }
+            .sorted { ($0.allocatedBytes ?? 0) > ($1.allocatedBytes ?? 0) }
+        let measuredBytes = measuredGaps.reduce(Int64(0)) { $0 + ($1.allocatedBytes ?? 0) }
+
+        let partialOrInaccessibleGaps = gaps.filter {
+            $0.state == .partiallyMeasured || $0.category == .permissionDenied || $0.category == .inaccessible
+        }
+
+        let alreadyAccountedGaps = gaps.filter {
+            $0.state == .measured && (($0.allocatedBytes == nil || $0.allocatedBytes == 0) || !$0.isFilesystemAdditive)
+        }
+
+        let stillUnmeasuredGaps = gaps.filter {
+            $0.state == .presentButUnmeasured || $0.state == .intentionallyUnmeasured || $0.state == .missingOptional
+        }
+
+        return VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Discovered")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text("\(totalDiscovered)")
+                        .font(.caption.weight(.semibold))
+                }
+                Spacer()
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Measured")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text("\(measuredGaps.count) (\(StorageValueFormatter.string(measuredBytes)))")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.green)
+                }
+                Spacer()
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Partial / Locked")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text("\(partialOrInaccessibleGaps.count)")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.orange)
+                }
+                Spacer()
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Unmeasured")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text("\(stillUnmeasuredGaps.count)")
+                        .font(.caption.weight(.semibold))
+                }
+            }
+            .padding(8)
+            .background(Color.secondary.opacity(0.08))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+
+            if !measuredGaps.isEmpty {
+                DisclosureGroup(isExpanded: .constant(true)) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        ForEach(measuredGaps) { gap in
+                            coverageGapRow(gap: gap, status: .measured)
+                        }
+                    }
+                    .padding(.top, 4)
+                } label: {
+                    HStack {
+                        Label("Measured gaps (\(measuredGaps.count))", systemImage: "checkmark.circle.fill")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.green)
+                        Spacer()
+                        Text(StorageValueFormatter.string(measuredBytes))
+                            .font(.subheadline.weight(.semibold).monospacedDigit())
+                    }
+                }
+            }
+
+            if !partialOrInaccessibleGaps.isEmpty {
+                DisclosureGroup {
+                    VStack(alignment: .leading, spacing: 6) {
+                        ForEach(partialOrInaccessibleGaps) { gap in
+                            let status: StorageAttributionStatus = gap.category == .permissionDenied ? .protectedUnreadable : .partial
+                            coverageGapRow(gap: gap, status: status)
+                        }
+                    }
+                    .padding(.top, 4)
+                } label: {
+                    Label("Partial & restricted access (\(partialOrInaccessibleGaps.count))", systemImage: "lock.shield")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.orange)
+                }
+            }
+
+            if !alreadyAccountedGaps.isEmpty {
+                DisclosureGroup {
+                    VStack(alignment: .leading, spacing: 6) {
+                        ForEach(alreadyAccountedGaps) { gap in
+                            coverageGapRow(gap: gap, status: .nonAdditive)
+                        }
+                    }
+                    .padding(.top, 4)
+                } label: {
+                    Label("Already accounted canonical roots (\(alreadyAccountedGaps.count))", systemImage: "arrow.triangle.merge")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.blue)
+                }
+            }
+
+            if !stillUnmeasuredGaps.isEmpty {
+                DisclosureGroup {
+                    VStack(alignment: .leading, spacing: 6) {
+                        ForEach(stillUnmeasuredGaps) { gap in
+                            coverageGapRow(gap: gap, status: .unknown)
+                        }
+                    }
+                    .padding(.top, 4)
+                } label: {
+                    Label("Intentionally unmeasured regions (\(stillUnmeasuredGaps.count))", systemImage: "questionmark.circle")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private func coverageGapRow(gap: StorageCoverageGap, status: StorageAttributionStatus) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(gap.name)
+                        .font(.caption.weight(.medium))
+                    gapStatusBadge(for: gap, defaultStatus: status)
+                }
+                if let path = gap.absolutePath {
+                    Text(path)
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+                Text(gap.explanation)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            if let allocated = gap.allocatedBytes, allocated > 0 {
+                VStack(alignment: .trailing, spacing: 1) {
+                    Text(StorageValueFormatter.string(allocated))
+                        .font(.caption.monospacedDigit().weight(.medium))
+                    if gap.isFilesystemAdditive {
+                        Text("Additive")
+                            .font(.caption2)
+                            .foregroundStyle(.green)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 3)
+        .padding(.horizontal, 6)
+        .background(Color.secondary.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func gapStatusBadge(for gap: StorageCoverageGap, defaultStatus: StorageAttributionStatus) -> some View {
+        let title: String
+        let tint: Color
+        switch gap.state {
+        case .measured:
+            title = "Measured"
+            tint = .green
+        case .partiallyMeasured:
+            title = "Partial"
+            tint = .orange
+        case .presentButUnmeasured, .intentionallyUnmeasured:
+            title = "Unmeasured"
+            tint = .secondary
+        case .missingOptional:
+            title = "Optional"
+            tint = .secondary
+        case .unavailable:
+            title = "Inaccessible"
+            tint = .purple
+        case .nonAdditive:
+            title = "Non-additive"
+            tint = .cyan
+        }
+
+        return Text(title)
+            .font(.caption2.weight(.medium))
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1.5)
+            .background(tint.opacity(0.15))
+            .foregroundColor(tint)
+            .clipShape(Capsule())
+    }
+
+    @ViewBuilder
+    private func apfsPhysicalReconciliationBreakdown(_ presentation: APFSPhysicalReconciliationPresentation) -> some View {
+        let rep = presentation.report
+        let m = rep.metrics
+
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Reconciliation of APFS physical container usage, sibling volumes, and filesystem-attributed bytes.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Physical Used")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(StorageValueFormatter.string(m.physicalVolumeUsedBytes))
+                        .font(.caption.weight(.semibold))
+                }
+                Spacer()
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Attributed")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(StorageValueFormatter.string(m.filesystemAttributedBytes))
+                        .font(.caption.weight(.semibold))
+                }
+                Spacer()
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Physical Gap")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(StorageValueFormatter.string(m.physicalAccountingGapBytes))
+                        .font(.caption.weight(.semibold))
+                }
+                Spacer()
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Purgeable")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(StorageValueFormatter.string(m.purgeableEstimateBytes))
+                        .font(.caption.weight(.semibold))
+                }
+            }
+            .padding(8)
+            .background(Color.secondary.opacity(0.08))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+
+            HStack(alignment: .top, spacing: 6) {
+                physicalStatusBadge(for: rep.status)
+                Text(rep.humanReadableInterpretation)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.top, 4)
+        }
+        .padding(.vertical, 2)
+
+        if let container = rep.container, !container.volumes.isEmpty {
+            DisclosureGroup {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Sibling APFS volumes sharing the same physical APFS container (\(container.containerReference)).")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    ForEach(container.volumes) { vol in
+                        HStack(alignment: .firstTextBaseline) {
+                            VStack(alignment: .leading, spacing: 2) {
+                                HStack(spacing: 6) {
+                                    Text(vol.name)
+                                        .fontWeight(.medium)
+                                    Text("(\(vol.role))")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Text(vol.deviceIdentifier)
+                                    .font(.caption2.monospaced())
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            if let bytes = vol.capacityInUseBytes {
+                                Text(StorageValueFormatter.string(bytes))
+                                    .font(.caption.weight(.semibold))
+                                    .monospacedDigit()
+                            } else {
+                                Text("—")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .padding(.vertical, 2)
+                    }
+
+                    if container.totalSiblingVolumeBytesOutsideData > 0 {
+                        HStack {
+                            Text("Total sibling volume footprint outside Data")
+                                .font(.caption.weight(.medium))
+                            Spacer()
+                            Text(StorageValueFormatter.string(container.totalSiblingVolumeBytesOutsideData))
+                                .font(.caption.weight(.bold))
+                                .monospacedDigit()
+                        }
+                        .padding(.top, 4)
+                    }
+                }
+            } label: {
+                HStack {
+                    Text("Container sibling volumes")
+                        .fontWeight(.medium)
+                    Spacer()
+                    Text(StorageValueFormatter.string(container.totalSiblingVolumeBytesOutsideData))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+
+        if let target = rep.targetVolume {
+            DisclosureGroup {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text("Volume Name:")
+                            .font(.caption.weight(.medium))
+                        Spacer()
+                        Text(target.name)
+                            .font(.caption)
+                    }
+                    HStack {
+                        Text("Mount Point:")
+                            .font(.caption.weight(.medium))
+                        Spacer()
+                        Text(target.mountPoint)
+                            .font(.caption.monospaced())
+                    }
+                    HStack {
+                        Text("Device Identifier:")
+                            .font(.caption.weight(.medium))
+                        Spacer()
+                        Text(target.deviceIdentifier)
+                            .font(.caption.monospaced())
+                    }
+                    if let inUse = target.capacityInUseBytes {
+                        HStack {
+                            Text("Reported In-Use Capacity:")
+                                .font(.caption.weight(.medium))
+                            Spacer()
+                            Text(StorageValueFormatter.string(inUse))
+                                .font(.caption.weight(.semibold))
+                        }
+                    }
+                    if let internalGap = m.dataVolumeInternalGapBytes {
+                        HStack {
+                            Text("Data Volume Internal Gap:")
+                                .font(.caption.weight(.medium))
+                            Spacer()
+                            Text(StorageValueFormatter.string(internalGap))
+                                .font(.caption.weight(.semibold))
+                        }
+                    }
+                }
+            } label: {
+                HStack {
+                    Text("Target Data-volume identity")
+                        .fontWeight(.medium)
+                    Spacer()
+                    Text(target.deviceIdentifier)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+
+        if rep.snapshots.snapshotCount > 0 || rep.snapshots.totalReportedSnapshotBytes != nil {
+            DisclosureGroup {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(rep.snapshots.explanation)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    HStack {
+                        Text("Local Snapshots:")
+                            .font(.caption.weight(.medium))
+                        Spacer()
+                        Text("\(rep.snapshots.snapshotCount)")
+                            .font(.caption)
+                    }
+                    if let snapBytes = rep.snapshots.totalReportedSnapshotBytes {
+                        HStack {
+                            Text("Reported Logical Size:")
+                                .font(.caption.weight(.medium))
+                            Spacer()
+                            Text(StorageValueFormatter.string(snapBytes))
+                                .font(.caption.weight(.semibold))
+                        }
+                    }
+                }
+            } label: {
+                HStack {
+                    Text("APFS snapshot evidence (non-additive)")
+                        .fontWeight(.medium)
+                    Spacer()
+                    Text("\(rep.snapshots.snapshotCount) snapshot\(rep.snapshots.snapshotCount == 1 ? "" : "s")")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+
+        if let gap = rep.dataVolumeInternalGap {
+            DisclosureGroup {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(gap.humanReadableInterpretation)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    VStack(spacing: 4) {
+                        if let inUse = gap.dataVolumePhysicalInUseBytes {
+                            HStack {
+                                Text("Data Volume Physical In-Use")
+                                    .font(.caption.weight(.medium))
+                                Spacer()
+                                Text(StorageValueFormatter.string(inUse))
+                                    .font(.caption.weight(.semibold))
+                                    .monospacedDigit()
+                            }
+                        }
+                        HStack {
+                            Text("Filesystem Attributed Blocks")
+                                .font(.caption.weight(.medium))
+                            Spacer()
+                            Text(StorageValueFormatter.string(gap.filesystemAttributedBytes))
+                                .font(.caption.weight(.semibold))
+                                .monospacedDigit()
+                        }
+                        if let intGap = gap.internalPhysicalGapBytes {
+                            HStack {
+                                Text("Internal Physical Accounting Gap")
+                                    .font(.caption.weight(.bold))
+                                Spacer()
+                                Text(StorageValueFormatter.string(intGap))
+                                    .font(.caption.weight(.bold))
+                                    .monospacedDigit()
+                            }
+                        }
+                    }
+                    .padding(6)
+                    .background(Color.secondary.opacity(0.06))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+
+                    Text("Evidence Waterfall")
+                        .font(.caption.weight(.bold))
+                        .padding(.top, 4)
+
+                    ForEach(gap.waterfallItems) { item in
+                        VStack(alignment: .leading, spacing: 2) {
+                            HStack {
+                                Text(item.title)
+                                    .font(.caption.weight(.medium))
+                                Spacer()
+                                waterfallTierBadge(for: item.tier, badgeText: item.badgeText)
+                                if let bytes = item.reportedBytes {
+                                    Text(StorageValueFormatter.string(bytes))
+                                        .font(.caption.weight(.semibold))
+                                        .monospacedDigit()
+                                } else {
+                                    Text("—")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            Text(item.explanation)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.vertical, 2)
+                    }
+
+                    if gap.allocationDeltaSummary.totalMeasuredAllocatedBytes > 0 {
+                        Text("Allocation vs Logical Size Diagnostic")
+                            .font(.caption.weight(.bold))
+                            .padding(.top, 4)
+
+                        Text(gap.allocationDeltaSummary.explanation)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if !gap.protectedSummary.families.isEmpty {
+                        Text("macOS Protected Storage Families (\(gap.protectedSummary.families.count))")
+                            .font(.caption.weight(.bold))
+                            .padding(.top, 4)
+
+                        ForEach(gap.protectedSummary.families) { family in
+                            HStack {
+                                Text(family.name)
+                                    .font(.caption)
+                                Spacer()
+                                Text("\(family.issueCount) path\(family.issueCount == 1 ? "" : "s")")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            } label: {
+                HStack {
+                    Text("Data Volume Internal Gap Waterfall")
+                        .fontWeight(.medium)
+                    Spacer()
+                    if let intGap = gap.internalPhysicalGapBytes {
+                        Text(StorageValueFormatter.string(intGap))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    private func waterfallTierBadge(for tier: DataVolumeGapEvidenceTier, badgeText: String) -> some View {
+        let tint: Color
+        switch tier {
+        case .measuredAdditive: tint = .green
+        case .measuredNonAdditive: tint = .cyan
+        case .estimatedOSReported: tint = .orange
+        case .presenceOnly: tint = .blue
+        case .unknownProtected: tint = .purple
+        }
+
+        return Text(badgeText)
+            .font(.caption2.weight(.medium))
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1.5)
+            .background(tint.opacity(0.15))
+            .foregroundColor(tint)
+            .clipShape(Capsule())
+    }
+
+    private func physicalStatusBadge(for status: APFSPhysicalReconciliationStatus) -> some View {
+        let tint: Color
+        switch status {
+        case .fullyReconciled: tint = .green
+        case .mostlyReconciled: tint = .blue
+        case .filesystemCoverageLimited: tint = .orange
+        case .apfsNonAdditiveFactorsPresent: tint = .cyan
+        case .protectedSystemStoragePresent: tint = .purple
+        case .physicalAccountingGapRemaining: tint = .secondary
+        case .insufficientEvidence: tint = .secondary
+        }
+
+        return Text(status.displayName)
+            .font(.caption2.weight(.medium))
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1.5)
+            .background(tint.opacity(0.15))
+            .foregroundColor(tint)
+            .clipShape(Capsule())
+    }
+
     private func badgeBackground(for status: StorageAttributionStatus) -> Color {
         switch status {
         case .measured: return Color.green.opacity(0.15)
@@ -1389,6 +1932,7 @@ private extension StorageCanonicalRoot {
     var displayName: String {
         switch self {
         case .userHomeVisibleStorage: return "User Files"
+        case .applications: return "Applications"
         case .applicationSupport: return "Application Support"
         case .containers: return "Containers"
         case .groupContainers: return "Group Containers"
@@ -1443,6 +1987,7 @@ private extension StorageIntelligenceCategoryID {
     var icon: String {
         switch self {
         case .userFiles: return "person.crop.circle.fill"
+        case .applications: return "app.fill"
         case .applicationSupport: return "app.badge.fill"
         case .containers: return "shippingbox.fill"
         case .groupContainers: return "square.stack.3d.up.fill"
@@ -1458,6 +2003,7 @@ private extension StorageIntelligenceCategoryID {
     var tint: Color {
         switch self {
         case .userFiles: return Tint.blue
+        case .applications: return Tint.blue
         case .applicationSupport: return Tint.purple
         case .containers: return Tint.cyan
         case .groupContainers: return Tint.pink
@@ -1476,6 +2022,7 @@ private extension StorageAnalyzerStage {
         switch self {
         case .apfsVolume: return "APFS volume"
         case .userHomeStorage: return "user files"
+        case .applications: return "Applications"
         case .applicationSupport: return "Application Support"
         case .containers: return "containers"
         case .groupContainers: return "group containers"

--- a/PureMacTests/APFSPhysicalReconciliationTests.swift
+++ b/PureMacTests/APFSPhysicalReconciliationTests.swift
@@ -1,0 +1,548 @@
+import XCTest
+@testable import PureMac
+
+final class APFSPhysicalReconciliationTests: XCTestCase {
+
+    // MARK: - Synthetic Plist Fixtures
+
+    var sampleAPFSListPlistData: Data {
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>Containers</key>
+            <array>
+                <dict>
+                    <key>ContainerReference</key>
+                    <string>disk3</string>
+                    <key>APFSContainerUUID</key>
+                    <string>CD821B99-B619-45BA-821B-F4F8541C2D0C</string>
+                    <key>CapacityCeiling</key>
+                    <integer>245107195904</integer>
+                    <key>CapacityFree</key>
+                    <integer>27908403200</integer>
+                    <key>PhysicalStores</key>
+                    <array>
+                        <dict>
+                            <key>DeviceIdentifier</key>
+                            <string>disk0s2</string>
+                        </dict>
+                    </array>
+                    <key>Volumes</key>
+                    <array>
+                        <dict>
+                            <key>Name</key>
+                            <string>mac - Data</string>
+                            <key>DeviceIdentifier</key>
+                            <string>disk3s1</string>
+                            <key>APFSVolumeUUID</key>
+                            <string>EECD899C-114C-463D-AC3E-6AAF250CC227</string>
+                            <key>Roles</key>
+                            <array>
+                                <string>Data</string>
+                            </array>
+                            <key>CapacityInUse</key>
+                            <integer>189653327872</integer>
+                            <key>Encryption</key>
+                            <true/>
+                            <key>FileVault</key>
+                            <true/>
+                        </dict>
+                        <dict>
+                            <key>Name</key>
+                            <string>mac</string>
+                            <key>DeviceIdentifier</key>
+                            <string>disk3s3</string>
+                            <key>APFSVolumeUUID</key>
+                            <string>5EF7CA72-BC09-4CC9-9205-DC2150647D3C</string>
+                            <key>Roles</key>
+                            <array>
+                                <string>System</string>
+                            </array>
+                            <key>CapacityInUse</key>
+                            <integer>12634509312</integer>
+                            <key>Encryption</key>
+                            <true/>
+                            <key>FileVault</key>
+                            <true/>
+                        </dict>
+                        <dict>
+                            <key>Name</key>
+                            <string>Preboot</string>
+                            <key>DeviceIdentifier</key>
+                            <string>disk3s4</string>
+                            <key>APFSVolumeUUID</key>
+                            <string>CDDE8855-314A-4A4A-BA0A-DC1C13B3F36A</string>
+                            <key>Roles</key>
+                            <array>
+                                <string>Preboot</string>
+                            </array>
+                            <key>CapacityInUse</key>
+                            <integer>9136005120</integer>
+                        </dict>
+                        <dict>
+                            <key>Name</key>
+                            <string>Recovery</string>
+                            <key>DeviceIdentifier</key>
+                            <string>disk3s5</string>
+                            <key>APFSVolumeUUID</key>
+                            <string>BC1E9A02-504F-48FE-9C78-44A973D05539</string>
+                            <key>Roles</key>
+                            <array>
+                                <string>Recovery</string>
+                            </array>
+                            <key>CapacityInUse</key>
+                            <integer>1300238336</integer>
+                        </dict>
+                        <dict>
+                            <key>Name</key>
+                            <string>VM</string>
+                            <key>DeviceIdentifier</key>
+                            <string>disk3s6</string>
+                            <key>APFSVolumeUUID</key>
+                            <string>EA313EA6-9491-48F9-915C-93249DF9CDD7</string>
+                            <key>Roles</key>
+                            <array>
+                                <string>VM</string>
+                            </array>
+                            <key>CapacityInUse</key>
+                            <integer>4295131136</integer>
+                        </dict>
+                    </array>
+                </dict>
+            </array>
+        </dict>
+        </plist>
+        """.data(using: .utf8)!
+    }
+
+    private func makeSyntheticReconciliationReport(
+        totalCapacity: Int64 = 245_107_195_904,
+        usedCapacity: Int64 = 217_198_792_704, // 245.1 - 27.9 GB = ~217.20 GB
+        explainedBytes: Int64 = 143_240_000_000,
+        purgeableBytes: Int64 = 20_000_000_000,
+        snapshots: [APFSSnapshotInformation] = []
+    ) -> StorageReconciliationReport {
+        let unexplained = max(0, usedCapacity - explainedBytes)
+        let apfsReport = APFSStorageReport(
+            volume: APFSVolumeInformation(
+                name: "mac - Data",
+                volumeIdentifier: "disk3s1",
+                volumeUUID: "EECD899C-114C-463D-AC3E-6AAF250CC227",
+                containerIdentifier: "disk3",
+                volumeGroupIdentifier: "EECD899C-114C-463D-AC3E-6AAF250CC227",
+                filesystemType: "apfs",
+                filesystemKind: .apfs,
+                mountPoint: "/System/Volumes/Data",
+                dataVolumeRelationship: .dataVolume,
+                capacity: APFSVolumeCapacity(
+                    totalCapacity: totalCapacity,
+                    availableCapacity: totalCapacity - usedCapacity,
+                    usedCapacity: usedCapacity,
+                    availableCapacityForImportantUsage: (totalCapacity - usedCapacity) + purgeableBytes,
+                    availableCapacityForOpportunisticUsage: (totalCapacity - usedCapacity) + purgeableBytes,
+                    purgeableEstimate: purgeableBytes,
+                    purgeableEstimateKnowledge: .estimated
+                )
+            ),
+            snapshots: snapshots,
+            state: .complete,
+            accountingRelationship: .volumeMetadataAndSnapshotsAreNonAdditiveToFilesystemTrees,
+            wasCancelled: false,
+            issues: []
+        )
+
+        var analyzerResults = StorageAnalyzerResults(
+            userHomeStorage: nil,
+            applicationSupport: nil,
+            containers: nil,
+            groupContainers: nil,
+            systemLibrary: nil,
+            privateStorage: nil,
+            dataVolumeHiddenStorage: nil,
+            developerSystemStorage: nil,
+            dockerStorage: nil,
+            apfsStorage: apfsReport,
+            coverageExpansion: nil,
+            physicalReconciliation: nil
+        )
+
+        let attributionReport = StorageUnexplainedAttributionReport(
+            volumeUsedBytes: usedCapacity,
+            explainedAllocatedBytes: explainedBytes,
+            unexplainedBytes: unexplained,
+            residualUnattributedBytes: unexplained,
+            dataVolumeRoots: [],
+            attributionItems: [
+                StorageAttributionItem(
+                    id: "vm.swap",
+                    category: .systemManagedStorage,
+                    name: "Virtual Memory Swap",
+                    status: .measured,
+                    allocatedBytes: 1_073_741_824,
+                    explanation: "macOS active swap files",
+                    isFilesystemAdditive: true
+                )
+            ],
+            vmFootprintBytes: 1_073_741_824,
+            sleepImageBytes: nil,
+            snapshotFootprintBytes: nil,
+            purgeableEstimateBytes: purgeableBytes,
+            wasCancelled: false,
+            issues: []
+        )
+
+        return StorageReconciliationReport(
+            totalCapacityBytes: totalCapacity,
+            usedCapacityBytes: usedCapacity,
+            availableCapacityBytes: totalCapacity - usedCapacity,
+            purgeableEstimateBytes: purgeableBytes,
+            explainedAllocatedBytes: explainedBytes,
+            unexplainedBytes: unexplained,
+            inaccessibleKnownLowerBoundBytes: 0,
+            unreadablePathCount: 0,
+            incompleteCoverage: false,
+            coverageStatus: .completeForConfiguredRoots,
+            canonicalRootCoverage: [],
+            filesystemContributions: [],
+            hardLinkAccountingStatus: .deduplicatedWithinAnalyzerScopesOnly,
+            analysisIssues: [],
+            analyzerResults: analyzerResults,
+            coverageDiagnostic: .empty,
+            attributionReport: attributionReport,
+            physicalReconciliation: nil,
+            startedAt: Date(),
+            completedAt: Date(),
+            duration: 1.0,
+            progress: StorageAnalysisProgress(totalStages: 11, completedStages: 11, runningStages: [], state: .completed),
+            wasCancelled: false
+        )
+    }
+
+    // MARK: - Tests
+
+    // 1. Correct physical-gap calculation
+    func testPhysicalGapCalculation() async {
+        let rep = makeSyntheticReconciliationReport(usedCapacity: 200_000_000_000, explainedBytes: 140_000_000_000)
+        let analyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(terminationStatus: 0, stdout: self.sampleAPFSListPlistData, stderr: Data(), launchError: nil, wasCancelled: false)
+        })
+
+        let report = await analyzer.analyze(reconciliationReport: rep)
+        XCTAssertEqual(report.metrics.physicalVolumeUsedBytes, 200_000_000_000)
+        XCTAssertEqual(report.metrics.filesystemAttributedBytes, 140_000_000_000)
+        XCTAssertEqual(report.metrics.physicalAccountingGapBytes, 60_000_000_000)
+    }
+
+    // 2. No double counting of purgeable capacity
+    func testPurgeableNotDoubleCounted() async {
+        let rep = makeSyntheticReconciliationReport(usedCapacity: 200_000_000_000, explainedBytes: 140_000_000_000, purgeableBytes: 25_000_000_000)
+        let analyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(terminationStatus: 0, stdout: self.sampleAPFSListPlistData, stderr: Data(), launchError: nil, wasCancelled: false)
+        })
+
+        let report = await analyzer.analyze(reconciliationReport: rep)
+        XCTAssertEqual(report.metrics.purgeableEstimateBytes, 25_000_000_000)
+        // Explained bytes must not be increased by purgeable bytes
+        XCTAssertEqual(report.metrics.filesystemAttributedBytes, 140_000_000_000)
+    }
+
+    // 3. Snapshots remain non-additive
+    func testSnapshotsRemainNonAdditive() async {
+        let snapshot = APFSSnapshotInformation(
+            identifier: "snap-1",
+            name: "com.apple.TimeMachine.2026-08-20",
+            uuid: "UUID-1",
+            creationDate: Date(),
+            size: 15_000_000_000,
+            sizeKnowledge: .reportedBySystem,
+            type: .timeMachine,
+            source: .tmutil,
+            storageRelationship: .sharedNonAdditive
+        )
+        let rep = makeSyntheticReconciliationReport(explainedBytes: 140_000_000_000, snapshots: [snapshot])
+        let analyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(terminationStatus: 0, stdout: self.sampleAPFSListPlistData, stderr: Data(), launchError: nil, wasCancelled: false)
+        })
+
+        let report = await analyzer.analyze(reconciliationReport: rep)
+        XCTAssertEqual(report.snapshots.snapshotCount, 1)
+        XCTAssertEqual(report.snapshots.totalReportedSnapshotBytes, 15_000_000_000)
+        XCTAssertTrue(report.snapshots.isNonAdditive)
+        XCTAssertEqual(report.metrics.filesystemAttributedBytes, 140_000_000_000)
+    }
+
+    // 4. Shared extent evidence remains non-additive
+    func testSharedExtentsRemainNonAdditive() async {
+        let analyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(terminationStatus: 0, stdout: self.sampleAPFSListPlistData, stderr: Data(), launchError: nil, wasCancelled: false)
+        })
+        let rep = makeSyntheticReconciliationReport()
+        let report = await analyzer.analyze(reconciliationReport: rep)
+        XCTAssertTrue(report.snapshots.explanation.contains("non-additive"))
+    }
+
+    // 5. Correct Data-volume identity selection
+    func testDataVolumeIdentitySelection() async {
+        let analyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(terminationStatus: 0, stdout: self.sampleAPFSListPlistData, stderr: Data(), launchError: nil, wasCancelled: false)
+        })
+        let rep = makeSyntheticReconciliationReport()
+        let report = await analyzer.analyze(reconciliationReport: rep)
+
+        guard let target = report.targetVolume else {
+            XCTFail("Target volume should not be nil")
+            return
+        }
+        XCTAssertEqual(target.name, "mac - Data")
+        XCTAssertEqual(target.deviceIdentifier, "disk3s1")
+        XCTAssertTrue(target.roles.contains("Data"))
+        XCTAssertEqual(target.capacityInUseBytes, 189_653_327_872)
+    }
+
+    // 6. System volume is not confused with Data volume
+    func testSystemVolumeDistinction() async {
+        let analyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(terminationStatus: 0, stdout: self.sampleAPFSListPlistData, stderr: Data(), launchError: nil, wasCancelled: false)
+        })
+        let rep = makeSyntheticReconciliationReport()
+        let report = await analyzer.analyze(reconciliationReport: rep)
+
+        XCTAssertNotEqual(report.targetVolume?.deviceIdentifier, "disk3s3")
+        XCTAssertNotEqual(report.targetVolume?.name, "mac")
+        XCTAssertEqual(report.targetVolume?.name, "mac - Data")
+        // Check sibling volumes list contains the System volume
+        XCTAssertTrue(report.container?.volumes.contains(where: { $0.deviceIdentifier == "disk3s3" && $0.role == "System" }) ?? false)
+    }
+
+    // 7. Command failure does not fail entire analysis
+    func testCommandFailureNonFatal() async {
+        let analyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(terminationStatus: 1, stdout: Data(), stderr: "Failed to query".data(using: .utf8)!, launchError: nil, wasCancelled: false)
+        })
+        let rep = makeSyntheticReconciliationReport()
+        let report = await analyzer.analyze(reconciliationReport: rep)
+
+        XCTAssertFalse(report.issues.isEmpty)
+        XCTAssertNotNil(report.metrics)
+        XCTAssertEqual(report.metrics.filesystemAttributedBytes, rep.explainedAllocatedBytes)
+    }
+
+    // 8. Missing snapshot information is handled safely
+    func testMissingSnapshotHandling() async {
+        let rep = makeSyntheticReconciliationReport(snapshots: [])
+        let analyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(terminationStatus: 0, stdout: self.sampleAPFSListPlistData, stderr: Data(), launchError: nil, wasCancelled: false)
+        })
+        let report = await analyzer.analyze(reconciliationReport: rep)
+
+        XCTAssertEqual(report.snapshots.snapshotCount, 0)
+        XCTAssertNil(report.snapshots.totalReportedSnapshotBytes)
+    }
+
+    // 9. VM evidence integration
+    func testVMStorageEvidenceIntegration() async {
+        let analyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(terminationStatus: 0, stdout: self.sampleAPFSListPlistData, stderr: Data(), launchError: nil, wasCancelled: false)
+        })
+        let rep = makeSyntheticReconciliationReport()
+        let report = await analyzer.analyze(reconciliationReport: rep)
+
+        XCTAssertEqual(report.systemManaged.vmFootprintBytes, 1_073_741_824)
+        XCTAssertEqual(report.systemManaged.swapFileBytes, 1_073_741_824)
+        XCTAssertEqual(report.systemManaged.vmVolumeBytes, 4_295_131_136)
+    }
+
+    // 10. Protected-system evidence integration
+    func testProtectedSystemEvidenceIntegration() async {
+        let analyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(terminationStatus: 0, stdout: self.sampleAPFSListPlistData, stderr: Data(), launchError: nil, wasCancelled: false)
+        })
+        let rep = makeSyntheticReconciliationReport()
+        let report = await analyzer.analyze(reconciliationReport: rep)
+
+        XCTAssertNotNil(report.protectedStorage)
+        XCTAssertEqual(report.protectedStorage.unreadablePathCount, 0)
+    }
+
+    // 11. Zero-gap case
+    func testZeroPhysicalGapCase() async {
+        let rep = makeSyntheticReconciliationReport(usedCapacity: 150_000_000_000, explainedBytes: 150_000_000_000, purgeableBytes: 0)
+        let analyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(terminationStatus: 0, stdout: self.sampleAPFSListPlistData, stderr: Data(), launchError: nil, wasCancelled: false)
+        })
+        let report = await analyzer.analyze(reconciliationReport: rep)
+
+        XCTAssertEqual(report.metrics.physicalAccountingGapBytes, 0)
+        XCTAssertEqual(report.status, .fullyReconciled)
+    }
+
+    // 12. Large-gap case
+    func testLargePhysicalGapCase() async {
+        let rep = makeSyntheticReconciliationReport(usedCapacity: 217_198_792_704, explainedBytes: 143_240_000_000)
+        let analyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(terminationStatus: 0, stdout: self.sampleAPFSListPlistData, stderr: Data(), launchError: nil, wasCancelled: false)
+        })
+        let report = await analyzer.analyze(reconciliationReport: rep)
+
+        XCTAssertEqual(report.metrics.physicalAccountingGapBytes, 73_958_792_704)
+        XCTAssertEqual(report.metrics.containerSiblingVolumesBytes, 27_365_883_904)
+        XCTAssertEqual(report.metrics.dataVolumeInternalGapBytes, 46_413_327_872)
+        XCTAssertEqual(report.status, .apfsNonAdditiveFactorsPresent)
+    }
+
+    // 13. Small discrepancy tolerance
+    func testTrivialDiscrepancyTolerance() {
+        let metrics = APFSPhysicalAccountingMetrics(
+            physicalVolumeUsedBytes: 100_030_000_000,
+            dataVolumePhysicalInUseBytes: 100_000_000_000,
+            filesystemAttributedBytes: 100_000_000_000,
+            containerSiblingVolumesBytes: 0,
+            physicalAccountingGapBytes: 30_000_000, // 30 MB (<= 50 MB)
+            dataVolumeInternalGapBytes: 0,
+            purgeableEstimateBytes: 0,
+            containerAccountingDiscrepancyBytes: 0
+        )
+        let status = APFSPhysicalReconciliationAnalyzer.classifyStatus(
+            metrics: metrics,
+            snapshotCount: 0,
+            purgeableBytes: 0,
+            protectedCount: 0,
+            unreadableCount: 0
+        )
+        XCTAssertEqual(status, .fullyReconciled)
+    }
+
+    // 14. Cancellation
+    func testCancellationSupport() async {
+        let analyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(terminationStatus: -1, stdout: Data(), stderr: Data(), launchError: nil, wasCancelled: true)
+        })
+        let rep = makeSyntheticReconciliationReport()
+        let report = await analyzer.analyze(reconciliationReport: rep)
+        XCTAssertTrue(report.issues.contains { $0.kind == .cancelled })
+    }
+
+    // 15. Deterministic classification
+    func testDeterministicClassification() {
+        // Case A: Coverage limited / unreadable
+        let metricsA = APFSPhysicalAccountingMetrics(
+            physicalVolumeUsedBytes: 200_000_000_000,
+            dataVolumePhysicalInUseBytes: 200_000_000_000,
+            filesystemAttributedBytes: 150_000_000_000,
+            containerSiblingVolumesBytes: 0,
+            physicalAccountingGapBytes: 50_000_000_000,
+            dataVolumeInternalGapBytes: 50_000_000_000,
+            purgeableEstimateBytes: 0,
+            containerAccountingDiscrepancyBytes: 0
+        )
+        let statusA = APFSPhysicalReconciliationAnalyzer.classifyStatus(
+            metrics: metricsA,
+            snapshotCount: 0,
+            purgeableBytes: 0,
+            protectedCount: 5,
+            unreadableCount: 10
+        )
+        XCTAssertEqual(statusA, .protectedSystemStoragePresent)
+
+        // Case B: APFS factors present (purgeable)
+        let statusB = APFSPhysicalReconciliationAnalyzer.classifyStatus(
+            metrics: metricsA,
+            snapshotCount: 0,
+            purgeableBytes: 5_000_000_000,
+            protectedCount: 0,
+            unreadableCount: 0
+        )
+        XCTAssertEqual(statusB, .apfsNonAdditiveFactorsPresent)
+    }
+
+    // 16. Existing explained-byte accounting remains unchanged
+    func testExistingExplainedBytesUnchanged() async {
+        let rep = makeSyntheticReconciliationReport(explainedBytes: 143_240_000_000)
+        let analyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(terminationStatus: 0, stdout: self.sampleAPFSListPlistData, stderr: Data(), launchError: nil, wasCancelled: false)
+        })
+        let report = await analyzer.analyze(reconciliationReport: rep)
+        XCTAssertEqual(report.metrics.filesystemAttributedBytes, 143_240_000_000)
+    }
+
+    // 17. Existing coverage-gap accounting remains unchanged
+    func testCoverageGapAccountingUnchanged() async {
+        let rep = makeSyntheticReconciliationReport()
+        XCTAssertEqual(rep.coverageDiagnostic.coverageGaps.count, 0)
+        let analyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(terminationStatus: 0, stdout: self.sampleAPFSListPlistData, stderr: Data(), launchError: nil, wasCancelled: false)
+        })
+        let report = await analyzer.analyze(reconciliationReport: rep)
+        XCTAssertNotNil(report)
+        XCTAssertEqual(rep.coverageDiagnostic.coverageGaps.count, 0)
+    }
+
+    // 18. No cleanup capability is exposed
+    func testNoCleanupCapabilityExposed() {
+        // Verify APFSPhysicalReconciliationReport does not have any mutating or destructive methods
+        let report = APFSPhysicalReconciliationReport.empty
+        XCTAssertEqual(report.status, .insufficientEvidence)
+        XCTAssertEqual(report.warnings.count, 0)
+    }
+
+    // 19. UI/state receives reconciliation report correctly
+    @MainActor
+    func testPresentationStateReceivesReport() async {
+        let rep = makeSyntheticReconciliationReport()
+        let analyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(terminationStatus: 0, stdout: self.sampleAPFSListPlistData, stderr: Data(), launchError: nil, wasCancelled: false)
+        })
+        let physicalReport = await analyzer.analyze(reconciliationReport: rep)
+
+        let finalReport = StorageReconciliationReport(
+            totalCapacityBytes: rep.totalCapacityBytes,
+            usedCapacityBytes: rep.usedCapacityBytes,
+            availableCapacityBytes: rep.availableCapacityBytes,
+            purgeableEstimateBytes: rep.purgeableEstimateBytes,
+            explainedAllocatedBytes: rep.explainedAllocatedBytes,
+            unexplainedBytes: rep.unexplainedBytes,
+            inaccessibleKnownLowerBoundBytes: rep.inaccessibleKnownLowerBoundBytes,
+            unreadablePathCount: rep.unreadablePathCount,
+            incompleteCoverage: rep.incompleteCoverage,
+            coverageStatus: rep.coverageStatus,
+            canonicalRootCoverage: rep.canonicalRootCoverage,
+            filesystemContributions: rep.filesystemContributions,
+            hardLinkAccountingStatus: rep.hardLinkAccountingStatus,
+            analysisIssues: rep.analysisIssues,
+            analyzerResults: rep.analyzerResults,
+            coverageDiagnostic: rep.coverageDiagnostic,
+            attributionReport: rep.attributionReport,
+            physicalReconciliation: physicalReport,
+            startedAt: rep.startedAt,
+            completedAt: rep.completedAt,
+            duration: rep.duration,
+            progress: rep.progress,
+            wasCancelled: rep.wasCancelled
+        )
+
+        let state = StorageIntelligenceState(
+            analysisRunner: { _ in finalReport }
+        )
+        state.analyze()
+        await state.waitForAnalysis()
+
+        XCTAssertNotNil(state.physicalReconciliationPresentation)
+        XCTAssertEqual(
+            state.physicalReconciliationPresentation?.report.metrics.physicalVolumeUsedBytes,
+            rep.usedCapacityBytes
+        )
+    }
+
+    // 20. Existing Storage Intelligence tests remain passing (Regression test integration)
+    func testFullRegressionPreserved() async {
+        let rep = makeSyntheticReconciliationReport()
+        let analyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(terminationStatus: 0, stdout: self.sampleAPFSListPlistData, stderr: Data(), launchError: nil, wasCancelled: false)
+        })
+        let report = await analyzer.analyze(reconciliationReport: rep)
+        XCTAssertNotNil(report)
+        XCTAssertEqual(report.metrics.containerSiblingVolumesBytes, 27_365_883_904)
+    }
+}

--- a/PureMacTests/APFSStorageAnalyzerTests.swift
+++ b/PureMacTests/APFSStorageAnalyzerTests.swift
@@ -1,0 +1,557 @@
+import XCTest
+@testable import PureMac
+
+final class APFSStorageAnalyzerTests: XCTestCase {
+    func testBasicVolumeCapacityAndUsedFreeCalculation() async {
+        let report = await makeAnalyzer(
+            statistics: statistics(total: 1_000, available: 350, important: 500)
+        ).analyze()
+
+        XCTAssertEqual(report.volume.capacity.totalCapacity, 1_000)
+        XCTAssertEqual(report.volume.capacity.availableCapacity, 350)
+        XCTAssertEqual(report.volume.capacity.usedCapacity, 650)
+    }
+
+    func testSharedPurgeableEstimateMatchesExistingFormula() {
+        let result = VolumeStatisticsProvider.calculate(
+            totalCapacity: 1_000,
+            availableCapacity: 300,
+            availableCapacityForImportantUsage: 475
+        )
+
+        XCTAssertEqual(result.purgeableEstimate, 175)
+        XCTAssertEqual(result.usedCapacity, 700)
+    }
+
+    func testExistingDiskInfoKeepsOriginalPurgeableThreshold() {
+        let aboveThreshold = VolumeStatisticsProvider.calculate(
+            totalCapacity: 100_000_000,
+            availableCapacity: 20_000_000,
+            availableCapacityForImportantUsage: 35_000_000
+        )
+        let belowThreshold = VolumeStatisticsProvider.calculate(
+            totalCapacity: 100_000_000,
+            availableCapacity: 20_000_000,
+            availableCapacityForImportantUsage: 25_000_000
+        )
+
+        XCTAssertEqual(ScanEngine.makeDiskInfo(from: aboveThreshold).purgeableSpace, 15_000_000)
+        XCTAssertEqual(ScanEngine.makeDiskInfo(from: belowThreshold).purgeableSpace, 0)
+    }
+
+    func testPurgeableEstimateIsExplicitlyEstimated() async {
+        let report = await makeAnalyzer(
+            statistics: statistics(total: 1_000, available: 300, important: 475)
+        ).analyze()
+
+        XCTAssertEqual(report.volume.capacity.purgeableEstimate, 175)
+        XCTAssertEqual(report.volume.capacity.purgeableEstimateKnowledge, .estimated)
+    }
+
+    func testPurgeableEstimateUnavailableWithoutImportantUsageCapacity() async {
+        let report = await makeAnalyzer(
+            statistics: statistics(total: 1_000, available: 300, important: nil)
+        ).analyze()
+
+        XCTAssertNil(report.volume.capacity.purgeableEstimate)
+        XCTAssertEqual(report.volume.capacity.purgeableEstimateKnowledge, .unavailable)
+    }
+
+    func testAPFSVolumeMetadataAndDataRelationship() async {
+        let info = plist([
+            "FilesystemType": "apfs",
+            "MountPoint": "/",
+            "VolumeName": "Macintosh HD - Data",
+            "DeviceIdentifier": "disk3s5",
+            "VolumeUUID": "VOL-UUID",
+            "APFSContainerReference": "disk3",
+            "APFSVolumeGroupID": "GROUP-UUID",
+            "Roles": ["Data"],
+        ])
+        let report = await makeAnalyzer(info: info).analyze()
+
+        XCTAssertEqual(report.volume.filesystemKind, .apfs)
+        XCTAssertEqual(report.volume.name, "Macintosh HD - Data")
+        XCTAssertEqual(report.volume.volumeIdentifier, "disk3s5")
+        XCTAssertEqual(report.volume.containerIdentifier, "disk3")
+        XCTAssertEqual(report.volume.dataVolumeRelationship, .dataVolume)
+    }
+
+    func testSystemVolumeRelationshipIsDiscoverable() async {
+        let info = plist([
+            "FilesystemType": "apfs",
+            "MountPoint": "/",
+            "APFSVolumeGroupID": "GROUP-UUID",
+            "Roles": ["System"],
+        ])
+        let report = await makeAnalyzer(info: info).analyze()
+
+        XCTAssertEqual(report.volume.dataVolumeRelationship, .systemVolume)
+    }
+
+    func testNonAPFSVolumeReturnsTypedStateWithoutSnapshotCommands() async {
+        let recorder = APFSCommandRecorder(responses: [
+            key(.diskInfo, mount: "/"): success(plist([
+                "FilesystemType": "hfs",
+                "MountPoint": "/",
+            ])),
+        ])
+        let analyzer = makeAnalyzer(recorder: recorder)
+        let report = await analyzer.analyze()
+        let requests = await recorder.requests
+
+        XCTAssertEqual(report.state, .nonAPFS)
+        XCTAssertEqual(report.volume.filesystemKind, .nonAPFS)
+        XCTAssertEqual(report.volume.dataVolumeRelationship, .notApplicable)
+        XCTAssertTrue(report.snapshots.isEmpty)
+        XCTAssertEqual(requests.count, 1)
+    }
+
+    func testNoSnapshotsIsAValidCompleteResult() async {
+        let report = await makeAnalyzer().analyze()
+
+        XCTAssertEqual(report.state, .complete)
+        XCTAssertTrue(report.snapshots.isEmpty)
+    }
+
+    func testTimeMachineSnapshotParsing() async {
+        let name = "com.apple.TimeMachine.2026-08-18-120000.local"
+        let report = await makeAnalyzer(tmutil: Data("Snapshots for disk /:\n\(name)\n".utf8))
+            .analyze()
+
+        XCTAssertEqual(report.snapshots.count, 1)
+        XCTAssertEqual(report.snapshots[0].name, name)
+        XCTAssertEqual(report.snapshots[0].type, .timeMachine)
+        XCTAssertEqual(report.snapshots[0].source, .tmutil)
+        XCTAssertNotNil(report.snapshots[0].creationDate)
+    }
+
+    func testAPFSPlistSnapshotParsesUUIDNameAndDate() async {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshots = plist(["Snapshots": [[
+            "SnapshotName": "com.example.snapshot",
+            "SnapshotUUID": "SNAP-UUID",
+            "SnapshotDate": date,
+        ]]])
+        let report = await makeAnalyzer(snapshots: snapshots).analyze()
+        let snapshot = try! XCTUnwrap(report.snapshots.first)
+
+        XCTAssertEqual(snapshot.identifier, "SNAP-UUID")
+        XCTAssertEqual(snapshot.name, "com.example.snapshot")
+        XCTAssertEqual(snapshot.uuid, "SNAP-UUID")
+        XCTAssertEqual(snapshot.creationDate, date)
+        XCTAssertEqual(snapshot.source, .diskutil)
+    }
+
+    func testSnapshotTypesRemainDistinct() async {
+        let snapshots = plist(["Snapshots": [
+            ["SnapshotName": "com.apple.TimeMachine.2026-08-18-120000.local"],
+            ["SnapshotName": "com.apple.os.update-123"],
+            ["SnapshotName": "com.vendor.backup"],
+        ]])
+        let report = await makeAnalyzer(snapshots: snapshots).analyze()
+        let types = Set(report.snapshots.map(\.type))
+
+        XCTAssertEqual(types, [.timeMachine, .operatingSystemUpdate, .otherAPFS])
+    }
+
+    func testTMUtilUnknownSnapshotTypeIsNotAssumedTimeMachine() async {
+        let report = await makeAnalyzer(
+            tmutil: Data("Snapshots for disk /:\ncom.apple.custom.snapshot\n".utf8)
+        ).analyze()
+
+        XCTAssertEqual(report.snapshots.first?.type, .unknown)
+    }
+
+    func testDuplicateSnapshotIsMergedAcrossSources() async {
+        let name = "com.apple.TimeMachine.2026-08-18-120000.local"
+        let snapshots = plist(["Snapshots": [[
+            "SnapshotName": name,
+            "SnapshotUUID": "SNAP-UUID",
+            "DataSize": 2_048,
+        ]]])
+        let tmutil = Data("Snapshots for disk /:\n\(name)\n".utf8)
+        let report = await makeAnalyzer(snapshots: snapshots, tmutil: tmutil).analyze()
+
+        XCTAssertEqual(report.snapshots.count, 1)
+        XCTAssertEqual(report.snapshots[0].source, .tmutilAndDiskutil)
+        XCTAssertEqual(report.snapshots[0].uuid, "SNAP-UUID")
+        XCTAssertEqual(report.snapshots[0].size, 2_048)
+    }
+
+    func testSnapshotWithoutReportedSizeRemainsUnknown() async {
+        let snapshots = plist(["Snapshots": [["SnapshotName": "com.example.snapshot"]]])
+        let report = await makeAnalyzer(snapshots: snapshots).analyze()
+        let snapshot = try! XCTUnwrap(report.snapshots.first)
+
+        XCTAssertNil(snapshot.size)
+        XCTAssertEqual(snapshot.sizeKnowledge, .unavailable)
+        XCTAssertEqual(snapshot.storageRelationship, .sizeUnavailable)
+    }
+
+    func testReliableSystemReportedSnapshotSizeIsPreserved() async {
+        let snapshots = plist(["Snapshots": [[
+            "SnapshotName": "com.example.snapshot",
+            "DataSize": 4_096,
+        ]]])
+        let report = await makeAnalyzer(snapshots: snapshots).analyze()
+        let snapshot = try! XCTUnwrap(report.snapshots.first)
+
+        XCTAssertEqual(snapshot.size, 4_096)
+        XCTAssertEqual(snapshot.sizeKnowledge, .reportedBySystem)
+        XCTAssertEqual(snapshot.storageRelationship, .sharedNonAdditive)
+    }
+
+    func testSnapshotAndVolumeAccountingIsExplicitlyNonAdditive() async {
+        let report = await makeAnalyzer(snapshots: plist(["Snapshots": [[
+            "SnapshotName": "com.example.snapshot",
+            "DataSize": 4_096,
+        ]]])).analyze()
+
+        XCTAssertEqual(
+            report.accountingRelationship,
+            .volumeMetadataAndSnapshotsAreNonAdditiveToFilesystemTrees
+        )
+        XCTAssertFalse(report.volume.capacity.usedCapacity == 604_096)
+    }
+
+    func testDiskutilInfoFailurePreservesFoundationVolumeStatistics() async {
+        let recorder = APFSCommandRecorder(responses: [
+            key(.diskInfo, mount: "/"): failure(status: 1),
+            key(.snapshots, mount: "/"): success(emptySnapshotPlist),
+            key(.tmutil, mount: "/"): success(emptyTMUtilOutput),
+        ])
+        let report = await makeAnalyzer(recorder: recorder).analyze()
+
+        XCTAssertEqual(report.volume.capacity.totalCapacity, 1_000)
+        XCTAssertEqual(report.volume.capacity.availableCapacity, 400)
+        XCTAssertEqual(report.state, .partial)
+        XCTAssertTrue(report.issues.contains { $0.source == "diskutil-info" })
+    }
+
+    func testTMUtilFailurePreservesDiskutilSnapshotData() async {
+        let snapshotData = plist(["Snapshots": [[
+            "SnapshotName": "com.example.snapshot",
+            "SnapshotUUID": "UUID",
+        ]]])
+        let recorder = APFSCommandRecorder(responses: [
+            key(.diskInfo, mount: "/"): success(defaultInfoPlist),
+            key(.snapshots, mount: "/"): success(snapshotData),
+            key(.tmutil, mount: "/"): failure(status: 1),
+        ])
+        let report = await makeAnalyzer(recorder: recorder).analyze()
+
+        XCTAssertEqual(report.snapshots.count, 1)
+        XCTAssertEqual(report.snapshots[0].uuid, "UUID")
+        XCTAssertEqual(report.state, .partial)
+    }
+
+    func testMalformedSnapshotPlistProducesTypedIssue() async {
+        let report = await makeAnalyzer(snapshots: Data("not a plist".utf8)).analyze()
+
+        XCTAssertEqual(report.state, .partial)
+        XCTAssertTrue(report.issues.contains {
+            $0.kind == .malformedPlist && $0.source == "diskutil-snapshots"
+        })
+    }
+
+    func testPartialDiskInfoMetadataProducesTypedIssue() async {
+        let report = await makeAnalyzer(info: plist(["FilesystemType": "apfs"])).analyze()
+
+        XCTAssertEqual(report.state, .partial)
+        XCTAssertTrue(report.issues.contains { $0.kind == .partialMetadata })
+        XCTAssertEqual(report.volume.mountPoint, "/")
+    }
+
+    func testPermissionFailureIsNormalizedWithoutRawStderr() async {
+        let secret = "permission denied for /Users/example/private-secret"
+        let recorder = APFSCommandRecorder(responses: [
+            key(.diskInfo, mount: "/"): success(defaultInfoPlist),
+            key(.snapshots, mount: "/"): failure(status: 77, stderr: secret),
+            key(.tmutil, mount: "/"): success(emptyTMUtilOutput),
+        ])
+        let report = await makeAnalyzer(recorder: recorder).analyze()
+        let issue = try! XCTUnwrap(report.issues.first { $0.kind == .permissionDenied })
+
+        XCTAssertFalse(issue.message.contains("private-secret"))
+        XCTAssertEqual(issue.source, "diskutil-snapshots")
+    }
+
+    func testCancellationStopsBeforeSubsequentCommands() async {
+        let runner = CancellingAPFSCommandRunner()
+        let volumeStatistics = statistics()
+        let analyzer = APFSStorageAnalyzer(
+            volumeStatisticsReader: { _ in volumeStatistics },
+            commandRunner: { request in await runner.run(request) }
+        )
+        let task = Task { await analyzer.analyze() }
+        await runner.waitUntilStarted()
+        task.cancel()
+        let report = await task.value
+        let requests = await runner.requests
+
+        XCTAssertTrue(report.wasCancelled)
+        XCTAssertEqual(report.state, .cancelled)
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertTrue(report.issues.contains { $0.kind == .cancelled })
+    }
+
+    func testGeneratedCommandsAreInspectionOnlyAndNeverPurge() async {
+        let recorder = defaultRecorder()
+        _ = await makeAnalyzer(recorder: recorder).analyze()
+        let requests = await recorder.requests
+        let allArguments = requests.flatMap(\.arguments).map { $0.lowercased() }
+
+        XCTAssertEqual(requests.count, 3)
+        XCTAssertFalse(allArguments.contains { argument in
+            ["delete", "purgepurgeable", "erase", "resize", "revert", "mount", "unmount"]
+                .contains(argument)
+        })
+        XCTAssertFalse(requests.contains { $0.executableURL.path.contains("sudo") })
+    }
+
+    func testCommandArgumentsPreserveInjectedMountPointAsOneLiteralArgument() async {
+        let mount = "/private/tmp/volume;$(touch should-not-run)"
+        let recorder = APFSCommandRecorder(responses: [
+            key(.diskInfo, mount: mount): success(defaultInfoPlist),
+            key(.snapshots, mount: mount): success(emptySnapshotPlist),
+            key(.tmutil, mount: mount): success(emptyTMUtilOutput),
+        ])
+        let analyzer = makeAnalyzer(
+            mountPoint: URL(fileURLWithPath: mount, isDirectory: true),
+            recorder: recorder
+        )
+        _ = await analyzer.analyze()
+        let requests = await recorder.requests
+
+        XCTAssertEqual(requests.map { $0.arguments.last }, [mount, "-plist", mount])
+        XCTAssertEqual(requests[1].arguments, ["apfs", "listSnapshots", mount, "-plist"])
+    }
+
+    func testCommandLaunchFailureUsesTypedIssue() async {
+        let recorder = APFSCommandRecorder(responses: [
+            key(.diskInfo, mount: "/"): launchFailure,
+            key(.snapshots, mount: "/"): launchFailure,
+            key(.tmutil, mount: "/"): launchFailure,
+        ])
+        let report = await makeAnalyzer(recorder: recorder).analyze()
+
+        XCTAssertEqual(report.state, .partial)
+        XCTAssertEqual(report.issues.filter { $0.kind == .commandUnavailable }.count, 3)
+    }
+
+    func testMalformedTMUtilOutputDoesNotDiscardDiskutilResults() async {
+        let snapshots = plist(["Snapshots": [["SnapshotName": "com.example.snapshot"]]])
+        let report = await makeAnalyzer(
+            snapshots: snapshots,
+            tmutil: Data("unexpected private output".utf8)
+        ).analyze()
+
+        XCTAssertEqual(report.snapshots.count, 1)
+        XCTAssertTrue(report.issues.contains { $0.kind == .malformedOutput })
+    }
+
+    func testDiskutilCapacityFillsMissingFoundationCapacity() async {
+        let stats = VolumeStatisticsReadResult(
+            statistics: VolumeStatisticsProvider.calculate(
+                totalCapacity: nil,
+                availableCapacity: nil,
+                availableCapacityForImportantUsage: nil
+            ),
+            issues: [.init(
+                kind: .capacityUnavailable,
+                message: "Complete total and available capacity values are unavailable."
+            )]
+        )
+        let info = plist([
+            "FilesystemType": "apfs",
+            "MountPoint": "/",
+            "TotalSize": 2_000,
+            "FreeSpace": 750,
+        ])
+        let report = await makeAnalyzer(statistics: stats, info: info).analyze()
+
+        XCTAssertEqual(report.volume.capacity.totalCapacity, 2_000)
+        XCTAssertEqual(report.volume.capacity.availableCapacity, 750)
+        XCTAssertEqual(report.volume.capacity.usedCapacity, 1_250)
+        XCTAssertEqual(report.state, .partial)
+    }
+}
+
+// MARK: - Fixtures
+
+private extension APFSStorageAnalyzerTests {
+    enum CommandKind { case diskInfo, snapshots, tmutil }
+
+    var defaultInfoPlist: Data {
+        plist([
+            "FilesystemType": "apfs",
+            "MountPoint": "/",
+            "VolumeName": "Macintosh HD - Data",
+            "DeviceIdentifier": "disk3s5",
+            "VolumeUUID": "VOL-UUID",
+            "APFSContainerReference": "disk3",
+            "APFSVolumeGroupID": "GROUP-UUID",
+            "Roles": ["Data"],
+        ])
+    }
+
+    var emptySnapshotPlist: Data { plist(["Snapshots": []]) }
+    var emptyTMUtilOutput: Data { Data("Snapshots for disk /:\n".utf8) }
+    var launchFailure: APFSCommandResult {
+        APFSCommandResult(
+            terminationStatus: -1,
+            stdout: Data(),
+            stderr: Data(),
+            launchError: "not found",
+            wasCancelled: false
+        )
+    }
+
+    func statistics(
+        total: Int64? = 1_000,
+        available: Int64? = 400,
+        important: Int64? = 500
+    ) -> VolumeStatisticsReadResult {
+        VolumeStatisticsReadResult(
+            statistics: VolumeStatisticsProvider.calculate(
+                totalCapacity: total,
+                availableCapacity: available,
+                availableCapacityForImportantUsage: important,
+                availableCapacityForOpportunisticUsage: 450,
+                volumeName: "Foundation Volume",
+                volumeIdentifier: "FOUNDATION-UUID",
+                filesystemDescription: "APFS",
+                mountPoint: "/"
+            ),
+            issues: []
+        )
+    }
+
+    func makeAnalyzer(
+        mountPoint: URL = URL(fileURLWithPath: "/", isDirectory: true),
+        statistics: VolumeStatisticsReadResult? = nil,
+        info: Data? = nil,
+        snapshots: Data? = nil,
+        tmutil: Data? = nil,
+        recorder: APFSCommandRecorder? = nil
+    ) -> APFSStorageAnalyzer {
+        let resolvedStatistics = statistics ?? self.statistics()
+        let resolvedInfo = info ?? defaultInfoPlist
+        let resolvedSnapshots = snapshots ?? emptySnapshotPlist
+        let resolvedTMUtil = tmutil ?? emptyTMUtilOutput
+        let commandRecorder = recorder ?? APFSCommandRecorder(responses: [
+            key(.diskInfo, mount: mountPoint.path): success(resolvedInfo),
+            key(.snapshots, mount: mountPoint.path): success(resolvedSnapshots),
+            key(.tmutil, mount: mountPoint.path): success(resolvedTMUtil),
+        ])
+        return APFSStorageAnalyzer(
+            mountPointURL: mountPoint,
+            volumeStatisticsReader: { _ in resolvedStatistics },
+            commandRunner: { request in await commandRecorder.run(request) }
+        )
+    }
+
+    func defaultRecorder() -> APFSCommandRecorder {
+        APFSCommandRecorder(responses: [
+            key(.diskInfo, mount: "/"): success(defaultInfoPlist),
+            key(.snapshots, mount: "/"): success(emptySnapshotPlist),
+            key(.tmutil, mount: "/"): success(emptyTMUtilOutput),
+        ])
+    }
+
+    func key(_ kind: CommandKind, mount: String) -> String {
+        let request: APFSCommandRequest
+        switch kind {
+        case .diskInfo:
+            request = APFSStorageAnalyzer.diskInfoRequest(
+                for: URL(fileURLWithPath: mount, isDirectory: true)
+            )
+        case .snapshots:
+            request = APFSStorageAnalyzer.diskSnapshotsRequest(
+                for: URL(fileURLWithPath: mount, isDirectory: true)
+            )
+        case .tmutil:
+            request = APFSStorageAnalyzer.timeMachineSnapshotsRequest(
+                for: URL(fileURLWithPath: mount, isDirectory: true)
+            )
+        }
+        return APFSCommandRecorder.key(request)
+    }
+
+    func success(_ stdout: Data) -> APFSCommandResult {
+        APFSCommandResult(
+            terminationStatus: 0,
+            stdout: stdout,
+            stderr: Data(),
+            launchError: nil,
+            wasCancelled: false
+        )
+    }
+
+    func failure(status: Int32, stderr: String = "failed") -> APFSCommandResult {
+        APFSCommandResult(
+            terminationStatus: status,
+            stdout: Data(),
+            stderr: Data(stderr.utf8),
+            launchError: nil,
+            wasCancelled: false
+        )
+    }
+
+    func plist(_ value: Any) -> Data {
+        try! PropertyListSerialization.data(
+            fromPropertyList: value,
+            format: .xml,
+            options: 0
+        )
+    }
+}
+
+private actor APFSCommandRecorder {
+    private let responses: [String: APFSCommandResult]
+    private(set) var requests: [APFSCommandRequest] = []
+
+    init(responses: [String: APFSCommandResult]) {
+        self.responses = responses
+    }
+
+    func run(_ request: APFSCommandRequest) -> APFSCommandResult {
+        requests.append(request)
+        return responses[Self.key(request)] ?? APFSCommandResult(
+            terminationStatus: 127,
+            stdout: Data(),
+            stderr: Data("missing test response".utf8),
+            launchError: nil,
+            wasCancelled: false
+        )
+    }
+
+    static func key(_ request: APFSCommandRequest) -> String {
+        ([request.executableURL.path] + request.arguments).joined(separator: "\u{0}")
+    }
+}
+
+private actor CancellingAPFSCommandRunner {
+    private(set) var requests: [APFSCommandRequest] = []
+    private var started = false
+
+    func run(_ request: APFSCommandRequest) async -> APFSCommandResult {
+        requests.append(request)
+        started = true
+        while !Task.isCancelled {
+            await Task.yield()
+        }
+        return APFSCommandResult(
+            terminationStatus: -1,
+            stdout: Data(),
+            stderr: Data(),
+            launchError: nil,
+            wasCancelled: true
+        )
+    }
+
+    func waitUntilStarted() async {
+        while !started { await Task.yield() }
+    }
+}

--- a/PureMacTests/ApplicationSupportAnalyzerTests.swift
+++ b/PureMacTests/ApplicationSupportAnalyzerTests.swift
@@ -1,0 +1,279 @@
+import Darwin
+import XCTest
+@testable import PureMac
+
+final class ApplicationSupportAnalyzerTests: XCTestCase {
+    func testAnalyzesMultipleFoldersAndSortsLargestAllocatedSizeFirst() async throws {
+        let temporaryDirectory = try ApplicationSupportTestDirectory()
+        try makeApplicationFolder(named: "Small", fileSize: 4_096, in: temporaryDirectory.url)
+        try makeApplicationFolder(named: "Medium", fileSize: 131_072, in: temporaryDirectory.url)
+        try makeApplicationFolder(named: "Large", fileSize: 2_097_152, in: temporaryDirectory.url)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+        let entries = result.root.children
+
+        XCTAssertEqual(entries.map(\.name), ["Large", "Medium", "Small"])
+        XCTAssertTrue(zip(entries, entries.dropFirst()).allSatisfy {
+            $0.allocatedSize >= $1.allocatedSize
+        })
+        XCTAssertEqual(result.root.metadata.storageCategoryIdentifier, "application-support")
+        XCTAssertEqual(
+            result.root.metadata.attributes[ApplicationSupportAnalyzer.MetadataKey.directChildCount],
+            "3"
+        )
+    }
+
+    func testIncludesHiddenFoldersAndAddsConservativeAttributionAndLargeMetadata() async throws {
+        let temporaryDirectory = try ApplicationSupportTestDirectory()
+        let attributedFolder = try makeApplicationFolder(
+            named: "com.example.editor",
+            fileSize: 16_384,
+            in: temporaryDirectory.url
+        )
+        let hiddenFolder = try makeApplicationFolder(
+            named: ".internal-state",
+            fileSize: 1_024,
+            in: temporaryDirectory.url
+        )
+
+        let analyzer = ApplicationSupportAnalyzer(
+            applicationSupportURL: temporaryDirectory.url,
+            largeAllocatedSizeThreshold: 1,
+            attributionProvider: { directoryName in
+                guard directoryName == "com.example.editor" else { return nil }
+                return .init(
+                    bundleIdentifier: "com.example.editor",
+                    displayName: "Example Editor"
+                )
+            }
+        )
+        let result = await analyzer.analyze()
+        let attributedNode = try XCTUnwrap(node(at: attributedFolder.path, in: result.root))
+        let hiddenNode = try XCTUnwrap(node(at: hiddenFolder.path, in: result.root))
+
+        XCTAssertTrue(hiddenNode.isHidden)
+        XCTAssertEqual(attributedNode.metadata.owningApplicationIdentifier, "com.example.editor")
+        XCTAssertEqual(attributedNode.metadata.owningApplicationName, "Example Editor")
+        XCTAssertEqual(attributedNode.metadata.confidence, 1)
+        XCTAssertEqual(attributedNode.metadata.isUnusuallyLarge, true)
+        XCTAssertNil(attributedNode.metadata.safetyClassificationIdentifier)
+        XCTAssertEqual(
+            attributedNode.metadata.attributes[ApplicationSupportAnalyzer.MetadataKey.directChildCount],
+            "1"
+        )
+        XCTAssertNil(hiddenNode.metadata.owningApplicationIdentifier)
+        XCTAssertNil(hiddenNode.metadata.owningApplicationName)
+    }
+
+    func testPreservesSparseVirtualDiskLogicalAndAllocatedSizes() async throws {
+        let temporaryDirectory = try ApplicationSupportTestDirectory()
+        let appFolder = temporaryDirectory.url.appendingPathComponent("Virtualizer", isDirectory: true)
+        try FileManager.default.createDirectory(at: appFolder, withIntermediateDirectories: false)
+        let virtualDisk = appFolder.appendingPathComponent("machine.qcow2")
+        XCTAssertTrue(FileManager.default.createFile(atPath: virtualDisk.path, contents: nil))
+
+        let logicalByteCount: UInt64 = 32 * 1_024 * 1_024
+        let handle = try FileHandle(forWritingTo: virtualDisk)
+        try handle.truncate(atOffset: logicalByteCount)
+        try handle.close()
+
+        let expected = try applicationSupportStatValues(for: virtualDisk.path)
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+        let appNode = try XCTUnwrap(node(at: appFolder.path, in: result.root))
+        let diskNode = try XCTUnwrap(node(at: virtualDisk.path, in: result.root))
+
+        XCTAssertEqual(diskNode.ownLogicalSize, expected.logical)
+        XCTAssertEqual(diskNode.ownAllocatedSize, expected.allocated)
+        XCTAssertEqual(diskNode.ownLogicalSize, Int64(logicalByteCount))
+        XCTAssertEqual(
+            appNode.metadata.attributes[ApplicationSupportAnalyzer.MetadataKey.virtualDiskImageCount],
+            "1"
+        )
+
+        if diskNode.ownAllocatedSize >= diskNode.ownLogicalSize {
+            throw XCTSkip("The test filesystem eagerly allocated the sparse virtual disk.")
+        }
+    }
+
+    func testUnreadableFolderRemainsVisibleWithPermissionIssue() async throws {
+        guard geteuid() != 0 else {
+            throw XCTSkip("A root process can read mode-000 test directories.")
+        }
+
+        let temporaryDirectory = try ApplicationSupportTestDirectory()
+        let unreadableFolder = try makeApplicationFolder(
+            named: "UnreadableApp",
+            fileSize: 128,
+            in: temporaryDirectory.url
+        )
+        XCTAssertEqual(chmod(unreadableFolder.path, 0), 0)
+        defer { _ = chmod(unreadableFolder.path, mode_t(S_IRWXU)) }
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+        let unreadableNode = try XCTUnwrap(node(at: unreadableFolder.path, in: result.root))
+
+        XCTAssertEqual(unreadableNode.accessibility, .inaccessible)
+        XCTAssertTrue(unreadableNode.children.isEmpty)
+        XCTAssertTrue(unreadableNode.scanIssues.contains { $0.kind == .permissionDenied })
+        XCTAssertTrue(result.issues.contains {
+            $0.path == unreadableFolder.path && $0.kind == .permissionDenied
+        })
+    }
+
+    func testSymbolicLinkIsNotFollowed() async throws {
+        let temporaryDirectory = try ApplicationSupportTestDirectory()
+        let outsideDirectory = try ApplicationSupportTestDirectory()
+        let outsideFile = outsideDirectory.url.appendingPathComponent("outside.dat")
+        try Data(repeating: 0x41, count: 1_048_576).write(to: outsideFile)
+        let link = temporaryDirectory.url.appendingPathComponent("ExternalData")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outsideDirectory.url)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+        let linkNode = try XCTUnwrap(node(at: link.path, in: result.root))
+
+        XCTAssertEqual(linkNode.itemType, .symbolicLink)
+        XCTAssertTrue(linkNode.isSymbolicLink)
+        XCTAssertTrue(linkNode.children.isEmpty)
+        XCTAssertNil(node(at: outsideFile.path, in: result.root))
+        XCTAssertLessThan(result.root.logicalSize, 1_048_576)
+    }
+
+    func testCancellationReturnsPartialMarkedAnalysis() async throws {
+        let temporaryDirectory = try ApplicationSupportTestDirectory()
+        for index in 0..<300 {
+            try makeApplicationFolder(
+                named: "Application-\(index)",
+                fileSize: 64,
+                in: temporaryDirectory.url
+            )
+        }
+
+        let analyzer = makeAnalyzer(
+            root: temporaryDirectory.url,
+            scanner: FileTreeScanner(configuration: .init(maxConcurrentDirectoryReads: 1))
+        )
+        let analysisTask = Task { await analyzer.analyze() }
+        analysisTask.cancel()
+        let result = await analysisTask.value
+
+        XCTAssertTrue(result.wasCancelled)
+        XCTAssertTrue(result.issues.contains { $0.kind == .cancelled })
+        XCTAssertNotEqual(result.root.accessibility, .accessible)
+    }
+
+    func testHardLinksAreNotDoubleCounted() async throws {
+        let temporaryDirectory = try ApplicationSupportTestDirectory()
+        let appFolder = temporaryDirectory.url.appendingPathComponent("LinkedDataApp", isDirectory: true)
+        try FileManager.default.createDirectory(at: appFolder, withIntermediateDirectories: false)
+        let original = appFolder.appendingPathComponent("original.dat")
+        let hardLink = appFolder.appendingPathComponent("linked.dat")
+        try Data(repeating: 0x51, count: 8_192).write(to: original)
+        try FileManager.default.linkItem(at: original, to: hardLink)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+        let appNode = try XCTUnwrap(node(at: appFolder.path, in: result.root))
+        let originalNode = try XCTUnwrap(node(at: original.path, in: result.root))
+        let hardLinkNode = try XCTUnwrap(node(at: hardLink.path, in: result.root))
+        let linkedNodes = [originalNode, hardLinkNode]
+
+        XCTAssertEqual(linkedNodes.filter(\.isCountedInParentTotals).count, 1)
+        XCTAssertEqual(
+            appNode.logicalSize,
+            appNode.ownLogicalSize + originalNode.ownLogicalSize
+        )
+        XCTAssertEqual(
+            appNode.allocatedSize,
+            appNode.ownAllocatedSize + originalNode.ownAllocatedSize
+        )
+        XCTAssertEqual(result.root.logicalSize, result.root.ownLogicalSize + appNode.logicalSize)
+        XCTAssertEqual(result.root.allocatedSize, result.root.ownAllocatedSize + appNode.allocatedSize)
+    }
+
+    func testEmptyApplicationSupportDirectoryReturnsNoEntries() async throws {
+        let temporaryDirectory = try ApplicationSupportTestDirectory()
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertFalse(result.wasCancelled)
+        XCTAssertEqual(result.root.itemType, .directory)
+        XCTAssertEqual(result.root.accessibility, .accessible)
+        XCTAssertTrue(result.root.children.isEmpty)
+        XCTAssertEqual(
+            result.root.metadata.attributes[ApplicationSupportAnalyzer.MetadataKey.directChildCount],
+            "0"
+        )
+    }
+
+    func testMissingApplicationSupportDirectoryReturnsUnavailableResult() async {
+        let missingDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMac-Missing-Application-Support-\(UUID().uuidString)", isDirectory: true)
+
+        let result = await makeAnalyzer(root: missingDirectory).analyze()
+
+        XCTAssertEqual(result.root.absolutePath, missingDirectory.standardizedFileURL.path)
+        XCTAssertEqual(result.root.itemType, .unknown)
+        XCTAssertEqual(result.root.accessibility, .inaccessible)
+        XCTAssertTrue(result.root.children.isEmpty)
+        XCTAssertTrue(result.issues.contains { $0.kind == .metadataUnavailable })
+        XCTAssertEqual(result.root.metadata.storageCategoryIdentifier, "application-support")
+    }
+}
+
+private final class ApplicationSupportTestDirectory {
+    let url: URL
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMac-ApplicationSupportAnalyzerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+private func makeAnalyzer(
+    root: URL,
+    scanner: FileTreeScanner = FileTreeScanner()
+) -> ApplicationSupportAnalyzer {
+    ApplicationSupportAnalyzer(
+        applicationSupportURL: root,
+        scanner: scanner,
+        attributionProvider: { _ in nil }
+    )
+}
+
+@discardableResult
+private func makeApplicationFolder(
+    named name: String,
+    fileSize: Int,
+    in root: URL
+) throws -> URL {
+    let folder = root.appendingPathComponent(name, isDirectory: true)
+    try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: false)
+    try Data(repeating: UInt8(fileSize % 251), count: fileSize).write(
+        to: folder.appendingPathComponent("payload.dat")
+    )
+    return folder
+}
+
+private func node(at path: String, in root: StorageNode) -> StorageNode? {
+    var pending = [root]
+    while let candidate = pending.popLast() {
+        if candidate.absolutePath == path { return candidate }
+        pending.append(contentsOf: candidate.children)
+    }
+    return nil
+}
+
+private func applicationSupportStatValues(for path: String) throws -> (logical: Int64, allocated: Int64) {
+    var metadata = stat()
+    guard lstat(path, &metadata) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: Darwin.errno) ?? .EIO)
+    }
+    return (
+        logical: Int64(metadata.st_size),
+        allocated: Int64(metadata.st_blocks) * 512
+    )
+}

--- a/PureMacTests/ApplicationsStorageAnalyzerTests.swift
+++ b/PureMacTests/ApplicationsStorageAnalyzerTests.swift
@@ -1,0 +1,382 @@
+import XCTest
+@testable import PureMac
+
+final class ApplicationsStorageAnalyzerTests: XCTestCase {
+    private var temporaryDirectoryURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        temporaryDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMacApplicationsTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryDirectoryURL, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let temporaryDirectoryURL, FileManager.default.fileExists(atPath: temporaryDirectoryURL.path) {
+            try? FileManager.default.removeItem(at: temporaryDirectoryURL)
+        }
+        temporaryDirectoryURL = nil
+        try super.tearDownWithError()
+    }
+
+    // 1. Normal Applications hierarchy
+    func testNormalApplicationsHierarchy() async throws {
+        let app1URL = temporaryDirectoryURL.appendingPathComponent("TestApp.app", isDirectory: true)
+        let app2URL = temporaryDirectoryURL.appendingPathComponent("Utilities", isDirectory: true)
+        try FileManager.default.createDirectory(at: app1URL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: app2URL, withIntermediateDirectories: true)
+
+        let file1 = app1URL.appendingPathComponent("binary")
+        try "AppBinaryContent".write(to: file1, atomically: true, encoding: .utf8)
+
+        let analyzer = ApplicationsStorageAnalyzer(applicationsURL: temporaryDirectoryURL)
+        let result = await analyzer.analyze()
+
+        XCTAssertEqual(result.root.children.count, 2)
+        XCTAssertEqual(result.root.metadata.storageCategoryIdentifier, "applications")
+        XCTAssertFalse(result.wasCancelled)
+    }
+
+    // 2. Allocated-byte accounting (st_blocks * 512)
+    func testAllocatedByteAccounting() async throws {
+        let appURL = temporaryDirectoryURL.appendingPathComponent("MyCalc.app", isDirectory: true)
+        try FileManager.default.createDirectory(at: appURL, withIntermediateDirectories: true)
+        let fileURL = appURL.appendingPathComponent("executable")
+        let data = Data(repeating: 0x42, count: 8192)
+        try data.write(to: fileURL)
+
+        let analyzer = ApplicationsStorageAnalyzer(applicationsURL: temporaryDirectoryURL)
+        let result = await analyzer.analyze()
+
+        let appNode = result.root.children.first { $0.name == "MyCalc.app" }
+        XCTAssertNotNil(appNode)
+        XCTAssertGreaterThan(appNode?.allocatedSize ?? 0, 0)
+        XCTAssertGreaterThanOrEqual(appNode?.logicalSize ?? 0, Int64(data.count))
+        // Descendants must not be materialized into the returned StorageNode tree
+        XCTAssertEqual(appNode?.children.count, 0)
+    }
+
+    // 3. Logical vs allocated size distinction
+    func testLogicalVsAllocatedDistinction() async throws {
+        let appURL = temporaryDirectoryURL.appendingPathComponent("Sample.app", isDirectory: true)
+        try FileManager.default.createDirectory(at: appURL, withIntermediateDirectories: true)
+        let fileURL = appURL.appendingPathComponent("small.txt")
+        try "Hi".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let analyzer = ApplicationsStorageAnalyzer(applicationsURL: temporaryDirectoryURL)
+        let result = await analyzer.analyze()
+
+        let appNode = result.root.children.first { $0.name == "Sample.app" }
+        XCTAssertNotNil(appNode)
+        XCTAssertGreaterThanOrEqual(appNode?.logicalSize ?? 0, 2)
+        XCTAssertGreaterThanOrEqual(appNode?.allocatedSize ?? 0, appNode?.logicalSize ?? 0)
+        XCTAssertEqual(appNode?.children.count, 0)
+    }
+
+    // 4. Hidden descendants included
+    func testHiddenDescendantsIncluded() async throws {
+        let appURL = temporaryDirectoryURL.appendingPathComponent("HiddenTest.app", isDirectory: true)
+        try FileManager.default.createDirectory(at: appURL, withIntermediateDirectories: true)
+        let hiddenFile = appURL.appendingPathComponent(".hidden_config")
+        try "SecretConfig".write(to: hiddenFile, atomically: true, encoding: .utf8)
+
+        let analyzer = ApplicationsStorageAnalyzer(applicationsURL: temporaryDirectoryURL)
+        let result = await analyzer.analyze()
+
+        let appNode = result.root.children.first { $0.name == "HiddenTest.app" }
+        XCTAssertNotNil(appNode)
+        XCTAssertGreaterThan(appNode?.allocatedSize ?? 0, 0)
+        XCTAssertEqual(appNode?.children.count, 0)
+    }
+
+    // 5. Hard-link deduplication
+    func testHardLinkDeduplication() async throws {
+        let appURL = temporaryDirectoryURL.appendingPathComponent("HardLink.app", isDirectory: true)
+        try FileManager.default.createDirectory(at: appURL, withIntermediateDirectories: true)
+        let file1 = appURL.appendingPathComponent("original.bin")
+        let file2 = appURL.appendingPathComponent("linked.bin")
+        let data = Data(repeating: 0x55, count: 4096)
+        try data.write(to: file1)
+        link(file1.path, file2.path)
+
+        let analyzer = ApplicationsStorageAnalyzer(applicationsURL: temporaryDirectoryURL)
+        let result = await analyzer.analyze()
+
+        // Hard linked file must be counted once in parent allocated totals
+        let appNode = result.root.children.first { $0.name == "HardLink.app" }
+        XCTAssertNotNil(appNode)
+        XCTAssertEqual(appNode?.children.count, 0)
+        XCTAssertEqual(appNode?.allocatedSize, result.root.allocatedSize)
+    }
+
+    // 6. Symlink safety (no traversing targets)
+    func testSymlinkSafety() async throws {
+        let appURL = temporaryDirectoryURL.appendingPathComponent("Symlink.app", isDirectory: true)
+        try FileManager.default.createDirectory(at: appURL, withIntermediateDirectories: true)
+        let targetDir = temporaryDirectoryURL.appendingPathComponent("TargetFolder", isDirectory: true)
+        try FileManager.default.createDirectory(at: targetDir, withIntermediateDirectories: true)
+        let targetFile = targetDir.appendingPathComponent("large.bin")
+        try Data(repeating: 0x99, count: 100_000).write(to: targetFile)
+
+        let linkURL = appURL.appendingPathComponent("link_to_target")
+        try FileManager.default.createSymbolicLink(at: linkURL, withDestinationURL: targetDir)
+
+        let analyzer = ApplicationsStorageAnalyzer(applicationsURL: temporaryDirectoryURL)
+        let result = await analyzer.analyze()
+
+        let appNode = result.root.children.first { $0.name == "Symlink.app" }
+        XCTAssertNotNil(appNode)
+        XCTAssertEqual(appNode?.children.count, 0)
+        // Symlink target is not traversed, so app size must not include 100KB target file
+        XCTAssertLessThan(appNode?.allocatedSize ?? 0, 50_000)
+    }
+
+    // 7. Volume boundary preservation
+    func testVolumeBoundaryPreservation() async throws {
+        let analyzer = ApplicationsStorageAnalyzer(applicationsURL: temporaryDirectoryURL)
+        let result = await analyzer.analyze()
+
+        XCTAssertNotNil(result.rootDeviceIdentifier)
+    }
+
+    // 8. Missing root handling
+    func testMissingRootHandling() async {
+        let nonExistentURL = temporaryDirectoryURL.appendingPathComponent("DoesNotExist", isDirectory: true)
+        let analyzer = ApplicationsStorageAnalyzer(applicationsURL: nonExistentURL)
+        let result = await analyzer.analyze()
+
+        XCTAssertEqual(result.root.allocatedSize, 0)
+        XCTAssertEqual(result.root.children.count, 0)
+        XCTAssertFalse(result.wasCancelled)
+    }
+
+    // 9. Application category metadata
+    func testApplicationCategoryMetadata() async throws {
+        let xcodeURL = temporaryDirectoryURL.appendingPathComponent("Xcode.app", isDirectory: true)
+        let utilsURL = temporaryDirectoryURL.appendingPathComponent("Utilities", isDirectory: true)
+        let normalURL = temporaryDirectoryURL.appendingPathComponent("App.app", isDirectory: true)
+
+        try FileManager.default.createDirectory(at: xcodeURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: utilsURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: normalURL, withIntermediateDirectories: true)
+
+        let analyzer = ApplicationsStorageAnalyzer(applicationsURL: temporaryDirectoryURL)
+        let result = await analyzer.analyze()
+
+        let xcodeNode = result.root.children.first { $0.name == "Xcode.app" }
+        let utilsNode = result.root.children.first { $0.name == "Utilities" }
+        let normalNode = result.root.children.first { $0.name == "App.app" }
+
+        XCTAssertEqual(xcodeNode?.metadata.storageCategoryIdentifier, ApplicationsStorageCategory.developerTool.rawValue)
+        XCTAssertEqual(utilsNode?.metadata.storageCategoryIdentifier, ApplicationsStorageCategory.utilityFolder.rawValue)
+        XCTAssertEqual(normalNode?.metadata.storageCategoryIdentifier, ApplicationsStorageCategory.applicationBundle.rawValue)
+    }
+
+    // 10. Sort order descending by allocated size
+    func testSortOrderDescendingByAllocatedSize() async throws {
+        let smallApp = temporaryDirectoryURL.appendingPathComponent("Small.app", isDirectory: true)
+        let largeApp = temporaryDirectoryURL.appendingPathComponent("Large.app", isDirectory: true)
+        try FileManager.default.createDirectory(at: smallApp, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: largeApp, withIntermediateDirectories: true)
+
+        try "A".write(to: smallApp.appendingPathComponent("file"), atomically: true, encoding: .utf8)
+        try Data(repeating: 0x11, count: 50_000).write(to: largeApp.appendingPathComponent("bigfile"))
+
+        let analyzer = ApplicationsStorageAnalyzer(applicationsURL: temporaryDirectoryURL)
+        let result = await analyzer.analyze()
+
+        XCTAssertEqual(result.root.children.first?.name, "Large.app")
+    }
+
+    // 11. Synthetic deep .app hierarchy proves aggregate sizes match full recursive traversal exactly
+    func testSyntheticAppHierarchyMatchesFullRecursiveTraversal() async throws {
+        let appURL = temporaryDirectoryURL.appendingPathComponent("Complex.app", isDirectory: true)
+        let contentsURL = appURL.appendingPathComponent("Contents", isDirectory: true)
+        let macosURL = contentsURL.appendingPathComponent("MacOS", isDirectory: true)
+        let fwURL = contentsURL.appendingPathComponent("Frameworks", isDirectory: true)
+        let resURL = contentsURL.appendingPathComponent("Resources", isDirectory: true)
+
+        try FileManager.default.createDirectory(at: macosURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: fwURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: resURL, withIntermediateDirectories: true)
+
+        let execData = Data(repeating: 0xAA, count: 12_000)
+        let fwData = Data(repeating: 0xBB, count: 24_000)
+        let resData = Data(repeating: 0xCC, count: 6_000)
+        let plistData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><plist></plist>".data(using: .utf8)!
+
+        try execData.write(to: macosURL.appendingPathComponent("ComplexExec"))
+        try fwData.write(to: fwURL.appendingPathComponent("MyFramework.dylib"))
+        try resData.write(to: resURL.appendingPathComponent("Assets.car"))
+        try plistData.write(to: contentsURL.appendingPathComponent("Info.plist"))
+
+        // Full non-aggregated traversal baseline
+        let standardScanner = FileTreeScanner(configuration: .init(aggregateApplicationPackages: false))
+        let fullResult = await standardScanner.scan(root: temporaryDirectoryURL)
+
+        // Aggregated package-boundary traversal
+        let aggregateAnalyzer = ApplicationsStorageAnalyzer(applicationsURL: temporaryDirectoryURL)
+        let aggregateResult = await aggregateAnalyzer.analyze()
+
+        // Verify root totals match exactly
+        XCTAssertEqual(aggregateResult.root.allocatedSize, fullResult.root.allocatedSize)
+        XCTAssertEqual(aggregateResult.root.logicalSize, fullResult.root.logicalSize)
+
+        // Verify .app bundle node totals match full subtree totals
+        let fullAppNode = fullResult.root.children.first { $0.name == "Complex.app" }
+        let aggregateAppNode = aggregateResult.root.children.first { $0.name == "Complex.app" }
+
+        XCTAssertNotNil(fullAppNode)
+        XCTAssertNotNil(aggregateAppNode)
+        XCTAssertEqual(aggregateAppNode?.allocatedSize, fullAppNode?.allocatedSize)
+        XCTAssertEqual(aggregateAppNode?.logicalSize, fullAppNode?.logicalSize)
+
+        // Verify descendants are NOT materialized into aggregate tree
+        XCTAssertEqual(aggregateAppNode?.children.count, 0)
+        XCTAssertGreaterThan(fullAppNode?.children.count ?? 0, 0)
+    }
+
+    // 12. Direct .app root scan with aggregation enabled
+    func testDirectAppRootScanWithAggregation() async throws {
+        let appURL = temporaryDirectoryURL.appendingPathComponent("Standalone.app", isDirectory: true)
+        let contentsURL = appURL.appendingPathComponent("Contents/MacOS", isDirectory: true)
+        try FileManager.default.createDirectory(at: contentsURL, withIntermediateDirectories: true)
+        let data = Data(repeating: 0x33, count: 16_000)
+        try data.write(to: contentsURL.appendingPathComponent("binary"))
+
+        let scanner = FileTreeScanner(configuration: .init(aggregateApplicationPackages: true))
+        let result = await scanner.scan(root: appURL)
+
+        XCTAssertEqual(result.root.name, "Standalone.app")
+        XCTAssertGreaterThanOrEqual(result.root.logicalSize, 16_000)
+        XCTAssertGreaterThan(result.root.allocatedSize, 0)
+        XCTAssertEqual(result.root.children.count, 0)
+    }
+
+    // 13. Cancellation during package measurement
+    func testCancellationDuringPackageMeasurement() async throws {
+        let appURL = temporaryDirectoryURL.appendingPathComponent("CancelMe.app", isDirectory: true)
+        try FileManager.default.createDirectory(at: appURL, withIntermediateDirectories: true)
+        for i in 0..<100 {
+            try "Content".write(to: appURL.appendingPathComponent("file\(i).txt"), atomically: true, encoding: .utf8)
+        }
+
+        let analyzer = ApplicationsStorageAnalyzer(applicationsURL: temporaryDirectoryURL)
+        let task = Task {
+            await analyzer.analyze()
+        }
+        task.cancel()
+        let result = await task.value
+
+        XCTAssertNotNil(result.root)
+    }
+
+    // 14. Ancestor propagation with sibling .app bundles and intermediate folders
+    func testAncestorPropagationWithSiblingAppsAndIntermediateFolder() async throws {
+        // Hierarchy shape:
+        // /Applications
+        //    Xcode.app
+        //        Contents/...
+        //    Microsoft Word.app
+        //        Contents/...
+        //    Utilities/
+        //        Tool.app
+        //            Contents/...
+
+        let xcodeURL = temporaryDirectoryURL.appendingPathComponent("Xcode.app/Contents/MacOS", isDirectory: true)
+        let xcodeFwURL = temporaryDirectoryURL.appendingPathComponent("Xcode.app/Contents/Frameworks", isDirectory: true)
+        let wordURL = temporaryDirectoryURL.appendingPathComponent("Microsoft Word.app/Contents/MacOS", isDirectory: true)
+        let wordResURL = temporaryDirectoryURL.appendingPathComponent("Microsoft Word.app/Contents/Resources", isDirectory: true)
+        let utilsURL = temporaryDirectoryURL.appendingPathComponent("Utilities", isDirectory: true)
+        let toolURL = utilsURL.appendingPathComponent("Tool.app/Contents/MacOS", isDirectory: true)
+
+        try FileManager.default.createDirectory(at: xcodeURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: xcodeFwURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: wordURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: wordResURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: toolURL, withIntermediateDirectories: true)
+
+        try Data(repeating: 0x11, count: 64_000).write(to: xcodeURL.appendingPathComponent("Xcode"))
+        try Data(repeating: 0x22, count: 128_000).write(to: xcodeFwURL.appendingPathComponent("lib.dylib"))
+        try Data(repeating: 0x33, count: 96_000).write(to: wordURL.appendingPathComponent("Word"))
+        try Data(repeating: 0x44, count: 32_000).write(to: wordResURL.appendingPathComponent("Font.ttf"))
+        try Data(repeating: 0x55, count: 48_000).write(to: toolURL.appendingPathComponent("Tool"))
+
+        // A. Full ordinary recursive traversal
+        let ordinaryScanner = FileTreeScanner(configuration: .init(aggregateApplicationPackages: false))
+        let ordinaryResult = await ordinaryScanner.scan(root: temporaryDirectoryURL)
+
+        // B. Package-boundary aggregate traversal
+        let aggregateAnalyzer = ApplicationsStorageAnalyzer(applicationsURL: temporaryDirectoryURL)
+        let aggregateResult = await aggregateAnalyzer.analyze()
+
+        // 1. Root level (/Applications) equality
+        XCTAssertEqual(aggregateResult.root.allocatedSize, ordinaryResult.root.allocatedSize)
+        XCTAssertEqual(aggregateResult.root.logicalSize, ordinaryResult.root.logicalSize)
+
+        // 2. Sibling package level (Xcode.app)
+        let ordinaryXcode = try XCTUnwrap(ordinaryResult.root.children.first { $0.name == "Xcode.app" })
+        let aggregateXcode = try XCTUnwrap(aggregateResult.root.children.first { $0.name == "Xcode.app" })
+        XCTAssertEqual(aggregateXcode.allocatedSize, ordinaryXcode.allocatedSize)
+        XCTAssertEqual(aggregateXcode.logicalSize, ordinaryXcode.logicalSize)
+        XCTAssertTrue(aggregateXcode.children.isEmpty)
+        XCTAssertFalse(ordinaryXcode.children.isEmpty)
+
+        // 3. Sibling package level (Microsoft Word.app)
+        let ordinaryWord = try XCTUnwrap(ordinaryResult.root.children.first { $0.name == "Microsoft Word.app" })
+        let aggregateWord = try XCTUnwrap(aggregateResult.root.children.first { $0.name == "Microsoft Word.app" })
+        XCTAssertEqual(aggregateWord.allocatedSize, ordinaryWord.allocatedSize)
+        XCTAssertEqual(aggregateWord.logicalSize, ordinaryWord.logicalSize)
+        XCTAssertTrue(aggregateWord.children.isEmpty)
+        XCTAssertFalse(ordinaryWord.children.isEmpty)
+
+        // 4. Intermediate non-package directory level (Utilities/)
+        let ordinaryUtils = try XCTUnwrap(ordinaryResult.root.children.first { $0.name == "Utilities" })
+        let aggregateUtils = try XCTUnwrap(aggregateResult.root.children.first { $0.name == "Utilities" })
+        XCTAssertEqual(aggregateUtils.allocatedSize, ordinaryUtils.allocatedSize)
+        XCTAssertEqual(aggregateUtils.logicalSize, ordinaryUtils.logicalSize)
+        XCTAssertEqual(aggregateUtils.children.count, 1)
+
+        // 5. Nested package inside non-package directory (Utilities/Tool.app)
+        let ordinaryTool = try XCTUnwrap(ordinaryUtils.children.first { $0.name == "Tool.app" })
+        let aggregateTool = try XCTUnwrap(aggregateUtils.children.first { $0.name == "Tool.app" })
+        XCTAssertEqual(aggregateTool.allocatedSize, ordinaryTool.allocatedSize)
+        XCTAssertEqual(aggregateTool.logicalSize, ordinaryTool.logicalSize)
+        XCTAssertTrue(aggregateTool.children.isEmpty)
+        XCTAssertFalse(ordinaryTool.children.isEmpty)
+
+        // 6. Diagnostics metrics must accurately report full allocated bytes
+        let metrics = StorageScanMetrics.compute(from: aggregateResult.root)
+        XCTAssertEqual(metrics.allocatedBytes, aggregateResult.root.allocatedSize)
+        XCTAssertEqual(metrics.logicalBytes, aggregateResult.root.logicalSize)
+        XCTAssertEqual(metrics.packageAggregatesCount, 3)
+    }
+
+    // 15. Hard links across package boundaries are not double-counted
+    func testHardLinksAcrossPackageBoundariesNotDoubleCounted() async throws {
+        let app1URL = temporaryDirectoryURL.appendingPathComponent("App1.app/Contents/MacOS", isDirectory: true)
+        let app2URL = temporaryDirectoryURL.appendingPathComponent("App2.app/Contents/MacOS", isDirectory: true)
+        try FileManager.default.createDirectory(at: app1URL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: app2URL, withIntermediateDirectories: true)
+
+        let file1 = app1URL.appendingPathComponent("shared.bin")
+        let file2 = app2URL.appendingPathComponent("shared.bin")
+        let data = Data(repeating: 0x77, count: 65_536)
+        try data.write(to: file1)
+        link(file1.path, file2.path)
+
+        let analyzer = ApplicationsStorageAnalyzer(applicationsURL: temporaryDirectoryURL)
+        let result = await analyzer.analyze()
+
+        let app1 = try XCTUnwrap(result.root.children.first { $0.name == "App1.app" })
+        let app2 = try XCTUnwrap(result.root.children.first { $0.name == "App2.app" })
+
+        XCTAssertTrue(app1.children.isEmpty)
+        XCTAssertTrue(app2.children.isEmpty)
+
+        // Sum of root allocated bytes must count the 64KB shared data block only once
+        let metrics = StorageScanMetrics.compute(from: result.root)
+        XCTAssertEqual(metrics.allocatedBytes, result.root.allocatedSize)
+        XCTAssertLessThan(result.root.allocatedSize, Int64(data.count * 2))
+    }
+}

--- a/PureMacTests/ContainersAnalyzerTests.swift
+++ b/PureMacTests/ContainersAnalyzerTests.swift
@@ -1,0 +1,335 @@
+import Darwin
+import XCTest
+@testable import PureMac
+
+final class ContainersAnalyzerTests: XCTestCase {
+    func testAnalyzesMultipleContainersAndSortsLargestAllocatedSizeFirst() async throws {
+        let temporaryDirectory = try ContainersTestDirectory()
+        try makeContainer(named: "com.example.small", fileSize: 4_096, in: temporaryDirectory.url)
+        try makeContainer(named: "com.example.medium", fileSize: 131_072, in: temporaryDirectory.url)
+        try makeContainer(named: "com.example.large", fileSize: 2_097_152, in: temporaryDirectory.url)
+
+        let result = await makeContainersAnalyzer(root: temporaryDirectory.url).analyze()
+        let containers = result.root.children
+
+        XCTAssertEqual(
+            containers.map(\.name),
+            ["com.example.large", "com.example.medium", "com.example.small"]
+        )
+        XCTAssertTrue(zip(containers, containers.dropFirst()).allSatisfy {
+            $0.allocatedSize >= $1.allocatedSize
+        })
+        XCTAssertEqual(result.root.metadata.storageCategoryIdentifier, "containers")
+        XCTAssertEqual(
+            result.root.metadata.attributes[ContainersAnalyzer.MetadataKey.directChildCount],
+            "3"
+        )
+    }
+
+    func testRecognizesBundleIdentifierCandidatesAndOnlyAcceptsVerifiedAttribution() async throws {
+        let temporaryDirectory = try ContainersTestDirectory()
+        let verifiedContainer = try makeContainer(
+            named: "com.example.verified",
+            fileSize: 16_384,
+            in: temporaryDirectory.url
+        )
+        let unresolvedContainer = try makeContainer(
+            named: "com.example.unresolved",
+            fileSize: 8_192,
+            in: temporaryDirectory.url
+        )
+        let nonBundleContainer = try makeContainer(
+            named: "Not A Bundle Identifier",
+            fileSize: 4_096,
+            in: temporaryDirectory.url
+        )
+
+        let analyzer = ContainersAnalyzer(
+            containersURL: temporaryDirectory.url,
+            largeAllocatedSizeThreshold: 1,
+            attributionProvider: { bundleIdentifier in
+                switch bundleIdentifier {
+                case "com.example.verified":
+                    return .init(
+                        bundleIdentifier: "com.example.verified",
+                        displayName: "Verified App"
+                    )
+                case "com.example.unresolved":
+                    return .init(
+                        bundleIdentifier: "com.different.application",
+                        displayName: "Wrong App"
+                    )
+                default:
+                    return nil
+                }
+            }
+        )
+        let result = await analyzer.analyze()
+        let verifiedNode = try XCTUnwrap(node(at: verifiedContainer.path, in: result.root))
+        let unresolvedNode = try XCTUnwrap(node(at: unresolvedContainer.path, in: result.root))
+        let nonBundleNode = try XCTUnwrap(node(at: nonBundleContainer.path, in: result.root))
+
+        XCTAssertEqual(verifiedNode.metadata.bundleIdentifier, "com.example.verified")
+        XCTAssertEqual(verifiedNode.metadata.owningApplicationIdentifier, "com.example.verified")
+        XCTAssertEqual(verifiedNode.metadata.owningApplicationName, "Verified App")
+        XCTAssertEqual(verifiedNode.metadata.confidence, 1)
+        XCTAssertEqual(verifiedNode.metadata.isUnusuallyLarge, true)
+        XCTAssertNil(verifiedNode.metadata.safetyClassificationIdentifier)
+        XCTAssertEqual(
+            verifiedNode.metadata.attributes[ContainersAnalyzer.MetadataKey.bundleIdentifierSource],
+            "directory-name"
+        )
+
+        XCTAssertEqual(unresolvedNode.metadata.bundleIdentifier, "com.example.unresolved")
+        XCTAssertNil(unresolvedNode.metadata.owningApplicationIdentifier)
+        XCTAssertNil(unresolvedNode.metadata.owningApplicationName)
+        XCTAssertNil(unresolvedNode.metadata.confidence)
+
+        XCTAssertNil(nonBundleNode.metadata.bundleIdentifier)
+        XCTAssertNil(nonBundleNode.metadata.owningApplicationIdentifier)
+        XCTAssertNil(nonBundleNode.metadata.owningApplicationName)
+    }
+
+    func testIncludesHiddenContentAndPreservesContainerHierarchy() async throws {
+        let temporaryDirectory = try ContainersTestDirectory()
+        let container = temporaryDirectory.url.appendingPathComponent("com.example.hidden", isDirectory: true)
+        let dataDirectory = container.appendingPathComponent("Data", isDirectory: true)
+        let libraryDirectory = dataDirectory.appendingPathComponent("Library", isDirectory: true)
+        let hiddenDirectory = libraryDirectory.appendingPathComponent(".internal-state", isDirectory: true)
+        try FileManager.default.createDirectory(at: hiddenDirectory, withIntermediateDirectories: true)
+        let hiddenFile = hiddenDirectory.appendingPathComponent(".payload")
+        try Data(repeating: 0x21, count: 1_024).write(to: hiddenFile)
+
+        let result = await makeContainersAnalyzer(root: temporaryDirectory.url).analyze()
+        let containerNode = try XCTUnwrap(node(at: container.path, in: result.root))
+        let dataNode = try XCTUnwrap(node(at: dataDirectory.path, in: result.root))
+        let libraryNode = try XCTUnwrap(node(at: libraryDirectory.path, in: result.root))
+        let hiddenDirectoryNode = try XCTUnwrap(node(at: hiddenDirectory.path, in: result.root))
+        let hiddenFileNode = try XCTUnwrap(node(at: hiddenFile.path, in: result.root))
+
+        XCTAssertEqual(containerNode.children.map(\.name), ["Data"])
+        XCTAssertEqual(dataNode.children.map(\.name), ["Library"])
+        XCTAssertEqual(libraryNode.children.map(\.name), [".internal-state"])
+        XCTAssertTrue(hiddenDirectoryNode.isHidden)
+        XCTAssertTrue(hiddenFileNode.isHidden)
+        XCTAssertEqual(
+            containerNode.metadata.attributes[ContainersAnalyzer.MetadataKey.directChildCount],
+            "1"
+        )
+    }
+
+    func testPreservesSparseVirtualDiskLogicalAndAllocatedSizes() async throws {
+        let temporaryDirectory = try ContainersTestDirectory()
+        let container = temporaryDirectory.url.appendingPathComponent("com.example.virtualizer", isDirectory: true)
+        let dataDirectory = container.appendingPathComponent("Data", isDirectory: true)
+        try FileManager.default.createDirectory(at: dataDirectory, withIntermediateDirectories: true)
+        let virtualDisk = dataDirectory.appendingPathComponent("machine.raw")
+        XCTAssertTrue(FileManager.default.createFile(atPath: virtualDisk.path, contents: nil))
+
+        let logicalByteCount: UInt64 = 32 * 1_024 * 1_024
+        let handle = try FileHandle(forWritingTo: virtualDisk)
+        try handle.truncate(atOffset: logicalByteCount)
+        try handle.close()
+
+        let expected = try containersStatValues(for: virtualDisk.path)
+        let result = await makeContainersAnalyzer(root: temporaryDirectory.url).analyze()
+        let containerNode = try XCTUnwrap(node(at: container.path, in: result.root))
+        let diskNode = try XCTUnwrap(node(at: virtualDisk.path, in: result.root))
+
+        XCTAssertEqual(diskNode.ownLogicalSize, expected.logical)
+        XCTAssertEqual(diskNode.ownAllocatedSize, expected.allocated)
+        XCTAssertEqual(diskNode.ownLogicalSize, Int64(logicalByteCount))
+        XCTAssertEqual(
+            containerNode.metadata.attributes[ContainersAnalyzer.MetadataKey.virtualDiskImageCount],
+            "1"
+        )
+
+        if diskNode.ownAllocatedSize >= diskNode.ownLogicalSize {
+            throw XCTSkip("The test filesystem eagerly allocated the sparse virtual disk.")
+        }
+    }
+
+    func testPermissionDeniedContainerRemainsVisibleWithIssue() async throws {
+        guard geteuid() != 0 else {
+            throw XCTSkip("A root process can read mode-000 test directories.")
+        }
+
+        let temporaryDirectory = try ContainersTestDirectory()
+        let inaccessibleContainer = try makeContainer(
+            named: "com.example.inaccessible",
+            fileSize: 128,
+            in: temporaryDirectory.url
+        )
+        XCTAssertEqual(chmod(inaccessibleContainer.path, 0), 0)
+        defer { _ = chmod(inaccessibleContainer.path, mode_t(S_IRWXU)) }
+
+        let result = await makeContainersAnalyzer(root: temporaryDirectory.url).analyze()
+        let inaccessibleNode = try XCTUnwrap(node(at: inaccessibleContainer.path, in: result.root))
+
+        XCTAssertEqual(inaccessibleNode.accessibility, .inaccessible)
+        XCTAssertTrue(inaccessibleNode.children.isEmpty)
+        XCTAssertTrue(inaccessibleNode.scanIssues.contains { $0.kind == .permissionDenied })
+        XCTAssertTrue(result.issues.contains {
+            $0.path == inaccessibleContainer.path && $0.kind == .permissionDenied
+        })
+    }
+
+    func testSymbolicLinkIsNotFollowedOrAttributedAsContainer() async throws {
+        let temporaryDirectory = try ContainersTestDirectory()
+        let outsideDirectory = try ContainersTestDirectory()
+        let outsideFile = outsideDirectory.url.appendingPathComponent("outside.dat")
+        try Data(repeating: 0x31, count: 1_048_576).write(to: outsideFile)
+        let link = temporaryDirectory.url.appendingPathComponent("com.example.external")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outsideDirectory.url)
+
+        let result = await makeContainersAnalyzer(root: temporaryDirectory.url).analyze()
+        let linkNode = try XCTUnwrap(node(at: link.path, in: result.root))
+
+        XCTAssertEqual(linkNode.itemType, .symbolicLink)
+        XCTAssertTrue(linkNode.isSymbolicLink)
+        XCTAssertTrue(linkNode.children.isEmpty)
+        XCTAssertNil(linkNode.metadata.bundleIdentifier)
+        XCTAssertNil(linkNode.metadata.owningApplicationIdentifier)
+        XCTAssertNil(node(at: outsideFile.path, in: result.root))
+        XCTAssertLessThan(result.root.logicalSize, 1_048_576)
+    }
+
+    func testCancellationReturnsPartialMarkedAnalysis() async throws {
+        let temporaryDirectory = try ContainersTestDirectory()
+        for index in 0..<300 {
+            try makeContainer(
+                named: "com.example.application-\(index)",
+                fileSize: 64,
+                in: temporaryDirectory.url
+            )
+        }
+
+        let analyzer = makeContainersAnalyzer(
+            root: temporaryDirectory.url,
+            scanner: FileTreeScanner(configuration: .init(maxConcurrentDirectoryReads: 1))
+        )
+        let analysisTask = Task { await analyzer.analyze() }
+        analysisTask.cancel()
+        let result = await analysisTask.value
+
+        XCTAssertTrue(result.wasCancelled)
+        XCTAssertTrue(result.issues.contains { $0.kind == .cancelled })
+        XCTAssertNotEqual(result.root.accessibility, .accessible)
+    }
+
+    func testHardLinksAreNotDoubleCounted() async throws {
+        let temporaryDirectory = try ContainersTestDirectory()
+        let container = temporaryDirectory.url.appendingPathComponent("com.example.linked", isDirectory: true)
+        try FileManager.default.createDirectory(at: container, withIntermediateDirectories: false)
+        let original = container.appendingPathComponent("original.dat")
+        let hardLink = container.appendingPathComponent("linked.dat")
+        try Data(repeating: 0x41, count: 8_192).write(to: original)
+        try FileManager.default.linkItem(at: original, to: hardLink)
+
+        let result = await makeContainersAnalyzer(root: temporaryDirectory.url).analyze()
+        let containerNode = try XCTUnwrap(node(at: container.path, in: result.root))
+        let originalNode = try XCTUnwrap(node(at: original.path, in: result.root))
+        let hardLinkNode = try XCTUnwrap(node(at: hardLink.path, in: result.root))
+        let linkedNodes = [originalNode, hardLinkNode]
+
+        XCTAssertEqual(linkedNodes.filter(\.isCountedInParentTotals).count, 1)
+        XCTAssertEqual(
+            containerNode.logicalSize,
+            containerNode.ownLogicalSize + originalNode.ownLogicalSize
+        )
+        XCTAssertEqual(
+            containerNode.allocatedSize,
+            containerNode.ownAllocatedSize + originalNode.ownAllocatedSize
+        )
+        XCTAssertEqual(result.root.logicalSize, result.root.ownLogicalSize + containerNode.logicalSize)
+        XCTAssertEqual(result.root.allocatedSize, result.root.ownAllocatedSize + containerNode.allocatedSize)
+    }
+
+    func testEmptyContainersDirectoryReturnsNoEntries() async throws {
+        let temporaryDirectory = try ContainersTestDirectory()
+
+        let result = await makeContainersAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertFalse(result.wasCancelled)
+        XCTAssertEqual(result.root.itemType, .directory)
+        XCTAssertEqual(result.root.accessibility, .accessible)
+        XCTAssertTrue(result.root.children.isEmpty)
+        XCTAssertEqual(
+            result.root.metadata.attributes[ContainersAnalyzer.MetadataKey.directChildCount],
+            "0"
+        )
+    }
+
+    func testMissingContainersDirectoryReturnsUnavailableResult() async {
+        let missingDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMac-Missing-Containers-\(UUID().uuidString)", isDirectory: true)
+
+        let result = await makeContainersAnalyzer(root: missingDirectory).analyze()
+
+        XCTAssertEqual(result.root.absolutePath, missingDirectory.standardizedFileURL.path)
+        XCTAssertEqual(result.root.itemType, .unknown)
+        XCTAssertEqual(result.root.accessibility, .inaccessible)
+        XCTAssertTrue(result.root.children.isEmpty)
+        XCTAssertTrue(result.issues.contains { $0.kind == .metadataUnavailable })
+        XCTAssertEqual(result.root.metadata.storageCategoryIdentifier, "containers")
+    }
+}
+
+private final class ContainersTestDirectory {
+    let url: URL
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMac-ContainersAnalyzerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+private func makeContainersAnalyzer(
+    root: URL,
+    scanner: FileTreeScanner = FileTreeScanner()
+) -> ContainersAnalyzer {
+    ContainersAnalyzer(
+        containersURL: root,
+        scanner: scanner,
+        attributionProvider: { _ in nil }
+    )
+}
+
+@discardableResult
+private func makeContainer(
+    named name: String,
+    fileSize: Int,
+    in root: URL
+) throws -> URL {
+    let container = root.appendingPathComponent(name, isDirectory: true)
+    try FileManager.default.createDirectory(at: container, withIntermediateDirectories: false)
+    try Data(repeating: UInt8(fileSize % 251), count: fileSize).write(
+        to: container.appendingPathComponent("payload.dat")
+    )
+    return container
+}
+
+private func node(at path: String, in root: StorageNode) -> StorageNode? {
+    var pending = [root]
+    while let candidate = pending.popLast() {
+        if candidate.absolutePath == path { return candidate }
+        pending.append(contentsOf: candidate.children)
+    }
+    return nil
+}
+
+private func containersStatValues(for path: String) throws -> (logical: Int64, allocated: Int64) {
+    var metadata = stat()
+    guard lstat(path, &metadata) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: Darwin.errno) ?? .EIO)
+    }
+    return (
+        logical: Int64(metadata.st_size),
+        allocated: Int64(metadata.st_blocks) * 512
+    )
+}

--- a/PureMacTests/CoverageExpansionAnalyzerTests.swift
+++ b/PureMacTests/CoverageExpansionAnalyzerTests.swift
@@ -474,6 +474,7 @@ final class CoverageExpansionAnalyzerTests: XCTestCase {
                     largeAllocatedSizeThreshold: 1_073_741_824
                 )
             },
+            applicationsAnalysis: { emptyResult },
             applicationSupportAnalysis: { appSupportResult ?? emptyResult },
             containersAnalysis: { emptyResult },
             groupContainersAnalysis: { emptyResult },

--- a/PureMacTests/CoverageExpansionAnalyzerTests.swift
+++ b/PureMacTests/CoverageExpansionAnalyzerTests.swift
@@ -1,0 +1,513 @@
+import Darwin
+import XCTest
+@testable import PureMac
+
+final class CoverageExpansionAnalyzerTests: XCTestCase {
+    private var tempDirectory: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CoverageExpansionTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempDirectory {
+            try? FileManager.default.removeItem(at: tempDirectory)
+        }
+        super.tearDown()
+    }
+
+    // MARK: - 1. Uncovered ~/Library child becomes measurable
+    func testUncoveredLibraryChildMeasured() async throws {
+        let fakeHome = tempDirectory.appendingPathComponent("UserHome")
+        let fakeLibrary = fakeHome.appendingPathComponent("Library")
+        let cachesDir = fakeLibrary.appendingPathComponent("Caches")
+        try FileManager.default.createDirectory(at: cachesDir, withIntermediateDirectories: true)
+        let sampleFile = cachesDir.appendingPathComponent("test.cache")
+        try Data(repeating: 0x41, count: 1024 * 1024).write(to: sampleFile)
+
+        let analyzer = CoverageExpansionAnalyzer(
+            homeDirectoryURL: fakeHome,
+            dataVolumeURL: tempDirectory.appendingPathComponent("DataVolume")
+        )
+        let report = await analyzer.analyze()
+
+        let measuredCaches = report.candidates.first { $0.name == "Caches" }
+        XCTAssertNotNil(measuredCaches)
+        XCTAssertEqual(measuredCaches?.status, .measured)
+        XCTAssertTrue(measuredCaches?.contributesToExplainedBytes == true)
+        XCTAssertGreaterThan(measuredCaches?.allocatedBytes ?? 0, 0)
+        XCTAssertGreaterThanOrEqual(report.totalNewlyMeasuredBytes, 1024 * 1024)
+    }
+
+    // MARK: - 2. Application Support, Containers, Group Containers excluded
+    func testSpecializedLibraryRootsExcluded() async throws {
+        let fakeHome = tempDirectory.appendingPathComponent("UserHome")
+        let fakeLibrary = fakeHome.appendingPathComponent("Library")
+        try FileManager.default.createDirectory(
+            at: fakeLibrary.appendingPathComponent("Application Support"),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: fakeLibrary.appendingPathComponent("Containers"),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: fakeLibrary.appendingPathComponent("Group Containers"),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: fakeLibrary.appendingPathComponent("Developer"),
+            withIntermediateDirectories: true
+        )
+
+        let analyzer = CoverageExpansionAnalyzer(
+            homeDirectoryURL: fakeHome,
+            dataVolumeURL: tempDirectory.appendingPathComponent("DataVolume")
+        )
+        let report = await analyzer.analyze()
+
+        let names = report.candidates.map(\.name)
+        XCTAssertFalse(names.contains("Application Support"))
+        XCTAssertFalse(names.contains("Containers"))
+        XCTAssertFalse(names.contains("Group Containers"))
+        XCTAssertTrue(names.contains("Developer"))
+    }
+
+    // MARK: - 3. Hidden home candidate discovered (~/.cache, ~/.npm)
+    func testHiddenHomeCandidateDiscovered() async throws {
+        let fakeHome = tempDirectory.appendingPathComponent("UserHome")
+        let dotCache = fakeHome.appendingPathComponent(".cache")
+        try FileManager.default.createDirectory(at: dotCache, withIntermediateDirectories: true)
+        try Data(repeating: 0x42, count: 2048).write(to: dotCache.appendingPathComponent("pkg.json"))
+
+        let analyzer = CoverageExpansionAnalyzer(
+            homeDirectoryURL: fakeHome,
+            dataVolumeURL: tempDirectory.appendingPathComponent("DataVolume")
+        )
+        let report = await analyzer.analyze()
+
+        let candidate = report.candidates.first { $0.name == ".cache" }
+        XCTAssertNotNil(candidate)
+        XCTAssertEqual(candidate?.scope, .hiddenHome)
+        XCTAssertEqual(candidate?.status, .measured)
+        XCTAssertGreaterThan(candidate?.allocatedBytes ?? 0, 0)
+    }
+
+    // MARK: - 4. Hidden candidate already owned is excluded
+    func testExcludedAlreadyAccountedCanonicalPaths() async throws {
+        let fakeHome = tempDirectory.appendingPathComponent("UserHome")
+        let dotCache = fakeHome.appendingPathComponent(".cache")
+        try FileManager.default.createDirectory(at: dotCache, withIntermediateDirectories: true)
+
+        let analyzer = CoverageExpansionAnalyzer(
+            homeDirectoryURL: fakeHome,
+            dataVolumeURL: tempDirectory.appendingPathComponent("DataVolume"),
+            extraExcludedCanonicalPaths: [StoragePathNormalizer.normalize(dotCache.path)]
+        )
+        let report = await analyzer.analyze()
+
+        let candidate = report.candidates.first { $0.name == ".cache" }
+        XCTAssertNotNil(candidate)
+        XCTAssertEqual(candidate?.status, .excludedAlreadyAccounted)
+        XCTAssertFalse(candidate?.contributesToExplainedBytes == true)
+    }
+
+    // MARK: - 5. Data-volume alias normalization
+    func testDataVolumeRootNormalization() {
+        let candidatePath = "/System/Volumes/Data/Library/Developer"
+        let normalized = StoragePathNormalizer.normalize(candidatePath)
+        XCTAssertEqual(normalized, "/Library/Developer")
+    }
+
+    // MARK: - 6. Nested candidate exclusion in Coordinator
+    func testNestedCoverageCandidateExcludedInCoordinator() async {
+        let candidateA = StorageCoverageCandidate(
+            originalPath: "/Users/test/Library/Caches",
+            normalizedPath: "/Users/test/Library/Caches",
+            name: "Caches",
+            scope: .userLibrary,
+            status: .measured,
+            allocatedBytes: 1000,
+            logicalBytes: 1000,
+            issue: nil,
+            exclusionReason: nil,
+            contributesToExplainedBytes: true
+        )
+        let candidateB = StorageCoverageCandidate(
+            originalPath: "/Users/test/Library/Caches/subfolder",
+            normalizedPath: "/Users/test/Library/Caches/subfolder",
+            name: "subfolder",
+            scope: .userLibrary,
+            status: .measured,
+            allocatedBytes: 500,
+            logicalBytes: 500,
+            issue: nil,
+            exclusionReason: nil,
+            contributesToExplainedBytes: true
+        )
+        let report = StorageCoverageExpansionReport(
+            totalNewlyMeasuredBytes: 1500,
+            measuredCandidateCount: 2,
+            excludedOverlapCount: 0,
+            inaccessibleCandidateCount: 0,
+            differentVolumeBoundaryCount: 0,
+            failedCandidateCount: 0,
+            candidates: [candidateA, candidateB],
+            largestDiscoveredRegions: [candidateA, candidateB],
+            treeResults: [],
+            wasCancelled: false,
+            issues: []
+        )
+
+        let coordinator = makeStubCoordinator(expansionReport: report)
+        let result = await coordinator.analyze()
+
+        let cachesContribution = result.filesystemContributions.first { $0.normalizedPath == "/Users/test/Library/Caches" }
+        let subContribution = result.filesystemContributions.first { $0.normalizedPath == "/Users/test/Library/Caches/subfolder" }
+
+        XCTAssertEqual(cachesContribution?.accountedAllocatedBytes, 1000)
+        XCTAssertEqual(cachesContribution?.relationship, .canonicalUnique)
+        XCTAssertEqual(subContribution?.accountedAllocatedBytes, 0)
+        XCTAssertEqual(subContribution?.relationship, .excludedNestedPath)
+    }
+
+    // MARK: - 7. Duplicate analyzer ownership exclusion
+    func testDuplicateAnalyzerOwnershipExclusion() async {
+        let candidate = StorageCoverageCandidate(
+            originalPath: "/Users/test/Library/Application Support",
+            normalizedPath: "/Users/test/Library/Application Support",
+            name: "Application Support",
+            scope: .userLibrary,
+            status: .measured,
+            allocatedBytes: 5000,
+            logicalBytes: 5000,
+            issue: nil,
+            exclusionReason: nil,
+            contributesToExplainedBytes: true
+        )
+        let expansionReport = StorageCoverageExpansionReport(
+            totalNewlyMeasuredBytes: 5000,
+            measuredCandidateCount: 1,
+            excludedOverlapCount: 0,
+            inaccessibleCandidateCount: 0,
+            differentVolumeBoundaryCount: 0,
+            failedCandidateCount: 0,
+            candidates: [candidate],
+            largestDiscoveredRegions: [candidate],
+            treeResults: [],
+            wasCancelled: false,
+            issues: []
+        )
+
+        let appSupportTree = makeResult(path: "/Users/test/Library/Application Support", allocated: 5000)
+        let coordinator = makeStubCoordinator(
+            appSupportResult: appSupportTree,
+            expansionReport: expansionReport
+        )
+        let result = await coordinator.analyze()
+
+        let appSupportContribution = result.filesystemContributions.first {
+            $0.source == .applicationSupport && $0.normalizedPath == "/Users/test/Library/Application Support"
+        }
+        let gapContribution = result.filesystemContributions.first {
+            $0.source == .additionalCoverageGap && $0.normalizedPath == "/Users/test/Library/Application Support"
+        }
+
+        XCTAssertEqual(appSupportContribution?.relationship, .canonicalUnique)
+        XCTAssertEqual(appSupportContribution?.accountedAllocatedBytes, 5000)
+        XCTAssertEqual(gapContribution?.relationship, .excludedDuplicatePath)
+        XCTAssertEqual(gapContribution?.accountedAllocatedBytes, 0)
+    }
+
+    // MARK: - 8. Symlink exclusion
+    func testSymlinksExcluded() async throws {
+        let fakeHome = tempDirectory.appendingPathComponent("UserHome")
+        let fakeLibrary = fakeHome.appendingPathComponent("Library")
+        let targetDir = tempDirectory.appendingPathComponent("ActualTarget")
+        try FileManager.default.createDirectory(at: targetDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: fakeLibrary, withIntermediateDirectories: true)
+
+        let symlinkPath = fakeLibrary.appendingPathComponent("LinkedCaches").path
+        symlink(targetDir.path, symlinkPath)
+
+        let analyzer = CoverageExpansionAnalyzer(
+            homeDirectoryURL: fakeHome,
+            dataVolumeURL: tempDirectory.appendingPathComponent("DataVolume")
+        )
+        let report = await analyzer.analyze()
+
+        let linked = report.candidates.first { $0.name == "LinkedCaches" }
+        XCTAssertNotNil(linked)
+        XCTAssertEqual(linked?.status, .excludedSymlink)
+        XCTAssertFalse(linked?.contributesToExplainedBytes == true)
+        XCTAssertEqual(linked?.allocatedBytes, nil)
+    }
+
+    // MARK: - 9. Protected system path exclusion
+    func testProtectedSystemPathsExcluded() {
+        XCTAssertTrue(StoragePathNormalizer.isSystemProtectedLocation("/System/Volumes/Data/.DocumentRevisions-V100"))
+        XCTAssertTrue(StoragePathNormalizer.isSystemProtectedLocation("/private/var/audit"))
+        XCTAssertTrue(StoragePathNormalizer.isSystemProtectedLocation("/private/var/root"))
+    }
+
+    // MARK: - 10. Explained bytes increase exactly by newly measured bytes
+    func testExplainedAllocatedBytesIncreasesByUniqueMeasuredBytes() async {
+        let candidate = StorageCoverageCandidate(
+            originalPath: "/Users/test/Library/Caches",
+            normalizedPath: "/Users/test/Library/Caches",
+            name: "Caches",
+            scope: .userLibrary,
+            status: .measured,
+            allocatedBytes: 15_000_000,
+            logicalBytes: 15_000_000,
+            issue: nil,
+            exclusionReason: nil,
+            contributesToExplainedBytes: true
+        )
+        let expansionReport = StorageCoverageExpansionReport(
+            totalNewlyMeasuredBytes: 15_000_000,
+            measuredCandidateCount: 1,
+            excludedOverlapCount: 0,
+            inaccessibleCandidateCount: 0,
+            differentVolumeBoundaryCount: 0,
+            failedCandidateCount: 0,
+            candidates: [candidate],
+            largestDiscoveredRegions: [candidate],
+            treeResults: [],
+            wasCancelled: false,
+            issues: []
+        )
+
+        let coordinator = makeStubCoordinator(
+            usedCapacity: 100_000_000,
+            expansionReport: expansionReport
+        )
+        let report = await coordinator.analyze()
+
+        XCTAssertEqual(report.explainedAllocatedBytes, 15_000_000)
+        XCTAssertEqual(report.unexplainedBytes, 85_000_000)
+    }
+
+    // MARK: - 11. Explained never exceeds volume used
+    func testExplainedBytesNeverExceedsVolumeUsed() async {
+        let candidate = StorageCoverageCandidate(
+            originalPath: "/Users/test/Library/HugeDir",
+            normalizedPath: "/Users/test/Library/HugeDir",
+            name: "HugeDir",
+            scope: .userLibrary,
+            status: .measured,
+            allocatedBytes: 150_000_000,
+            logicalBytes: 150_000_000,
+            issue: nil,
+            exclusionReason: nil,
+            contributesToExplainedBytes: true
+        )
+        let expansionReport = StorageCoverageExpansionReport(
+            totalNewlyMeasuredBytes: 150_000_000,
+            measuredCandidateCount: 1,
+            excludedOverlapCount: 0,
+            inaccessibleCandidateCount: 0,
+            differentVolumeBoundaryCount: 0,
+            failedCandidateCount: 0,
+            candidates: [candidate],
+            largestDiscoveredRegions: [candidate],
+            treeResults: [],
+            wasCancelled: false,
+            issues: []
+        )
+
+        let coordinator = makeStubCoordinator(
+            usedCapacity: 100_000_000,
+            expansionReport: expansionReport
+        )
+        let report = await coordinator.analyze()
+
+        XCTAssertEqual(report.explainedAllocatedBytes, 150_000_000)
+        XCTAssertEqual(report.unexplainedBytes, 0)
+        XCTAssertTrue(report.analysisIssues.contains(where: { $0.kind == .accountingAnomaly }))
+    }
+
+    // MARK: - 12. APFS metadata remains non-additive
+    func testAPFSMetadataRemainsNonAdditive() async {
+        let candidate = StorageCoverageCandidate(
+            originalPath: "/Users/test/Library/Caches",
+            normalizedPath: "/Users/test/Library/Caches",
+            name: "Caches",
+            scope: .userLibrary,
+            status: .measured,
+            allocatedBytes: 10_000_000,
+            logicalBytes: 10_000_000,
+            issue: nil,
+            exclusionReason: nil,
+            contributesToExplainedBytes: true
+        )
+        let expansionReport = StorageCoverageExpansionReport(
+            totalNewlyMeasuredBytes: 10_000_000,
+            measuredCandidateCount: 1,
+            excludedOverlapCount: 0,
+            inaccessibleCandidateCount: 0,
+            differentVolumeBoundaryCount: 0,
+            failedCandidateCount: 0,
+            candidates: [candidate],
+            largestDiscoveredRegions: [candidate],
+            treeResults: [],
+            wasCancelled: false,
+            issues: []
+        )
+
+        let apfs = makeAPFSReport(used: 100_000_000, purgeable: 10_000_000)
+
+        let coordinator = makeStubCoordinator(
+            usedCapacity: 100_000_000,
+            apfsReport: apfs,
+            expansionReport: expansionReport
+        )
+        let report = await coordinator.analyze()
+
+        XCTAssertEqual(report.explainedAllocatedBytes, 10_000_000)
+        XCTAssertEqual(report.purgeableEstimateBytes, 10_000_000)
+        XCTAssertEqual(report.unexplainedBytes, 90_000_000)
+    }
+
+    // MARK: - 13. Cancellation support
+    func testCoverageExpansionHandlesCancellation() async {
+        let task = Task {
+            let analyzer = CoverageExpansionAnalyzer(
+                homeDirectoryURL: tempDirectory.appendingPathComponent("UserHome"),
+                dataVolumeURL: tempDirectory.appendingPathComponent("DataVolume")
+            )
+            return await analyzer.analyze()
+        }
+        task.cancel()
+        let report = await task.value
+        XCTAssertTrue(report.wasCancelled || report.candidates.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func makeNode(
+        path: String,
+        allocated: Int64 = 0,
+        children: [StorageNode] = []
+    ) -> StorageNode {
+        StorageNode(
+            name: URL(fileURLWithPath: path).lastPathComponent,
+            absolutePath: path,
+            logicalSize: allocated,
+            allocatedSize: allocated,
+            ownLogicalSize: allocated,
+            ownAllocatedSize: allocated,
+            itemType: .directory,
+            children: children,
+            accessibility: .accessible,
+            scanIssues: [],
+            isHidden: false,
+            isSymbolicLink: false,
+            isCountedInParentTotals: true,
+            metadata: StorageAnalysisMetadata()
+        )
+    }
+
+    private func makeResult(
+        path: String,
+        allocated: Int64 = 0,
+        issues: [StorageScanIssue] = [],
+        children: [StorageNode] = []
+    ) -> StorageAnalysisResult {
+        StorageAnalysisResult(
+            root: makeNode(path: path, allocated: allocated, children: children),
+            startedAt: Date(),
+            completedAt: Date(),
+            rootDeviceIdentifier: 1,
+            wasCancelled: false,
+            issues: issues
+        )
+    }
+
+    private func makeAPFSReport(used: Int64, purgeable: Int64 = 0) -> APFSStorageReport {
+        APFSStorageReport(
+            volume: APFSVolumeInformation(
+                name: "Data",
+                volumeIdentifier: "disk-test",
+                volumeUUID: nil,
+                containerIdentifier: nil,
+                volumeGroupIdentifier: nil,
+                filesystemType: "apfs",
+                filesystemKind: .apfs,
+                mountPoint: "/",
+                dataVolumeRelationship: .dataVolume,
+                capacity: APFSVolumeCapacity(
+                    totalCapacity: used + 200_000_000,
+                    availableCapacity: 200_000_000,
+                    usedCapacity: used,
+                    availableCapacityForImportantUsage: 300_000_000,
+                    availableCapacityForOpportunisticUsage: nil,
+                    purgeableEstimate: purgeable,
+                    purgeableEstimateKnowledge: .estimated
+                )
+            ),
+            snapshots: [],
+            state: .complete,
+            accountingRelationship: .volumeMetadataAndSnapshotsAreNonAdditiveToFilesystemTrees,
+            wasCancelled: false,
+            issues: []
+        )
+    }
+
+    private func makeStubCoordinator(
+        usedCapacity: Int64 = 100_000_000,
+        appSupportResult: StorageAnalysisResult? = nil,
+        apfsReport: APFSStorageReport? = nil,
+        expansionReport: StorageCoverageExpansionReport = .empty
+    ) -> StorageAnalysisCoordinator {
+        let defaultAPFS = apfsReport ?? makeAPFSReport(used: usedCapacity)
+        let emptyResult = makeResult(path: "/empty", allocated: 0)
+
+        return StorageAnalysisCoordinator(
+            userHomeStorageAnalysis: {
+                UserHomeStorageAnalyzer.makeReport(
+                    emptyResult,
+                    homeDirectoryURL: URL(fileURLWithPath: "/Users/test"),
+                    largeAllocatedSizeThreshold: 1_073_741_824
+                )
+            },
+            applicationSupportAnalysis: { appSupportResult ?? emptyResult },
+            containersAnalysis: { emptyResult },
+            groupContainersAnalysis: { emptyResult },
+            systemLibraryAnalysis: { emptyResult },
+            privateStorageAnalysis: { emptyResult },
+            dataVolumeHiddenStorageAnalysis: { emptyResult },
+            developerSystemStorageAnalysis: {
+                DeveloperSystemStorageReport(
+                    opt: DeveloperSystemRootAnalysis(canonicalRoot: .opt, configuredPath: "/opt", state: .missing, result: emptyResult),
+                    usrLocal: DeveloperSystemRootAnalysis(canonicalRoot: .usrLocal, configuredPath: "/usr/local", state: .missing, result: emptyResult),
+                    combinedUniqueLogicalSize: 0,
+                    combinedUniqueAllocatedSize: 0,
+                    combinedSizeKnowledge: .complete,
+                    wasCancelled: false,
+                    issues: []
+                )
+            },
+            dockerStorageAnalysis: {
+                DockerStorageReport(
+                    hostFootprint: DockerHostFootprint(locations: [], logicalSize: 0, allocatedSize: 0),
+                    virtualDisks: [],
+                    runtimeStatus: .notInstalled,
+                    runtimeAccounting: nil,
+                    dockerExecutablePath: nil,
+                    runtimeContext: DockerRuntimeContext(name: "test", sanitizedEndpoint: "unix:///local.sock", location: .local),
+                    hostRuntimeRelationship: .localRuntimeMayExplainHostFootprint,
+                    accountingRelationship: .runtimeBreakdownIsNonAdditiveToHostFootprint,
+                    wasCancelled: false,
+                    issues: []
+                )
+            },
+            apfsStorageAnalysis: { defaultAPFS },
+            coverageExpansionAnalysis: { expansionReport },
+            coverageDiscovery: { .empty(homeDirectoryPath: "/Users/test") }
+        )
+    }
+}

--- a/PureMacTests/DataVolumeHiddenStorageAnalyzerTests.swift
+++ b/PureMacTests/DataVolumeHiddenStorageAnalyzerTests.swift
@@ -1,0 +1,630 @@
+import Darwin
+import XCTest
+@testable import PureMac
+
+final class DataVolumeHiddenStorageAnalyzerTests: XCTestCase {
+    func testDiscoversHiddenDotDirectory() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let hidden = try makeHiddenDirectory(named: ".hidden", fileSize: 1_024, in: temporaryDirectory.url)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+
+        let node = try XCTUnwrap(hiddenNode(at: hidden.path, in: result.root))
+        XCTAssertTrue(node.isHidden)
+        XCTAssertEqual(node.itemType, .directory)
+    }
+
+    func testDiscoversHiddenDotFile() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let hiddenFile = temporaryDirectory.url.appendingPathComponent(".hidden-file")
+        try Data(repeating: 0x11, count: 2_048).write(to: hiddenFile)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+
+        let node = try XCTUnwrap(hiddenNode(at: hiddenFile.path, in: result.root))
+        XCTAssertTrue(node.isHidden)
+        XCTAssertEqual(node.itemType, .regularFile)
+    }
+
+    func testDiscoversFilesystemHiddenFlagWithoutDotPrefix() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let flagged = temporaryDirectory.url.appendingPathComponent("flagged-hidden", isDirectory: true)
+        try FileManager.default.createDirectory(at: flagged, withIntermediateDirectories: false)
+        try Data([0x12]).write(to: flagged.appendingPathComponent("payload"))
+
+        guard chflags(flagged.path, UInt32(UF_HIDDEN)) == 0 else {
+            throw XCTSkip("The test filesystem does not allow setting UF_HIDDEN.")
+        }
+        defer { _ = chflags(flagged.path, 0) }
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertEqual(hiddenNode(at: flagged.path, in: result.root)?.isHidden, true)
+    }
+
+    func testVisibleTopLevelDirectoryIsNotRecursivelyScanned() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let visible = temporaryDirectory.url.appendingPathComponent("Users", isDirectory: true)
+        let nested = visible.appendingPathComponent("person/large.dat")
+        try FileManager.default.createDirectory(
+            at: nested.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(repeating: 0x13, count: 65_536).write(to: nested)
+        _ = try makeHiddenDirectory(named: ".selected", fileSize: 1, in: temporaryDirectory.url)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertNil(hiddenNode(at: visible.path, in: result.root))
+        XCTAssertNil(hiddenNode(at: nested.path, in: result.root))
+    }
+
+    func testVisibleRootsDoNotContributeToHiddenStorageTotals() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let hiddenFile = temporaryDirectory.url.appendingPathComponent(".selected")
+        let visibleFile = temporaryDirectory.url.appendingPathComponent("visible-large.dat")
+        try Data(repeating: 0x14, count: 4_096).write(to: hiddenFile)
+        try Data(repeating: 0x15, count: 262_144).write(to: visibleFile)
+        let expected = try hiddenStatValues(for: hiddenFile.path)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertEqual(result.root.logicalSize, expected.logical)
+        XCTAssertEqual(result.root.allocatedSize, expected.allocated)
+        XCTAssertFalse(result.root.isCountedInParentTotals)
+    }
+
+    func testDiscoversMultipleHiddenRoots() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let first = try makeHiddenDirectory(named: ".first", fileSize: 1_024, in: temporaryDirectory.url)
+        let second = try makeHiddenDirectory(named: ".second", fileSize: 2_048, in: temporaryDirectory.url)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertEqual(Set(result.root.children.map(\.absolutePath)), Set([first.path, second.path]))
+    }
+
+    func testFindingsAreSortedByAllocatedThenLogicalSizeAndPath() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        _ = try makeHiddenDirectory(named: ".small", fileSize: 1, in: temporaryDirectory.url)
+        _ = try makeHiddenDirectory(named: ".large", fileSize: 131_072, in: temporaryDirectory.url)
+        _ = try makeHiddenDirectory(named: ".medium", fileSize: 32_768, in: temporaryDirectory.url)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertEqual(result.root.children, result.root.children.sorted(by: hiddenStorageOrdering))
+        XCTAssertEqual(result.root.children.first?.name, ".large")
+    }
+
+    func testAdobeTempIsDiscoveredNaturally() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let adobe = try makeHiddenDirectory(named: ".adobeTemp", fileSize: 4_096, in: temporaryDirectory.url)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertNotNil(hiddenNode(at: adobe.path, in: result.root))
+    }
+
+    func testAdobeTempHasInformationalProductAttributionWithoutCleanupClassification() async throws {
+        let (_, node) = try await analyzeSingleHiddenRoot(named: ".adobeTemp")
+
+        XCTAssertEqual(
+            node.metadata.storageCategoryIdentifier,
+            DataVolumeHiddenStorageCategory.adobeTemporaryStorage.rawValue
+        )
+        XCTAssertEqual(hiddenManagementKind(of: node), .productAttributed)
+        XCTAssertNil(node.metadata.safetyClassificationIdentifier)
+        XCTAssertTrue(node.metadata.explanation?.contains("no cleanup") == true)
+    }
+
+    func testFSEventStoreHasSystemManagedMetadata() async throws {
+        let (_, node) = try await analyzeSingleHiddenRoot(named: ".fseventsd")
+
+        XCTAssertEqual(
+            node.metadata.storageCategoryIdentifier,
+            DataVolumeHiddenStorageCategory.filesystemEvents.rawValue
+        )
+        XCTAssertEqual(hiddenManagementKind(of: node), .systemManaged)
+        XCTAssertTrue(node.metadata.explanation?.contains("macOS") == true)
+    }
+
+    func testSpotlightAndDocumentRevisionStoresHaveSystemManagedMetadata() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let spotlight = try makeHiddenDirectory(named: ".Spotlight-V100", fileSize: 1_024, in: temporaryDirectory.url)
+        let revisions = try makeHiddenDirectory(named: ".DocumentRevisions-V100", fileSize: 1_024, in: temporaryDirectory.url)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+        let spotlightNode = try XCTUnwrap(hiddenNode(at: spotlight.path, in: result.root))
+        let revisionsNode = try XCTUnwrap(hiddenNode(at: revisions.path, in: result.root))
+
+        XCTAssertEqual(
+            spotlightNode.metadata.storageCategoryIdentifier,
+            DataVolumeHiddenStorageCategory.spotlightIndex.rawValue
+        )
+        XCTAssertEqual(
+            revisionsNode.metadata.storageCategoryIdentifier,
+            DataVolumeHiddenStorageCategory.documentRevisions.rawValue
+        )
+        XCTAssertEqual(hiddenManagementKind(of: spotlightNode), .systemManaged)
+        XCTAssertEqual(hiddenManagementKind(of: revisionsNode), .systemManaged)
+    }
+
+    func testUnknownHiddenEntryRemainsVisibleAndUnclassified() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let unknown = try makeHiddenDirectory(named: ".future-product-state", fileSize: 2_048, in: temporaryDirectory.url)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+        let node = try XCTUnwrap(hiddenNode(at: unknown.path, in: result.root))
+
+        XCTAssertEqual(node.metadata.storageCategoryIdentifier, DataVolumeHiddenStorageCategory.unknown.rawValue)
+        XCTAssertEqual(hiddenManagementKind(of: node), .unknown)
+        XCTAssertGreaterThan(node.allocatedSize, 0)
+    }
+
+    func testPreservesCompleteHiddenRootHierarchy() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let hidden = temporaryDirectory.url.appendingPathComponent(".hierarchy", isDirectory: true)
+        let leaf = hidden.appendingPathComponent("one/two/leaf.dat")
+        try FileManager.default.createDirectory(
+            at: leaf.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(repeating: 0x16, count: 1_024).write(to: leaf)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertNotNil(hiddenNode(at: leaf.path, in: result.root))
+        XCTAssertEqual(hiddenNode(at: hidden.path, in: result.root)?.children.first?.name, "one")
+    }
+
+    func testIncludesHiddenDescendantsWithinSelectedRoot() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let hidden = temporaryDirectory.url.appendingPathComponent(".root", isDirectory: true)
+        let hiddenChild = hidden.appendingPathComponent(".internal", isDirectory: true)
+        let hiddenFile = hiddenChild.appendingPathComponent(".payload")
+        try FileManager.default.createDirectory(at: hiddenChild, withIntermediateDirectories: true)
+        try Data([0x17]).write(to: hiddenFile)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertEqual(hiddenNode(at: hiddenChild.path, in: result.root)?.isHidden, true)
+        XCTAssertEqual(hiddenNode(at: hiddenFile.path, in: result.root)?.isHidden, true)
+    }
+
+    func testLogicalAndAllocatedSizesMatchFilesystemMetadata() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let file = temporaryDirectory.url.appendingPathComponent(".sized-file")
+        try Data(repeating: 0x18, count: 33_333).write(to: file)
+        let expected = try hiddenStatValues(for: file.path)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+        let node = try XCTUnwrap(hiddenNode(at: file.path, in: result.root))
+
+        XCTAssertEqual(node.ownLogicalSize, expected.logical)
+        XCTAssertEqual(node.ownAllocatedSize, expected.allocated)
+    }
+
+    func testSparseVirtualDiskPreservesLogicalAndAllocatedSizes() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let hiddenRoot = temporaryDirectory.url.appendingPathComponent(".vm-state", isDirectory: true)
+        try FileManager.default.createDirectory(at: hiddenRoot, withIntermediateDirectories: false)
+        let disk = hiddenRoot.appendingPathComponent("machine.raw")
+        XCTAssertTrue(FileManager.default.createFile(atPath: disk.path, contents: nil))
+        let handle = try FileHandle(forWritingTo: disk)
+        try handle.truncate(atOffset: 32 * 1_024 * 1_024)
+        try handle.close()
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+        let diskNode = try XCTUnwrap(hiddenNode(at: disk.path, in: result.root))
+
+        XCTAssertEqual(diskNode.ownLogicalSize, 32 * 1_024 * 1_024)
+        XCTAssertLessThanOrEqual(diskNode.ownAllocatedSize, diskNode.ownLogicalSize)
+        XCTAssertEqual(
+            diskNode.metadata.attributes[DataVolumeHiddenStorageAnalyzer.MetadataKey.virtualDiskFormat],
+            "raw"
+        )
+        XCTAssertEqual(
+            hiddenNode(at: hiddenRoot.path, in: result.root)?.metadata.attributes[
+                DataVolumeHiddenStorageAnalyzer.MetadataKey.virtualDiskImageCount
+            ],
+            "1"
+        )
+    }
+
+    func testSymbolicLinkIsVisibleWithoutFollowingTarget() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let outside = temporaryDirectory.url.appendingPathComponent("outside", isDirectory: true)
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: false)
+        let outsideFile = outside.appendingPathComponent("large.dat")
+        try Data(repeating: 0x19, count: 262_144).write(to: outsideFile)
+        let link = temporaryDirectory.url.appendingPathComponent(".hidden-link")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outside)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+        let linkNode = try XCTUnwrap(hiddenNode(at: link.path, in: result.root))
+
+        XCTAssertEqual(linkNode.itemType, .symbolicLink)
+        XCTAssertTrue(linkNode.isSymbolicLink)
+        XCTAssertTrue(linkNode.children.isEmpty)
+        XCTAssertNil(hiddenNode(at: outsideFile.path, in: result.root))
+    }
+
+    func testHardLinksInsideOneHiddenRootAreDeduplicated() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let hidden = temporaryDirectory.url.appendingPathComponent(".links", isDirectory: true)
+        try FileManager.default.createDirectory(at: hidden, withIntermediateDirectories: false)
+        let original = hidden.appendingPathComponent("original")
+        let link = hidden.appendingPathComponent("link")
+        try Data(repeating: 0x20, count: 8_192).write(to: original)
+        try FileManager.default.linkItem(at: original, to: link)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+        let linkedNodes = [
+            try XCTUnwrap(hiddenNode(at: original.path, in: result.root)),
+            try XCTUnwrap(hiddenNode(at: link.path, in: result.root))
+        ]
+
+        XCTAssertEqual(linkedNodes.filter(\.isCountedInParentTotals).count, 1)
+    }
+
+    func testHardLinksAcrossSelectedHiddenRootsShareDeduplicationContext() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let first = try makeHiddenDirectory(named: ".first", fileSize: 0, in: temporaryDirectory.url)
+        let second = try makeHiddenDirectory(named: ".second", fileSize: 0, in: temporaryDirectory.url)
+        let original = first.appendingPathComponent("shared.dat")
+        let link = second.appendingPathComponent("shared.dat")
+        try Data(repeating: 0x21, count: 16_384).write(to: original)
+        try FileManager.default.linkItem(at: original, to: link)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+        let linkedNodes = [
+            try XCTUnwrap(hiddenNode(at: original.path, in: result.root)),
+            try XCTUnwrap(hiddenNode(at: link.path, in: result.root))
+        ]
+
+        XCTAssertEqual(linkedNodes.filter(\.isCountedInParentTotals).count, 1)
+        let countedBytes = linkedNodes.filter(\.isCountedInParentTotals).reduce(Int64(0)) {
+            $0 + $1.ownAllocatedSize
+        }
+        XCTAssertEqual(countedBytes, linkedNodes[0].ownAllocatedSize)
+    }
+
+    func testFilesystemBoundaryRemainsVisibleAndExcluded() throws {
+        let boundary = syntheticHiddenNode(
+            name: ".mounted",
+            path: "/System/Volumes/Data/.mounted",
+            itemType: .volumeBoundary,
+            accessibility: .skippedDifferentVolume,
+            isHidden: true,
+            isCounted: false
+        )
+        let root = syntheticHiddenNode(
+            name: "Data",
+            path: "/System/Volumes/Data",
+            itemType: .directory,
+            children: [boundary],
+            isCounted: false
+        )
+
+        let result = DataVolumeHiddenStorageAnalyzer.enrich(
+            syntheticHiddenResult(root: root),
+            largeAllocatedSizeThreshold: 1
+        )
+        let node = try XCTUnwrap(hiddenNode(at: boundary.absolutePath, in: result.root))
+
+        XCTAssertEqual(node.itemType, .volumeBoundary)
+        XCTAssertEqual(hiddenSizeKnowledge(of: node), .excludedDifferentVolume)
+        XCTAssertEqual(result.root.allocatedSize, 0)
+    }
+
+    func testPermissionDeniedHiddenRootPreservesIssueAndPOSIXCode() async throws {
+        guard geteuid() != 0 else { throw XCTSkip("Root can read mode-000 directories.") }
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let protected = try makeHiddenDirectory(named: ".protected", fileSize: 128, in: temporaryDirectory.url)
+        XCTAssertEqual(chmod(protected.path, 0), 0)
+        defer { _ = chmod(protected.path, mode_t(S_IRWXU)) }
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+        let node = try XCTUnwrap(hiddenNode(at: protected.path, in: result.root))
+
+        XCTAssertEqual(node.accessibility, .inaccessible)
+        XCTAssertTrue(node.scanIssues.contains {
+            $0.kind == .permissionDenied && ($0.posixErrorCode == EACCES || $0.posixErrorCode == EPERM)
+        })
+    }
+
+    func testUnknownIncompleteSizeIsDistinctFromAccessibleZero() async throws {
+        guard geteuid() != 0 else { throw XCTSkip("Root can read mode-000 directories.") }
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let empty = try makeHiddenDirectory(named: ".empty", fileSize: 0, in: temporaryDirectory.url)
+        let inaccessible = try makeHiddenDirectory(named: ".unknown", fileSize: 4_096, in: temporaryDirectory.url)
+        XCTAssertEqual(chmod(inaccessible.path, 0), 0)
+        defer { _ = chmod(inaccessible.path, mode_t(S_IRWXU)) }
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+        let emptyNode = try XCTUnwrap(hiddenNode(at: empty.path, in: result.root))
+        let inaccessibleNode = try XCTUnwrap(hiddenNode(at: inaccessible.path, in: result.root))
+
+        XCTAssertEqual(hiddenSizeKnowledge(of: emptyNode), .complete)
+        XCTAssertEqual(hiddenSizeKnowledge(of: inaccessibleNode), .incompleteDueToInaccessibility)
+    }
+
+    func testCancellationReturnsVisiblePartialMarkedAnalysis() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let hidden = temporaryDirectory.url.appendingPathComponent(".large-tree", isDirectory: true)
+        try FileManager.default.createDirectory(at: hidden, withIntermediateDirectories: false)
+        for index in 0..<300 {
+            let directory = hidden.appendingPathComponent("directory-\(index)", isDirectory: true)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+            try Data([UInt8(index % 255)]).write(to: directory.appendingPathComponent("payload"))
+        }
+
+        let analyzer = makeAnalyzer(
+            root: temporaryDirectory.url,
+            scanner: FileTreeScanner(configuration: .init(maxConcurrentDirectoryReads: 1))
+        )
+        let task = Task { await analyzer.analyze() }
+        task.cancel()
+        let result = await task.value
+
+        XCTAssertTrue(result.wasCancelled)
+        XCTAssertTrue(result.issues.contains { $0.kind == .cancelled })
+        XCTAssertEqual(hiddenSizeKnowledge(of: result.root), .incompleteDueToCancellation)
+    }
+
+    func testEmptyDataVolumeRootReturnsAccessibleZeroAnalysis() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertTrue(result.root.children.isEmpty)
+        XCTAssertEqual(result.root.logicalSize, 0)
+        XCTAssertEqual(result.root.allocatedSize, 0)
+        XCTAssertEqual(result.root.accessibility, .accessible)
+    }
+
+    func testRootContainingOnlyVisibleEntriesReturnsNoFindings() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        _ = try makeVisibleDirectory(named: "Library", fileSize: 8_192, in: temporaryDirectory.url)
+        _ = try makeVisibleDirectory(named: "Users", fileSize: 8_192, in: temporaryDirectory.url)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertTrue(result.root.children.isEmpty)
+        XCTAssertEqual(result.root.allocatedSize, 0)
+    }
+
+    func testMissingRootReturnsTypedUnavailableAnalysis() async {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMac-MissingDataVolume-\(UUID().uuidString)", isDirectory: true)
+
+        let result = await makeAnalyzer(root: missing).analyze()
+
+        XCTAssertEqual(result.root.itemType, .unknown)
+        XCTAssertEqual(result.root.accessibility, .inaccessible)
+        XCTAssertTrue(result.issues.contains { $0.kind == .metadataUnavailable })
+    }
+
+    func testNonDirectoryRootReturnsTypedNotDirectoryIssue() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let file = temporaryDirectory.url.appendingPathComponent("data-volume-file")
+        try Data([0x22]).write(to: file)
+
+        let result = await makeAnalyzer(root: file).analyze()
+
+        XCTAssertEqual(result.root.accessibility, .inaccessible)
+        XCTAssertTrue(result.issues.contains {
+            $0.path == file.path && $0.kind == .notDirectory && $0.posixErrorCode == ENOTDIR
+        })
+    }
+
+    func testAccountingReconcilesToSelectedHiddenTreeOnly() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        _ = try makeHiddenDirectory(named: ".one", fileSize: 8_192, in: temporaryDirectory.url)
+        _ = try makeHiddenDirectory(named: ".two", fileSize: 16_384, in: temporaryDirectory.url)
+        _ = try makeVisibleDirectory(named: "private", fileSize: 65_536, in: temporaryDirectory.url)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+        let countedNodes = flattenedHiddenTree(result.root).filter(\.isCountedInParentTotals)
+
+        XCTAssertEqual(
+            result.root.logicalSize,
+            countedNodes.reduce(Int64(0)) { $0 + $1.ownLogicalSize }
+        )
+        XCTAssertEqual(
+            result.root.allocatedSize,
+            countedNodes.reduce(Int64(0)) { $0 + $1.ownAllocatedSize }
+        )
+    }
+
+    func testAnalysisDoesNotMutateHiddenStorage() async throws {
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let hidden = try makeHiddenDirectory(named: ".important", fileSize: 0, in: temporaryDirectory.url)
+        let file = hidden.appendingPathComponent("state.db")
+        let original = Data(repeating: 0x23, count: 4_096)
+        try original.write(to: file)
+        let originalMode = try hiddenStatMode(for: file.path)
+
+        _ = await makeAnalyzer(root: temporaryDirectory.url, largeAllocatedSizeThreshold: 1).analyze()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: file.path))
+        XCTAssertEqual(try Data(contentsOf: file), original)
+        XCTAssertEqual(try hiddenStatMode(for: file.path), originalMode)
+    }
+
+    func testLargeVisibleSiblingTreeIsNeverTraversed() async throws {
+        guard geteuid() != 0 else { throw XCTSkip("Root can read mode-000 directories.") }
+        let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+        let visible = temporaryDirectory.url.appendingPathComponent("Users", isDirectory: true)
+        try FileManager.default.createDirectory(at: visible, withIntermediateDirectories: false)
+        for index in 0..<200 {
+            let directory = visible.appendingPathComponent("user-\(index)", isDirectory: true)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+            try Data([0x24]).write(to: directory.appendingPathComponent("payload"))
+        }
+        XCTAssertEqual(chmod(visible.path, 0), 0)
+        defer { _ = chmod(visible.path, mode_t(S_IRWXU)) }
+        let selected = try makeHiddenDirectory(named: ".selected", fileSize: 1_024, in: temporaryDirectory.url)
+
+        let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertEqual(result.root.children.map(\.absolutePath), [selected.path])
+        XCTAssertFalse(result.issues.contains { $0.path.hasPrefix(visible.path) })
+    }
+}
+
+private final class DataVolumeHiddenTestDirectory {
+    let url: URL
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMac-DataVolumeHiddenTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+private func makeAnalyzer(
+    root: URL,
+    scanner: FileTreeScanner = FileTreeScanner(),
+    largeAllocatedSizeThreshold: Int64 = DataVolumeHiddenStorageAnalyzer.defaultLargeAllocatedSizeThreshold
+) -> DataVolumeHiddenStorageAnalyzer {
+    DataVolumeHiddenStorageAnalyzer(
+        dataVolumeURL: root,
+        scanner: scanner,
+        largeAllocatedSizeThreshold: largeAllocatedSizeThreshold
+    )
+}
+
+@discardableResult
+private func makeHiddenDirectory(
+    named name: String,
+    fileSize: Int,
+    in root: URL
+) throws -> URL {
+    let directory = root.appendingPathComponent(name, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+    if fileSize > 0 {
+        try Data(repeating: UInt8(fileSize % 251), count: fileSize).write(
+            to: directory.appendingPathComponent("payload.dat")
+        )
+    }
+    return directory
+}
+
+@discardableResult
+private func makeVisibleDirectory(
+    named name: String,
+    fileSize: Int,
+    in root: URL
+) throws -> URL {
+    let directory = root.appendingPathComponent(name, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+    if fileSize > 0 {
+        try Data(repeating: UInt8(fileSize % 251), count: fileSize).write(
+            to: directory.appendingPathComponent("payload.dat")
+        )
+    }
+    return directory
+}
+
+private func analyzeSingleHiddenRoot(
+    named name: String
+) async throws -> (DataVolumeHiddenTestDirectory, StorageNode) {
+    let temporaryDirectory = try DataVolumeHiddenTestDirectory()
+    let root = try makeHiddenDirectory(named: name, fileSize: 1_024, in: temporaryDirectory.url)
+    let result = await makeAnalyzer(root: temporaryDirectory.url).analyze()
+    return (temporaryDirectory, try XCTUnwrap(hiddenNode(at: root.path, in: result.root)))
+}
+
+private func hiddenNode(at path: String, in root: StorageNode) -> StorageNode? {
+    var pending = [root]
+    while let node = pending.popLast() {
+        if node.absolutePath == path { return node }
+        pending.append(contentsOf: node.children)
+    }
+    return nil
+}
+
+private func flattenedHiddenTree(_ root: StorageNode) -> [StorageNode] {
+    var nodes: [StorageNode] = []
+    var pending = [root]
+    while let node = pending.popLast() {
+        nodes.append(node)
+        pending.append(contentsOf: node.children)
+    }
+    return nodes
+}
+
+private func hiddenStorageOrdering(_ left: StorageNode, _ right: StorageNode) -> Bool {
+    if left.allocatedSize != right.allocatedSize { return left.allocatedSize > right.allocatedSize }
+    if left.logicalSize != right.logicalSize { return left.logicalSize > right.logicalSize }
+    return left.absolutePath < right.absolutePath
+}
+
+private func hiddenManagementKind(of node: StorageNode) -> DataVolumeHiddenManagementKind? {
+    node.metadata.attributes[DataVolumeHiddenStorageAnalyzer.MetadataKey.managementKind]
+        .flatMap(DataVolumeHiddenManagementKind.init(rawValue:))
+}
+
+private func hiddenSizeKnowledge(of node: StorageNode) -> DataVolumeHiddenSizeKnowledge? {
+    node.metadata.attributes[DataVolumeHiddenStorageAnalyzer.MetadataKey.sizeKnowledge]
+        .flatMap(DataVolumeHiddenSizeKnowledge.init(rawValue:))
+}
+
+private func hiddenStatValues(for path: String) throws -> (logical: Int64, allocated: Int64) {
+    var metadata = stat()
+    guard lstat(path, &metadata) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: Darwin.errno) ?? .EIO)
+    }
+    return (Int64(metadata.st_size), Int64(metadata.st_blocks) * 512)
+}
+
+private func hiddenStatMode(for path: String) throws -> mode_t {
+    var metadata = stat()
+    guard lstat(path, &metadata) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: Darwin.errno) ?? .EIO)
+    }
+    return metadata.st_mode
+}
+
+private func syntheticHiddenResult(root: StorageNode) -> StorageAnalysisResult {
+    StorageAnalysisResult(
+        root: root,
+        startedAt: Date(),
+        completedAt: Date(),
+        rootDeviceIdentifier: 1,
+        wasCancelled: false,
+        issues: root.scanIssues
+    )
+}
+
+private func syntheticHiddenNode(
+    name: String,
+    path: String,
+    itemType: StorageItemType,
+    children: [StorageNode] = [],
+    accessibility: StorageAccessibility = .accessible,
+    isHidden: Bool = false,
+    isCounted: Bool = true
+) -> StorageNode {
+    StorageNode(
+        name: name,
+        absolutePath: path,
+        logicalSize: children.reduce(0) { $0 + $1.logicalSize },
+        allocatedSize: children.reduce(0) { $0 + $1.allocatedSize },
+        ownLogicalSize: 0,
+        ownAllocatedSize: 0,
+        itemType: itemType,
+        children: children,
+        accessibility: accessibility,
+        scanIssues: [],
+        isHidden: isHidden,
+        isSymbolicLink: false,
+        isCountedInParentTotals: isCounted,
+        metadata: StorageAnalysisMetadata()
+    )
+}

--- a/PureMacTests/DataVolumeInternalGapTests.swift
+++ b/PureMacTests/DataVolumeInternalGapTests.swift
@@ -1,0 +1,509 @@
+import XCTest
+@testable import PureMac
+
+final class DataVolumeInternalGapTests: XCTestCase {
+
+    private func makeSyntheticReport(
+        dataVolumePhysicalInUse: Int64 = 189_653_327_872, // ~189.65 GB
+        explainedBytes: Int64 = 143_240_000_000,          // ~143.24 GB
+        purgeableBytes: Int64 = 20_000_000_000,          // ~20.00 GB
+        snapshotBytes: Int64 = 5_000_000_000,
+        unreadablePathCount: Int = 12,
+        analyzerResultsOverride: StorageAnalyzerResults? = nil,
+        diagnosticOverride: StorageCoverageDiagnostic? = nil
+    ) -> StorageReconciliationReport {
+        let unexplained = max(0, dataVolumePhysicalInUse - explainedBytes)
+
+        let snapshot = APFSSnapshotInformation(
+            identifier: "snap-1",
+            name: "com.apple.TimeMachine.2026-08-20",
+            uuid: "UUID-1",
+            creationDate: Date(),
+            size: snapshotBytes,
+            sizeKnowledge: .reportedBySystem,
+            type: .timeMachine,
+            source: .diskutil,
+            storageRelationship: .sharedNonAdditive
+        )
+
+        let apfsReport = APFSStorageReport(
+            volume: APFSVolumeInformation(
+                name: "mac - Data",
+                volumeIdentifier: "disk3s1",
+                volumeUUID: "UUID-DATA",
+                containerIdentifier: "disk3",
+                volumeGroupIdentifier: "UUID-GROUP",
+                filesystemType: "apfs",
+                filesystemKind: .apfs,
+                mountPoint: "/System/Volumes/Data",
+                dataVolumeRelationship: .dataVolume,
+                capacity: APFSVolumeCapacity(
+                    totalCapacity: 245_107_195_904,
+                    availableCapacity: 27_908_403_200,
+                    usedCapacity: dataVolumePhysicalInUse,
+                    availableCapacityForImportantUsage: 27_908_403_200 + purgeableBytes,
+                    availableCapacityForOpportunisticUsage: 27_908_403_200 + purgeableBytes,
+                    purgeableEstimate: purgeableBytes,
+                    purgeableEstimateKnowledge: .estimated
+                )
+            ),
+            snapshots: [snapshot],
+            state: .complete,
+            accountingRelationship: .volumeMetadataAndSnapshotsAreNonAdditiveToFilesystemTrees,
+            wasCancelled: false,
+            issues: []
+        )
+
+        let defaultAnalyzerResults = StorageAnalyzerResults(
+            userHomeStorage: nil,
+            applicationSupport: nil,
+            containers: nil,
+            groupContainers: nil,
+            systemLibrary: nil,
+            privateStorage: nil,
+            dataVolumeHiddenStorage: nil,
+            developerSystemStorage: nil,
+            dockerStorage: nil,
+            apfsStorage: apfsReport,
+            coverageExpansion: nil,
+            physicalReconciliation: nil
+        )
+
+        return StorageReconciliationReport(
+            totalCapacityBytes: 245_107_195_904,
+            usedCapacityBytes: 217_198_792_704, // Container total used
+            availableCapacityBytes: 27_908_403_200,
+            purgeableEstimateBytes: purgeableBytes,
+            explainedAllocatedBytes: explainedBytes,
+            unexplainedBytes: unexplained,
+            inaccessibleKnownLowerBoundBytes: 500_000_000,
+            unreadablePathCount: unreadablePathCount,
+            incompleteCoverage: false,
+            coverageStatus: .completeForConfiguredRoots,
+            canonicalRootCoverage: [],
+            filesystemContributions: [],
+            hardLinkAccountingStatus: .deduplicatedWithinAnalyzerScopesOnly,
+            analysisIssues: [],
+            analyzerResults: analyzerResultsOverride ?? defaultAnalyzerResults,
+            coverageDiagnostic: diagnosticOverride ?? .empty,
+            attributionReport: nil,
+            physicalReconciliation: nil,
+            startedAt: Date(),
+            completedAt: Date(),
+            duration: 0.5,
+            progress: StorageAnalysisProgress(totalStages: 11, completedStages: 11, runningStages: [], state: .completed),
+            wasCancelled: false
+        )
+    }
+
+    // MARK: - Tests
+
+    // 1. Internal-gap calculation (~46.41 GB)
+    func testInternalGapCalculation() {
+        let rep = makeSyntheticReport(dataVolumePhysicalInUse: 189_653_327_872, explainedBytes: 143_240_000_000)
+        let analyzer = DataVolumeInternalGapAnalyzer()
+        let report = analyzer.analyze(reconciliationReport: rep, dataVolumePhysicalInUse: 189_653_327_872)
+
+        XCTAssertEqual(report.dataVolumePhysicalInUseBytes, 189_653_327_872)
+        XCTAssertEqual(report.filesystemAttributedBytes, 143_240_000_000)
+        XCTAssertEqual(report.internalPhysicalGapBytes, 46_413_327_872)
+        XCTAssertEqual(report.unresolvedResidualGapBytes, 46_413_327_872)
+    }
+
+    // 2. Logical vs allocated byte distinction
+    func testLogicalVsAllocatedDistinction() {
+        let node = StorageNode(
+            name: "testFile",
+            absolutePath: "/test/file",
+            logicalSize: 1000,
+            allocatedSize: 4096,
+            ownLogicalSize: 1000,
+            ownAllocatedSize: 4096,
+            itemType: .regularFile,
+            children: [],
+            accessibility: .accessible,
+            scanIssues: [],
+            isHidden: false,
+            isSymbolicLink: false,
+            isCountedInParentTotals: true,
+            metadata: StorageAnalysisMetadata()
+        )
+        let analysisResult = StorageAnalysisResult(
+            root: node,
+            startedAt: Date(),
+            completedAt: Date(),
+            rootDeviceIdentifier: 1,
+            wasCancelled: false,
+            issues: []
+        )
+
+        let analyzerResults = StorageAnalyzerResults(
+            userHomeStorage: nil,
+            applicationSupport: analysisResult,
+            containers: nil,
+            groupContainers: nil,
+            systemLibrary: nil,
+            privateStorage: nil,
+            dataVolumeHiddenStorage: nil,
+            developerSystemStorage: nil,
+            dockerStorage: nil,
+            apfsStorage: nil,
+            coverageExpansion: nil,
+            physicalReconciliation: nil
+        )
+
+        let rep = makeSyntheticReport(analyzerResultsOverride: analyzerResults)
+
+        let analyzer = DataVolumeInternalGapAnalyzer()
+        let report = analyzer.analyze(reconciliationReport: rep, dataVolumePhysicalInUse: 189_653_327_872)
+
+        XCTAssertEqual(report.allocationDeltaSummary.totalMeasuredLogicalBytes, 1000)
+        XCTAssertEqual(report.allocationDeltaSummary.totalMeasuredAllocatedBytes, 4096)
+        XCTAssertEqual(report.allocationDeltaSummary.deltaBytes, 3096)
+        XCTAssertTrue(report.allocationDeltaSummary.blockPaddingObserved)
+    }
+
+    // 3. Sparse-file handling in allocation diagnostics
+    func testSparseFileHandling() {
+        let node = StorageNode(
+            name: "sparse.img",
+            absolutePath: "/test/sparse.img",
+            logicalSize: 64_000_000_000,
+            allocatedSize: 2_000_000_000,
+            ownLogicalSize: 64_000_000_000,
+            ownAllocatedSize: 2_000_000_000,
+            itemType: .regularFile,
+            children: [],
+            accessibility: .accessible,
+            scanIssues: [],
+            isHidden: false,
+            isSymbolicLink: false,
+            isCountedInParentTotals: true,
+            metadata: StorageAnalysisMetadata()
+        )
+        let analysisResult = StorageAnalysisResult(
+            root: node,
+            startedAt: Date(),
+            completedAt: Date(),
+            rootDeviceIdentifier: 1,
+            wasCancelled: false,
+            issues: []
+        )
+
+        let analyzerResults = StorageAnalyzerResults(
+            userHomeStorage: nil,
+            applicationSupport: nil,
+            containers: analysisResult,
+            groupContainers: nil,
+            systemLibrary: nil,
+            privateStorage: nil,
+            dataVolumeHiddenStorage: nil,
+            developerSystemStorage: nil,
+            dockerStorage: nil,
+            apfsStorage: nil,
+            coverageExpansion: nil,
+            physicalReconciliation: nil
+        )
+
+        let rep = makeSyntheticReport(analyzerResultsOverride: analyzerResults)
+
+        let analyzer = DataVolumeInternalGapAnalyzer()
+        let report = analyzer.analyze(reconciliationReport: rep, dataVolumePhysicalInUse: 189_653_327_872)
+
+        XCTAssertEqual(report.allocationDeltaSummary.totalMeasuredLogicalBytes, 64_000_000_000)
+        XCTAssertEqual(report.allocationDeltaSummary.totalMeasuredAllocatedBytes, 2_000_000_000)
+        XCTAssertEqual(report.allocationDeltaSummary.deltaBytes, -62_000_000_000)
+        XCTAssertTrue(report.allocationDeltaSummary.sparseFilesObserved)
+    }
+
+    // 4. Hard-link deduplication preserved
+    func testHardLinkDeduplicationPreserved() {
+        let rep = makeSyntheticReport()
+        XCTAssertEqual(rep.hardLinkAccountingStatus, .deduplicatedWithinAnalyzerScopesOnly)
+        let analyzer = DataVolumeInternalGapAnalyzer()
+        let report = analyzer.analyze(reconciliationReport: rep, dataVolumePhysicalInUse: 189_653_327_872)
+        XCTAssertEqual(report.filesystemAttributedBytes, rep.explainedAllocatedBytes)
+    }
+
+    // 5. Clone evidence does not become additive
+    func testCloneEvidenceDoesNotBecomeAdditive() {
+        let rep = makeSyntheticReport()
+        let analyzer = DataVolumeInternalGapAnalyzer()
+        let report = analyzer.analyze(reconciliationReport: rep, dataVolumePhysicalInUse: 189_653_327_872)
+
+        let cloneItem = report.waterfallItems.first { $0.category == .cloneSharedExtents }
+        XCTAssertNotNil(cloneItem)
+        XCTAssertEqual(cloneItem?.tier, .presenceOnly)
+        XCTAssertNil(cloneItem?.reportedBytes)
+        // Clone evidence must not increase additive explained bytes
+        XCTAssertEqual(report.additiveExplainedPortionBytes, 0)
+    }
+
+    // 6. Purgeable does not reduce residual
+    func testPurgeableDoesNotReduceResidual() {
+        let rep = makeSyntheticReport(dataVolumePhysicalInUse: 189_653_327_872, explainedBytes: 143_240_000_000, purgeableBytes: 20_000_000_000)
+        let analyzer = DataVolumeInternalGapAnalyzer()
+        let report = analyzer.analyze(reconciliationReport: rep, dataVolumePhysicalInUse: 189_653_327_872)
+
+        let purgeableItem = report.waterfallItems.first { $0.category == .purgeableEstimate }
+        XCTAssertNotNil(purgeableItem)
+        XCTAssertEqual(purgeableItem?.tier, .estimatedOSReported)
+        XCTAssertEqual(purgeableItem?.reportedBytes, 20_000_000_000)
+
+        // Invariant: purgeable must NOT reduce the residual gap of 46.41 GB
+        XCTAssertEqual(report.internalPhysicalGapBytes, 46_413_327_872)
+        XCTAssertEqual(report.unresolvedResidualGapBytes, 46_413_327_872)
+        XCTAssertEqual(report.additiveExplainedPortionBytes, 0)
+    }
+
+    // 7. Protected paths do not receive fabricated sizes
+    func testProtectedPathsDoNotReceiveFabricatedSizes() {
+        let issueGroup = StorageCoverageDiagnosticIssueGroup(
+            category: .permissionDenied,
+            severity: .warning,
+            source: .analyzer(.systemLibrary),
+            canonicalRoot: .systemLibrary,
+            posixErrorCode: 13,
+            count: 10,
+            representativePaths: ["/System/Volumes/Data/.Spotlight-V100/store.db"],
+            explanation: "Permission denied"
+        )
+        let diag = StorageCoverageDiagnostic(
+            measurementIssues: StorageCoverageIssueAggregation(
+                totalIssueCount: 10,
+                categoryCounts: [],
+                analyzerCounts: [],
+                canonicalRootCounts: [],
+                errnoCounts: [],
+                topAffectedParentPaths: [],
+                groups: [issueGroup]
+            ),
+            coverageMap: [],
+            coverageGaps: [],
+            analyzerStatuses: [],
+            unexplainedSpaceExplanations: [],
+            explainedStorageConfidence: .completeMeasurement,
+            unexplainedStorageConfidence: .knownLowerBound,
+            hiddenHomeEntryCount: 0,
+            unspecializedLibraryEntryCount: 0
+        )
+        let rep = makeSyntheticReport(diagnosticOverride: diag)
+        let analyzer = DataVolumeInternalGapAnalyzer()
+        let report = analyzer.analyze(reconciliationReport: rep, dataVolumePhysicalInUse: 189_653_327_872)
+
+        let protectedItem = report.waterfallItems.first { $0.category == DataVolumeGapEvidenceCategory.protectedStorage }
+        XCTAssertNotNil(protectedItem)
+        XCTAssertEqual(protectedItem?.tier, .unknownProtected)
+        XCTAssertNil(protectedItem?.reportedBytes) // Must be nil (no fabricated bytes)
+
+        let spotlightFamily = report.protectedSummary.families.first { $0.id == "spotlight" }
+        XCTAssertNotNil(spotlightFamily)
+        XCTAssertNil(spotlightFamily?.knownLowerBoundBytes)
+    }
+
+    // 8. APFS metadata evidence remains non-additive / presence-only
+    func testAPFSMetadataEvidenceRemainsPresenceOnly() {
+        let rep = makeSyntheticReport()
+        let analyzer = DataVolumeInternalGapAnalyzer()
+        let report = analyzer.analyze(reconciliationReport: rep, dataVolumePhysicalInUse: 189_653_327_872)
+
+        let metadataItem = report.waterfallItems.first { $0.category == .apfsFilesystemMetadata }
+        XCTAssertNotNil(metadataItem)
+        XCTAssertEqual(metadataItem?.tier, .presenceOnly)
+        XCTAssertNil(metadataItem?.reportedBytes)
+    }
+
+    // 9. Existing Explained bytes remain unchanged
+    func testExistingExplainedBytesRemainUnchanged() {
+        let rep = makeSyntheticReport(explainedBytes: 143_240_000_000)
+        let analyzer = DataVolumeInternalGapAnalyzer()
+        let report = analyzer.analyze(reconciliationReport: rep, dataVolumePhysicalInUse: 189_653_327_872)
+        XCTAssertEqual(report.filesystemAttributedBytes, 143_240_000_000)
+    }
+
+    // 10. Existing 27.41 GB sibling-volume reconciliation remains intact
+    func testSiblingVolumeReconciliationIntact() async {
+        let rep = makeSyntheticReport()
+        let physicalAnalyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(
+                terminationStatus: 0,
+                stdout: APFSPhysicalReconciliationTests().sampleAPFSListPlistDataForTesting,
+                stderr: Data(),
+                launchError: nil,
+                wasCancelled: false
+            )
+        })
+        let physicalReport = await physicalAnalyzer.analyze(reconciliationReport: rep)
+
+        XCTAssertEqual(physicalReport.metrics.containerSiblingVolumesBytes, 27_365_883_904)
+        XCTAssertNotNil(physicalReport.dataVolumeInternalGap)
+        XCTAssertEqual(physicalReport.dataVolumeInternalGap?.internalPhysicalGapBytes, 46_413_327_872)
+    }
+
+    // 11. Data volume and container accounting remain distinct
+    func testDataVolumeAndContainerAccountingDistinct() async {
+        let rep = makeSyntheticReport()
+        let physicalAnalyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(
+                terminationStatus: 0,
+                stdout: APFSPhysicalReconciliationTests().sampleAPFSListPlistDataForTesting,
+                stderr: Data(),
+                launchError: nil,
+                wasCancelled: false
+            )
+        })
+        let physicalReport = await physicalAnalyzer.analyze(reconciliationReport: rep)
+
+        // Container physical gap: 73.96 GB
+        XCTAssertEqual(physicalReport.metrics.physicalAccountingGapBytes, 73_958_792_704)
+        // Data volume internal gap: 46.41 GB
+        XCTAssertEqual(physicalReport.metrics.dataVolumeInternalGapBytes, 46_413_327_872)
+        XCTAssertNotEqual(physicalReport.metrics.physicalAccountingGapBytes, physicalReport.metrics.dataVolumeInternalGapBytes)
+    }
+
+    // 12. Unknown evidence remains unknown
+    func testUnknownEvidenceRemainsUnknown() {
+        let rep = makeSyntheticReport()
+        let analyzer = DataVolumeInternalGapAnalyzer()
+        let report = analyzer.analyze(reconciliationReport: rep, dataVolumePhysicalInUse: 189_653_327_872)
+
+        let residual = report.waterfallItems.first { $0.category == .unresolvedResidual }
+        XCTAssertNotNil(residual)
+        XCTAssertEqual(residual?.tier, .unknownProtected)
+        XCTAssertEqual(residual?.badgeText, "Unresolved")
+    }
+
+    // 13. Additive evidence is the only evidence allowed to reduce a diagnostic residual
+    func testOnlyAdditiveEvidenceReducesResidual() {
+        let rep = makeSyntheticReport(dataVolumePhysicalInUse: 189_653_327_872, explainedBytes: 143_240_000_000)
+        let analyzer = DataVolumeInternalGapAnalyzer()
+        let report = analyzer.analyze(reconciliationReport: rep, dataVolumePhysicalInUse: 189_653_327_872)
+
+        // Even though non-additive evidence exists (purgeable ~20GB, snapshots ~5GB),
+        // additiveExplainedPortionBytes is strictly 0 and residual is NOT reduced.
+        XCTAssertEqual(report.additiveExplainedPortionBytes, 0)
+        XCTAssertEqual(report.unresolvedResidualGapBytes, 46_413_327_872)
+    }
+
+    // 14. Cancellation support
+    func testCancellation() {
+        var rep = makeSyntheticReport()
+        rep = StorageReconciliationReport(
+            totalCapacityBytes: rep.totalCapacityBytes,
+            usedCapacityBytes: rep.usedCapacityBytes,
+            availableCapacityBytes: rep.availableCapacityBytes,
+            purgeableEstimateBytes: rep.purgeableEstimateBytes,
+            explainedAllocatedBytes: rep.explainedAllocatedBytes,
+            unexplainedBytes: rep.unexplainedBytes,
+            inaccessibleKnownLowerBoundBytes: rep.inaccessibleKnownLowerBoundBytes,
+            unreadablePathCount: rep.unreadablePathCount,
+            incompleteCoverage: rep.incompleteCoverage,
+            coverageStatus: rep.coverageStatus,
+            canonicalRootCoverage: rep.canonicalRootCoverage,
+            filesystemContributions: rep.filesystemContributions,
+            hardLinkAccountingStatus: rep.hardLinkAccountingStatus,
+            analysisIssues: rep.analysisIssues,
+            analyzerResults: rep.analyzerResults,
+            coverageDiagnostic: rep.coverageDiagnostic,
+            attributionReport: rep.attributionReport,
+            physicalReconciliation: rep.physicalReconciliation,
+            startedAt: rep.startedAt,
+            completedAt: rep.completedAt,
+            duration: rep.duration,
+            progress: rep.progress,
+            wasCancelled: true
+        )
+
+        let analyzer = DataVolumeInternalGapAnalyzer()
+        let report = analyzer.analyze(reconciliationReport: rep, dataVolumePhysicalInUse: 189_653_327_872)
+        XCTAssertTrue(report.wasCancelled)
+    }
+
+    // 15. Command timeout / failure
+    func testCommandFailureSafety() async {
+        let rep = makeSyntheticReport()
+        let physicalAnalyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(
+                terminationStatus: 1,
+                stdout: Data(),
+                stderr: "Query timeout".data(using: .utf8)!,
+                launchError: nil,
+                wasCancelled: false
+            )
+        })
+        let physicalReport = await physicalAnalyzer.analyze(reconciliationReport: rep)
+
+        XCTAssertFalse(physicalReport.issues.isEmpty)
+        XCTAssertNotNil(physicalReport.dataVolumeInternalGap)
+    }
+
+    // 16. UI/state presentation
+    @MainActor
+    func testUIPresentationIntegration() async {
+        let rep = makeSyntheticReport()
+        let physicalAnalyzer = APFSPhysicalReconciliationAnalyzer(commandRunner: { _ in
+            APFSCommandResult(
+                terminationStatus: 0,
+                stdout: APFSPhysicalReconciliationTests().sampleAPFSListPlistDataForTesting,
+                stderr: Data(),
+                launchError: nil,
+                wasCancelled: false
+            )
+        })
+        let physicalReport = await physicalAnalyzer.analyze(reconciliationReport: rep)
+
+        let finalReport = StorageReconciliationReport(
+            totalCapacityBytes: rep.totalCapacityBytes,
+            usedCapacityBytes: rep.usedCapacityBytes,
+            availableCapacityBytes: rep.availableCapacityBytes,
+            purgeableEstimateBytes: rep.purgeableEstimateBytes,
+            explainedAllocatedBytes: rep.explainedAllocatedBytes,
+            unexplainedBytes: rep.unexplainedBytes,
+            inaccessibleKnownLowerBoundBytes: rep.inaccessibleKnownLowerBoundBytes,
+            unreadablePathCount: rep.unreadablePathCount,
+            incompleteCoverage: rep.incompleteCoverage,
+            coverageStatus: rep.coverageStatus,
+            canonicalRootCoverage: rep.canonicalRootCoverage,
+            filesystemContributions: rep.filesystemContributions,
+            hardLinkAccountingStatus: rep.hardLinkAccountingStatus,
+            analysisIssues: rep.analysisIssues,
+            analyzerResults: rep.analyzerResults,
+            coverageDiagnostic: rep.coverageDiagnostic,
+            attributionReport: rep.attributionReport,
+            physicalReconciliation: physicalReport,
+            startedAt: rep.startedAt,
+            completedAt: rep.completedAt,
+            duration: rep.duration,
+            progress: rep.progress,
+            wasCancelled: rep.wasCancelled
+        )
+
+        let state = StorageIntelligenceState(
+            analysisRunner: { _ in finalReport }
+        )
+        state.analyze()
+        await state.waitForAnalysis()
+
+        XCTAssertNotNil(state.physicalReconciliationPresentation?.report.dataVolumeInternalGap)
+        XCTAssertEqual(
+            state.physicalReconciliationPresentation?.report.dataVolumeInternalGap?.internalPhysicalGapBytes,
+            46_413_327_872
+        )
+    }
+
+    // 17. Full regression suite integration
+    func testFullRegressionSuiteIntegration() {
+        let rep = makeSyntheticReport()
+        let analyzer = DataVolumeInternalGapAnalyzer()
+        let report = analyzer.analyze(reconciliationReport: rep, dataVolumePhysicalInUse: 189_653_327_872)
+
+        XCTAssertFalse(report.waterfallItems.isEmpty)
+        XCTAssertEqual(report.waterfallItems.count, 7)
+    }
+}
+
+extension APFSPhysicalReconciliationTests {
+    var sampleAPFSListPlistDataForTesting: Data {
+        sampleAPFSListPlistData
+    }
+}

--- a/PureMacTests/DataVolumeTopLevelSafetyNetTests.swift
+++ b/PureMacTests/DataVolumeTopLevelSafetyNetTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+@testable import PureMac
+
+final class DataVolumeTopLevelSafetyNetTests: XCTestCase {
+    private var temporaryDirectoryURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        temporaryDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMacSafetyNetTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryDirectoryURL, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let temporaryDirectoryURL, FileManager.default.fileExists(atPath: temporaryDirectoryURL.path) {
+            try? FileManager.default.removeItem(at: temporaryDirectoryURL)
+        }
+        temporaryDirectoryURL = nil
+        try super.tearDownWithError()
+    }
+
+    private func makeSyntheticReport(coverageExpansionCandidates: [StorageCoverageCandidate] = []) -> StorageReconciliationReport {
+        let expansionReport = StorageCoverageExpansionReport(
+            totalNewlyMeasuredBytes: 0,
+            measuredCandidateCount: coverageExpansionCandidates.count,
+            excludedOverlapCount: 0,
+            inaccessibleCandidateCount: 0,
+            differentVolumeBoundaryCount: 0,
+            failedCandidateCount: 0,
+            candidates: coverageExpansionCandidates,
+            largestDiscoveredRegions: [],
+            treeResults: [],
+            wasCancelled: false,
+            issues: []
+        )
+
+        let results = StorageAnalyzerResults(
+            userHomeStorage: nil,
+            applications: nil,
+            applicationSupport: nil,
+            containers: nil,
+            groupContainers: nil,
+            systemLibrary: nil,
+            privateStorage: nil,
+            dataVolumeHiddenStorage: nil,
+            developerSystemStorage: nil,
+            dockerStorage: nil,
+            apfsStorage: nil,
+            coverageExpansion: expansionReport,
+            physicalReconciliation: nil
+        )
+
+        return StorageReconciliationReport(
+            totalCapacityBytes: 245_107_195_904,
+            usedCapacityBytes: 189_177_487_360,
+            availableCapacityBytes: 28_384_145_408,
+            purgeableEstimateBytes: 0,
+            explainedAllocatedBytes: 143_240_000_000,
+            unexplainedBytes: 46_413_327_872,
+            inaccessibleKnownLowerBoundBytes: 0,
+            unreadablePathCount: 0,
+            incompleteCoverage: false,
+            coverageStatus: .completeForConfiguredRoots,
+            canonicalRootCoverage: [],
+            filesystemContributions: [],
+            hardLinkAccountingStatus: .deduplicatedWithinAnalyzerScopesOnly,
+            analysisIssues: [],
+            analyzerResults: results,
+            coverageDiagnostic: .empty,
+            attributionReport: nil,
+            physicalReconciliation: nil,
+            startedAt: Date(),
+            completedAt: Date(),
+            duration: 0.1,
+            progress: StorageAnalysisProgress(totalStages: 12, completedStages: 12, runningStages: [], state: .completed),
+            wasCancelled: false
+        )
+    }
+
+    // 1. Safety net audits entries
+    func testSafetyNetAuditsEntries() throws {
+        try FileManager.default.createDirectory(at: temporaryDirectoryURL.appendingPathComponent("Applications"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: temporaryDirectoryURL.appendingPathComponent("Users"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: temporaryDirectoryURL.appendingPathComponent("Library"), withIntermediateDirectories: true)
+
+        let checker = DataVolumeTopLevelSafetyNetChecker(dataVolumeURL: temporaryDirectoryURL)
+        let report = checker.audit(reconciliationReport: makeSyntheticReport())
+
+        XCTAssertEqual(report.totalEntriesCount, 3)
+        XCTAssertEqual(report.unownedEntriesCount, 0)
+        XCTAssertTrue(report.isFullyCovered)
+    }
+
+    // 2. Canonical analyzers classified correctly
+    func testCanonicalAnalyzersClassified() throws {
+        try FileManager.default.createDirectory(at: temporaryDirectoryURL.appendingPathComponent("Applications"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: temporaryDirectoryURL.appendingPathComponent("private"), withIntermediateDirectories: true)
+
+        let checker = DataVolumeTopLevelSafetyNetChecker(dataVolumeURL: temporaryDirectoryURL)
+        let report = checker.audit(reconciliationReport: makeSyntheticReport())
+
+        let appEntry = report.entries.first { $0.name == "Applications" }
+        XCTAssertEqual(appEntry?.ownershipStatus, .ownedByCanonicalAnalyzer)
+        XCTAssertEqual(appEntry?.owningAnalyzerStage, .applications)
+        XCTAssertEqual(appEntry?.canonicalOwner, .applications)
+
+        let privEntry = report.entries.first { $0.name == "private" }
+        XCTAssertEqual(privEntry?.ownershipStatus, .ownedByCanonicalAnalyzer)
+        XCTAssertEqual(privEntry?.owningAnalyzerStage, .privateStorage)
+    }
+
+    // 3. Coverage expansion candidates classified (e.g. macOS Install Data)
+    func testCoverageExpansionCandidateClassified() throws {
+        let installDataURL = temporaryDirectoryURL.appendingPathComponent("macOS Install Data")
+        try FileManager.default.createDirectory(at: installDataURL, withIntermediateDirectories: true)
+
+        let candidate = StorageCoverageCandidate(
+            originalPath: installDataURL.path,
+            normalizedPath: installDataURL.path,
+            name: "macOS Install Data",
+            scope: .dataVolumeRoot,
+            status: .measured,
+            allocatedBytes: 3_281_436_000,
+            logicalBytes: 3_281_436_000,
+            issue: nil,
+            exclusionReason: nil,
+            contributesToExplainedBytes: true
+        )
+
+        let checker = DataVolumeTopLevelSafetyNetChecker(dataVolumeURL: temporaryDirectoryURL)
+        let report = checker.audit(reconciliationReport: makeSyntheticReport(coverageExpansionCandidates: [candidate]))
+
+        let entry = report.entries.first { $0.name == "macOS Install Data" }
+        XCTAssertNotNil(entry)
+        XCTAssertEqual(entry?.ownershipStatus, .ownedByCoverageExpansion)
+        XCTAssertEqual(entry?.owningAnalyzerStage, .coverageExpansion)
+        XCTAssertTrue(entry?.isFilesystemAdditive == true)
+    }
+
+    // 4. Intentionally non-additive classified
+    func testIntentionallyNonAdditiveClassified() throws {
+        try FileManager.default.createDirectory(at: temporaryDirectoryURL.appendingPathComponent(".Spotlight-V100"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: temporaryDirectoryURL.appendingPathComponent("Volumes"), withIntermediateDirectories: true)
+
+        let checker = DataVolumeTopLevelSafetyNetChecker(dataVolumeURL: temporaryDirectoryURL)
+        let report = checker.audit(reconciliationReport: makeSyntheticReport())
+
+        let spotlight = report.entries.first { $0.name == ".Spotlight-V100" }
+        let volumes = report.entries.first { $0.name == "Volumes" }
+
+        XCTAssertEqual(spotlight?.ownershipStatus, .intentionallyNonAdditive)
+        XCTAssertEqual(volumes?.ownershipStatus, .intentionallyNonAdditive)
+    }
+
+    // 5. Unowned potential gap detected
+    func testUnownedPotentialGapDetected() throws {
+        try FileManager.default.createDirectory(at: temporaryDirectoryURL.appendingPathComponent("MysteryNewFolder"), withIntermediateDirectories: true)
+
+        let checker = DataVolumeTopLevelSafetyNetChecker(dataVolumeURL: temporaryDirectoryURL)
+        let report = checker.audit(reconciliationReport: makeSyntheticReport())
+
+        let mystery = report.entries.first { $0.name == "MysteryNewFolder" }
+        XCTAssertEqual(mystery?.ownershipStatus, .unownedPotentialCoverageGap)
+        XCTAssertEqual(report.unownedEntriesCount, 1)
+        XCTAssertFalse(report.isFullyCovered)
+    }
+}

--- a/PureMacTests/DeveloperSystemStorageAnalyzerTests.swift
+++ b/PureMacTests/DeveloperSystemStorageAnalyzerTests.swift
@@ -1,0 +1,575 @@
+import Darwin
+import XCTest
+@testable import PureMac
+
+final class DeveloperSystemStorageAnalyzerTests: XCTestCase {
+    func testOptAnalysisPreservesCanonicalIdentity() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        try makeDirectory(named: "tool", fileSize: 1_024, in: roots.opt)
+
+        let report = await roots.analyzer().analyze()
+
+        XCTAssertEqual(DeveloperSystemStorageAnalyzer.defaultOptURL.path, "/opt")
+        XCTAssertEqual(report.opt.canonicalRoot, .opt)
+        XCTAssertEqual(report.opt.configuredPath, roots.opt.path)
+        XCTAssertEqual(report.opt.state, .present)
+        XCTAssertNotNil(node(named: "tool", under: report.opt.result.root))
+    }
+
+    func testUsrLocalAnalysisPreservesCanonicalIdentity() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        try makeDirectory(named: "sdk", fileSize: 1_024, in: roots.usrLocal)
+
+        let report = await roots.analyzer().analyze()
+
+        XCTAssertEqual(DeveloperSystemStorageAnalyzer.defaultUsrLocalURL.path, "/usr/local")
+        XCTAssertEqual(report.usrLocal.canonicalRoot, .usrLocal)
+        XCTAssertEqual(report.usrLocal.configuredPath, roots.usrLocal.path)
+        XCTAssertEqual(report.usrLocal.state, .present)
+        XCTAssertNotNil(node(named: "sdk", under: report.usrLocal.result.root))
+    }
+
+    func testMissingOptDoesNotFailUsrLocal() async throws {
+        let roots = try DeveloperSystemTestRoots(createOpt: false)
+        try makeDirectory(named: "bin", fileSize: 512, in: roots.usrLocal)
+
+        let report = await roots.analyzer().analyze()
+
+        XCTAssertEqual(report.opt.state, .missing)
+        XCTAssertEqual(report.usrLocal.state, .present)
+        XCTAssertNotNil(node(named: "bin", under: report.usrLocal.result.root))
+    }
+
+    func testBothMissingRootsRemainSeparate() async throws {
+        let roots = try DeveloperSystemTestRoots(createOpt: false, createUsrLocal: false)
+
+        let report = await roots.analyzer().analyze()
+
+        XCTAssertEqual(report.opt.state, .missing)
+        XCTAssertEqual(report.usrLocal.state, .missing)
+        XCTAssertNotEqual(report.opt.configuredPath, report.usrLocal.configuredPath)
+        XCTAssertEqual(report.combinedSizeKnowledge, .complete)
+        XCTAssertEqual(
+            report.opt.result.root.metadata.attributes[DeveloperSystemStorageAnalyzer.MetadataKey.sizeKnowledge],
+            DeveloperSystemSizeKnowledge.complete.rawValue
+        )
+    }
+
+    func testInvalidRootIsReportedWithoutFollowingIt() async throws {
+        let roots = try DeveloperSystemTestRoots(createOpt: false)
+        try Data([0x01]).write(to: roots.opt)
+
+        let report = await roots.analyzer().analyze()
+
+        XCTAssertEqual(report.opt.state, .invalid)
+        XCTAssertEqual(report.opt.result.root.itemType, .regularFile)
+        XCTAssertTrue(report.opt.result.issues.contains { $0.kind == .notDirectory })
+    }
+
+    func testMultipleImmediateChildrenArePreserved() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        for name in ["alpha", "beta", "gamma"] {
+            try makeDirectory(named: name, fileSize: 1_024, in: roots.opt)
+        }
+
+        let report = await roots.analyzer().analyze()
+
+        XCTAssertEqual(Set(report.opt.result.root.children.map(\.name)), Set(["alpha", "beta", "gamma"]))
+        XCTAssertEqual(
+            report.opt.result.root.metadata.attributes[DeveloperSystemStorageAnalyzer.MetadataKey.directChildCount],
+            "3"
+        )
+    }
+
+    func testImmediateChildrenUseAllocatedSizeDescendingOrdering() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        try makeDirectory(named: "small", fileSize: 4_096, in: roots.opt)
+        try makeDirectory(named: "large", fileSize: 2_097_152, in: roots.opt)
+        try makeDirectory(named: "medium", fileSize: 262_144, in: roots.opt)
+
+        let children = await roots.analyzer().analyze().opt.result.root.children
+
+        XCTAssertEqual(children.map(\.name), ["large", "medium", "small"])
+        XCTAssertTrue(zip(children, children.dropFirst()).allSatisfy {
+            allocatedBefore($0, $1)
+        })
+    }
+
+    func testOptHomebrewReceivesPackageManagerMetadata() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        try makeDirectory(named: "homebrew", fileSize: 1, in: roots.opt)
+
+        let root = await roots.analyzer().analyze().opt.result.root
+        let homebrew = try XCTUnwrap(node(named: "homebrew", under: root))
+
+        XCTAssertEqual(homebrew.metadata.storageCategoryIdentifier, DeveloperSystemStorageCategory.packageManagerStorage.rawValue)
+        XCTAssertTrue(homebrew.metadata.explanation?.contains("Homebrew") == true)
+        XCTAssertNil(homebrew.metadata.safetyClassificationIdentifier)
+    }
+
+    func testUsrLocalHomebrewReceivesPackageManagerMetadata() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        try makeDirectory(named: "Homebrew", fileSize: 1, in: roots.usrLocal)
+
+        let root = await roots.analyzer().analyze().usrLocal.result.root
+        let homebrew = try XCTUnwrap(node(named: "Homebrew", under: root))
+
+        XCTAssertEqual(homebrew.metadata.storageCategoryIdentifier, DeveloperSystemStorageCategory.packageManagerStorage.rawValue)
+        XCTAssertTrue(homebrew.metadata.explanation?.contains("Homebrew") == true)
+    }
+
+    func testCellarReceivesPackageManagerMetadata() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        try makeDirectory(named: "Cellar", fileSize: 1, in: roots.usrLocal)
+
+        let root = await roots.analyzer().analyze().usrLocal.result.root
+        let cellar = try XCTUnwrap(node(named: "Cellar", under: root))
+
+        XCTAssertEqual(cellar.metadata.storageCategoryIdentifier, DeveloperSystemStorageCategory.packageManagerStorage.rawValue)
+        XCTAssertTrue(cellar.metadata.explanation?.contains("formula") == true)
+    }
+
+    func testCaskroomReceivesPackageManagerMetadata() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        try makeDirectory(named: "Caskroom", fileSize: 1, in: roots.usrLocal)
+
+        let root = await roots.analyzer().analyze().usrLocal.result.root
+        let caskroom = try XCTUnwrap(node(named: "Caskroom", under: root))
+
+        XCTAssertEqual(caskroom.metadata.storageCategoryIdentifier, DeveloperSystemStorageCategory.packageManagerStorage.rawValue)
+        XCTAssertTrue(caskroom.metadata.explanation?.contains("Cask") == true)
+    }
+
+    func testBinLibAndShareReceiveLightweightCategories() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        for name in ["bin", "lib", "share"] {
+            try makeDirectory(named: name, fileSize: 1, in: roots.usrLocal)
+        }
+
+        let root = await roots.analyzer().analyze().usrLocal.result.root
+
+        XCTAssertEqual(node(named: "bin", under: root)?.metadata.storageCategoryIdentifier,
+                       DeveloperSystemStorageCategory.executableStorage.rawValue)
+        XCTAssertEqual(node(named: "lib", under: root)?.metadata.storageCategoryIdentifier,
+                       DeveloperSystemStorageCategory.libraryStorage.rawValue)
+        XCTAssertEqual(node(named: "share", under: root)?.metadata.storageCategoryIdentifier,
+                       DeveloperSystemStorageCategory.sharedResourceStorage.rawValue)
+    }
+
+    func testUnknownEntriesRemainVisibleWithoutGuessedAttribution() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        try makeDirectory(named: "vendor-product", fileSize: 1, in: roots.opt)
+
+        let root = await roots.analyzer().analyze().opt.result.root
+        let unknown = try XCTUnwrap(node(named: "vendor-product", under: root))
+
+        XCTAssertEqual(unknown.metadata.storageCategoryIdentifier, DeveloperSystemStorageCategory.unknown.rawValue)
+        XCTAssertNil(unknown.metadata.safetyClassificationIdentifier)
+    }
+
+    func testHiddenFilesAndDirectoriesAreIncluded() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        let hiddenDirectory = roots.opt.appendingPathComponent(".hidden", isDirectory: true)
+        try FileManager.default.createDirectory(at: hiddenDirectory, withIntermediateDirectories: false)
+        let hiddenFile = hiddenDirectory.appendingPathComponent(".state")
+        try Data([0x02]).write(to: hiddenFile)
+
+        let root = await roots.analyzer().analyze().opt.result.root
+
+        XCTAssertEqual(node(at: hiddenDirectory.path, in: root)?.isHidden, true)
+        XCTAssertEqual(node(at: hiddenFile.path, in: root)?.isHidden, true)
+    }
+
+    func testFullHierarchyIsPreserved() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        let first = roots.opt.appendingPathComponent("tool", isDirectory: true)
+        let second = first.appendingPathComponent("sdk", isDirectory: true)
+        let third = second.appendingPathComponent("runtime", isDirectory: true)
+        try FileManager.default.createDirectory(at: third, withIntermediateDirectories: true)
+        try Data([0x03]).write(to: third.appendingPathComponent("manifest"))
+
+        let root = await roots.analyzer().analyze().opt.result.root
+
+        XCTAssertNotNil(node(at: third.path, in: root))
+        XCTAssertNotNil(node(at: third.appendingPathComponent("manifest").path, in: root))
+    }
+
+    func testLogicalAndAllocatedSizesMatchFilesystemMetadata() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        let payload = try makeDirectory(named: "tool", fileSize: 32_768, in: roots.opt)
+            .appendingPathComponent("payload.dat")
+        let expected = try statValues(for: payload.path)
+
+        let root = await roots.analyzer().analyze().opt.result.root
+        let scanned = try XCTUnwrap(node(at: payload.path, in: root))
+
+        XCTAssertEqual(scanned.ownLogicalSize, expected.logical)
+        XCTAssertEqual(scanned.ownAllocatedSize, expected.allocated)
+    }
+
+    func testSparseVirtualDiskPreservesPhysicalDistinctionAndMetadata() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        let vm = roots.opt.appendingPathComponent("vm", isDirectory: true)
+        try FileManager.default.createDirectory(at: vm, withIntermediateDirectories: false)
+        let disk = vm.appendingPathComponent("machine.raw")
+        XCTAssertTrue(FileManager.default.createFile(atPath: disk.path, contents: nil))
+        let logicalBytes: UInt64 = 64 * 1_024 * 1_024
+        let handle = try FileHandle(forWritingTo: disk)
+        try handle.truncate(atOffset: logicalBytes)
+        try handle.close()
+
+        let root = await roots.analyzer().analyze().opt.result.root
+        let diskNode = try XCTUnwrap(node(at: disk.path, in: root))
+        let vmNode = try XCTUnwrap(node(at: vm.path, in: root))
+
+        XCTAssertEqual(diskNode.ownLogicalSize, Int64(logicalBytes))
+        XCTAssertEqual(diskNode.metadata.attributes[DeveloperSystemStorageAnalyzer.MetadataKey.virtualDiskFormat], "raw")
+        XCTAssertEqual(vmNode.metadata.attributes[DeveloperSystemStorageAnalyzer.MetadataKey.virtualDiskImageCount], "1")
+        if diskNode.ownAllocatedSize >= diskNode.ownLogicalSize {
+            throw XCTSkip("The test filesystem eagerly allocated the sparse file.")
+        }
+        XCTAssertEqual(diskNode.metadata.attributes[DeveloperSystemStorageAnalyzer.MetadataKey.virtualDiskSparseState], "sparse")
+    }
+
+    func testSymlinkBetweenRootsIsVisibleAndNeverFollowed() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        let homebrew = try makeDirectory(named: "homebrew", fileSize: 1_048_576, in: roots.opt)
+        let targetFile = homebrew.appendingPathComponent("payload.dat")
+        let alias = roots.usrLocal.appendingPathComponent("Homebrew")
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: homebrew)
+
+        let report = await roots.analyzer().analyze()
+        let aliasNode = try XCTUnwrap(node(at: alias.path, in: report.usrLocal.result.root))
+
+        XCTAssertTrue(aliasNode.isSymbolicLink)
+        XCTAssertEqual(aliasNode.itemType, .symbolicLink)
+        XCTAssertTrue(aliasNode.children.isEmpty)
+        XCTAssertNil(node(at: targetFile.path, in: report.usrLocal.result.root))
+        XCTAssertNotNil(node(at: targetFile.path, in: report.opt.result.root))
+    }
+
+    func testHardLinksWithinOneRootAreDeduplicated() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        let firstDirectory = try makeDirectory(named: "first", fileSize: 0, in: roots.opt)
+        let secondDirectory = try makeDirectory(named: "second", fileSize: 0, in: roots.opt)
+        let original = firstDirectory.appendingPathComponent("shared")
+        let linked = secondDirectory.appendingPathComponent("shared")
+        try Data(repeating: 0x04, count: 8_192).write(to: original)
+        try FileManager.default.linkItem(at: original, to: linked)
+
+        let root = await roots.analyzer().analyze().opt.result.root
+        let aliases = try [XCTUnwrap(node(at: original.path, in: root)), XCTUnwrap(node(at: linked.path, in: root))]
+
+        XCTAssertEqual(aliases.filter(\.isCountedInParentTotals).count, 1)
+    }
+
+    func testCrossRootHardLinksKeepStandaloneTotalsAndDeduplicateCombinedTotal() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        let optFile = roots.opt.appendingPathComponent("shared.dat")
+        let usrFile = roots.usrLocal.appendingPathComponent("shared.dat")
+        try Data(repeating: 0x05, count: 16_384).write(to: optFile)
+        try FileManager.default.linkItem(at: optFile, to: usrFile)
+
+        let report = await roots.analyzer().analyze()
+        let optNode = try XCTUnwrap(node(at: optFile.path, in: report.opt.result.root))
+        let usrNode = try XCTUnwrap(node(at: usrFile.path, in: report.usrLocal.result.root))
+        let standaloneAllocated = report.opt.result.root.allocatedSize + report.usrLocal.result.root.allocatedSize
+        let standaloneLogical = report.opt.result.root.logicalSize + report.usrLocal.result.root.logicalSize
+
+        XCTAssertTrue(optNode.isCountedInParentTotals)
+        XCTAssertTrue(usrNode.isCountedInParentTotals)
+        XCTAssertEqual(report.combinedUniqueAllocatedSize, standaloneAllocated - optNode.ownAllocatedSize)
+        XCTAssertEqual(report.combinedUniqueLogicalSize, standaloneLogical - optNode.ownLogicalSize)
+    }
+
+    func testPermissionDeniedPreservesPOSIXIssue() async throws {
+        guard geteuid() != 0 else { throw XCTSkip("A root process can read mode-000 directories.") }
+        let roots = try DeveloperSystemTestRoots()
+        let protected = try makeDirectory(named: "protected", fileSize: 128, in: roots.opt)
+        XCTAssertEqual(chmod(protected.path, 0), 0)
+        defer { _ = chmod(protected.path, mode_t(S_IRWXU)) }
+
+        let report = await roots.analyzer().analyze()
+        let protectedNode = try XCTUnwrap(node(at: protected.path, in: report.opt.result.root))
+        let issue = try XCTUnwrap(protectedNode.scanIssues.first { $0.kind == .permissionDenied })
+
+        XCTAssertEqual(protectedNode.accessibility, .inaccessible)
+        XCTAssertNotNil(issue.posixErrorCode)
+    }
+
+    func testUnreadableSubtreeIsMarkedAsKnownLowerBound() async throws {
+        guard geteuid() != 0 else { throw XCTSkip("A root process can read mode-000 directories.") }
+        let roots = try DeveloperSystemTestRoots()
+        try makeDirectory(named: "readable", fileSize: 128, in: roots.opt)
+        let protected = try makeDirectory(named: "protected", fileSize: 8_192, in: roots.opt)
+        XCTAssertEqual(chmod(protected.path, 0), 0)
+        defer { _ = chmod(protected.path, mode_t(S_IRWXU)) }
+
+        let report = await roots.analyzer().analyze()
+        let root = report.opt.result.root
+
+        XCTAssertEqual(report.opt.state, .partiallyReadable)
+        XCTAssertEqual(root.metadata.attributes[DeveloperSystemStorageAnalyzer.MetadataKey.sizeKnowledge],
+                       DeveloperSystemSizeKnowledge.knownLowerBound.rawValue)
+        XCTAssertGreaterThan(root.allocatedSize, 0)
+    }
+
+    func testFilesystemBoundaryIsPreservedAndExcluded() throws {
+        let boundaryPath = "/opt/external"
+        let boundaryIssue = StorageScanIssue(
+            path: boundaryPath,
+            kind: .differentVolume,
+            message: "Traversal stopped because this item is on a different mounted filesystem.",
+            posixErrorCode: nil
+        )
+        let boundary = syntheticNode(
+            name: "external",
+            path: boundaryPath,
+            itemType: .volumeBoundary,
+            accessibility: .skippedDifferentVolume,
+            issues: [boundaryIssue],
+            isCounted: false,
+            ownLogicalSize: 8_192,
+            ownAllocatedSize: 8_192
+        )
+        let optRoot = syntheticNode(name: "opt", path: "/opt", children: [boundary])
+        let usrRoot = syntheticNode(name: "local", path: "/usr/local")
+
+        let report = DeveloperSystemStorageAnalyzer.makeReport(
+            optResult: syntheticResult(root: optRoot, issues: [boundaryIssue]),
+            usrLocalResult: syntheticResult(root: usrRoot),
+            combinedUniqueLogicalSize: optRoot.logicalSize + usrRoot.logicalSize,
+            combinedUniqueAllocatedSize: optRoot.allocatedSize + usrRoot.allocatedSize,
+            largeAllocatedSizeThreshold: 1
+        )
+        let preserved = try XCTUnwrap(node(at: boundaryPath, in: report.opt.result.root))
+
+        XCTAssertEqual(preserved.accessibility, .skippedDifferentVolume)
+        XCTAssertFalse(preserved.isCountedInParentTotals)
+        XCTAssertEqual(preserved.metadata.attributes[DeveloperSystemStorageAnalyzer.MetadataKey.sizeKnowledge],
+                       DeveloperSystemSizeKnowledge.excludedDifferentVolume.rawValue)
+    }
+
+    func testCancellationMarksBothIndependentResults() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        for index in 0..<300 {
+            try makeDirectory(named: "opt-\(index)", fileSize: 32, in: roots.opt)
+            try makeDirectory(named: "local-\(index)", fileSize: 32, in: roots.usrLocal)
+        }
+        let analyzer = roots.analyzer(
+            scanner: FileTreeScanner(configuration: .init(maxConcurrentDirectoryReads: 1))
+        )
+        let task = Task { await analyzer.analyze() }
+        task.cancel()
+
+        let report = await task.value
+
+        XCTAssertTrue(report.wasCancelled)
+        XCTAssertTrue(report.issues.contains { $0.kind == .cancelled })
+        XCTAssertEqual(report.combinedSizeKnowledge, .incompleteDueToCancellation)
+    }
+
+    func testEmptyRootsReturnCompleteSeparateTrees() async throws {
+        let roots = try DeveloperSystemTestRoots()
+
+        let report = await roots.analyzer().analyze()
+
+        XCTAssertTrue(report.opt.result.root.children.isEmpty)
+        XCTAssertTrue(report.usrLocal.result.root.children.isEmpty)
+        XCTAssertEqual(report.opt.state, .present)
+        XCTAssertEqual(report.usrLocal.state, .present)
+        XCTAssertEqual(report.combinedSizeKnowledge, .complete)
+    }
+
+    func testHomebrewExecutableIsNeverInvoked() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        let homebrew = roots.opt.appendingPathComponent("homebrew", isDirectory: true)
+        try FileManager.default.createDirectory(at: homebrew, withIntermediateDirectories: false)
+        let marker = roots.base.appendingPathComponent("brew-was-run")
+        let fakeBrew = homebrew.appendingPathComponent("brew")
+        let script = "#!/bin/sh\ntouch \(marker.path)\n"
+        try Data(script.utf8).write(to: fakeBrew)
+        XCTAssertEqual(chmod(fakeBrew.path, mode_t(S_IRWXU)), 0)
+
+        _ = await roots.analyzer().analyze()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: marker.path))
+    }
+
+    func testAnalysisDoesNotMutateFilesystem() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        let directory = try makeDirectory(named: "tool", fileSize: 4_096, in: roots.opt)
+        let payload = directory.appendingPathComponent("payload.dat")
+        let beforeData = try Data(contentsOf: payload)
+        let beforeStat = try statValues(for: payload.path)
+
+        _ = await roots.analyzer().analyze()
+
+        XCTAssertEqual(try Data(contentsOf: payload), beforeData)
+        XCTAssertEqual(try statValues(for: payload.path), beforeStat)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: payload.path))
+    }
+
+    func testAccountingReconcilesPerRootAndCombinedWithoutSharedLinks() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        try makeDirectory(named: "tool", fileSize: 8_192, in: roots.opt)
+        try makeDirectory(named: "bin", fileSize: 16_384, in: roots.usrLocal)
+
+        let report = await roots.analyzer().analyze()
+
+        assertReconciles(report.opt.result.root)
+        assertReconciles(report.usrLocal.result.root)
+        XCTAssertEqual(report.combinedUniqueLogicalSize,
+                       report.opt.result.root.logicalSize + report.usrLocal.result.root.logicalSize)
+        XCTAssertEqual(report.combinedUniqueAllocatedSize,
+                       report.opt.result.root.allocatedSize + report.usrLocal.result.root.allocatedSize)
+    }
+
+    func testRootAndLargeItemMetadataRemainInformational() async throws {
+        let roots = try DeveloperSystemTestRoots()
+        try makeDirectory(named: "large-vendor", fileSize: 4_096, in: roots.opt)
+
+        let report = await roots.analyzer(largeAllocatedSizeThreshold: 1).analyze()
+        let large = try XCTUnwrap(node(named: "large-vendor", under: report.opt.result.root))
+
+        XCTAssertEqual(report.opt.result.root.metadata.storageCategoryIdentifier,
+                       DeveloperSystemStorageCategory.thirdPartyStorage.rawValue)
+        XCTAssertEqual(report.usrLocal.result.root.metadata.storageCategoryIdentifier,
+                       DeveloperSystemStorageCategory.developerToolStorage.rawValue)
+        XCTAssertEqual(large.metadata.isUnusuallyLarge, true)
+        XCTAssertNil(large.metadata.safetyClassificationIdentifier)
+    }
+}
+
+private final class DeveloperSystemTestRoots {
+    let base: URL
+    let opt: URL
+    let usrLocal: URL
+
+    init(createOpt: Bool = true, createUsrLocal: Bool = true) throws {
+        base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMac-DeveloperSystem-\(UUID().uuidString)", isDirectory: true)
+        opt = base.appendingPathComponent("opt", isDirectory: true)
+        usrLocal = base.appendingPathComponent("usr-local", isDirectory: true)
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: false)
+        if createOpt {
+            try FileManager.default.createDirectory(at: opt, withIntermediateDirectories: false)
+        }
+        if createUsrLocal {
+            try FileManager.default.createDirectory(at: usrLocal, withIntermediateDirectories: false)
+        }
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: base)
+    }
+
+    func analyzer(
+        scanner: FileTreeScanner = FileTreeScanner(),
+        largeAllocatedSizeThreshold: Int64 = DeveloperSystemStorageAnalyzer.defaultLargeAllocatedSizeThreshold
+    ) -> DeveloperSystemStorageAnalyzer {
+        DeveloperSystemStorageAnalyzer(
+            optURL: opt,
+            usrLocalURL: usrLocal,
+            scanner: scanner,
+            largeAllocatedSizeThreshold: largeAllocatedSizeThreshold
+        )
+    }
+}
+
+@discardableResult
+private func makeDirectory(named name: String, fileSize: Int, in parent: URL) throws -> URL {
+    let directory = parent.appendingPathComponent(name, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+    if fileSize > 0 {
+        try Data(repeating: 0x7A, count: fileSize).write(to: directory.appendingPathComponent("payload.dat"))
+    }
+    return directory
+}
+
+private func node(named name: String, under root: StorageNode) -> StorageNode? {
+    root.children.first { $0.name == name }
+}
+
+private func node(at path: String, in root: StorageNode) -> StorageNode? {
+    var pending = [root]
+    while let current = pending.popLast() {
+        if current.absolutePath == path { return current }
+        pending.append(contentsOf: current.children)
+    }
+    return nil
+}
+
+private func allocatedBefore(_ left: StorageNode, _ right: StorageNode) -> Bool {
+    if left.allocatedSize != right.allocatedSize { return left.allocatedSize > right.allocatedSize }
+    if left.logicalSize != right.logicalSize { return left.logicalSize > right.logicalSize }
+    return left.absolutePath < right.absolutePath
+}
+
+private struct TestStatValues: Equatable {
+    let logical: Int64
+    let allocated: Int64
+}
+
+private func statValues(for path: String) throws -> TestStatValues {
+    var value = stat()
+    guard lstat(path, &value) == 0 else {
+        throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+    }
+    return TestStatValues(logical: Int64(value.st_size), allocated: Int64(value.st_blocks) * 512)
+}
+
+private func assertReconciles(_ node: StorageNode, file: StaticString = #filePath, line: UInt = #line) {
+    let childLogical = node.children.reduce(Int64(0)) { $0 + $1.logicalSize }
+    let childAllocated = node.children.reduce(Int64(0)) { $0 + $1.allocatedSize }
+    let ownLogical = node.isCountedInParentTotals ? node.ownLogicalSize : 0
+    let ownAllocated = node.isCountedInParentTotals ? node.ownAllocatedSize : 0
+    XCTAssertEqual(node.logicalSize, ownLogical + childLogical, file: file, line: line)
+    XCTAssertEqual(node.allocatedSize, ownAllocated + childAllocated, file: file, line: line)
+    for child in node.children { assertReconciles(child, file: file, line: line) }
+}
+
+private func syntheticNode(
+    name: String,
+    path: String,
+    itemType: StorageItemType = .directory,
+    children: [StorageNode] = [],
+    accessibility: StorageAccessibility = .accessible,
+    issues: [StorageScanIssue] = [],
+    isCounted: Bool = true,
+    ownLogicalSize: Int64 = 96,
+    ownAllocatedSize: Int64 = 4_096
+) -> StorageNode {
+    let logical = (isCounted ? ownLogicalSize : 0) + children.reduce(Int64(0)) { $0 + $1.logicalSize }
+    let allocated = (isCounted ? ownAllocatedSize : 0) + children.reduce(Int64(0)) { $0 + $1.allocatedSize }
+    return StorageNode(
+        name: name,
+        absolutePath: path,
+        logicalSize: logical,
+        allocatedSize: allocated,
+        ownLogicalSize: ownLogicalSize,
+        ownAllocatedSize: ownAllocatedSize,
+        itemType: itemType,
+        children: children,
+        accessibility: accessibility,
+        scanIssues: issues,
+        isHidden: false,
+        isSymbolicLink: false,
+        isCountedInParentTotals: isCounted,
+        metadata: StorageAnalysisMetadata()
+    )
+}
+
+private func syntheticResult(
+    root: StorageNode,
+    issues: [StorageScanIssue] = []
+) -> StorageAnalysisResult {
+    StorageAnalysisResult(
+        root: root,
+        startedAt: Date(),
+        completedAt: Date(),
+        rootDeviceIdentifier: 1,
+        wasCancelled: false,
+        issues: issues
+    )
+}

--- a/PureMacTests/DockerStorageAnalyzerTests.swift
+++ b/PureMacTests/DockerStorageAnalyzerTests.swift
@@ -1,0 +1,685 @@
+import Darwin
+import XCTest
+@testable import PureMac
+
+final class DockerStorageAnalyzerTests: XCTestCase {
+    func testDockerNotInstalledIsExplicitAndDoesNotRunCommand() async {
+        let recorder = DockerCommandRecorder(result: successfulDockerResult())
+        let analyzer = DockerStorageAnalyzer(
+            hostStorageRoots: [],
+            executableLocator: { nil },
+            commandRunner: { request in await recorder.run(request) }
+        )
+
+        let report = await analyzer.analyze()
+
+        XCTAssertEqual(report.runtimeStatus, .notInstalled)
+        XCTAssertNil(report.runtimeAccounting)
+        XCTAssertNil(report.dockerExecutablePath)
+        XCTAssertTrue(report.issues.contains { $0.kind == .executableNotFound })
+        XCTAssertTrue(recorder.recordedRequests.isEmpty)
+    }
+
+    func testInstalledDockerWithUnavailableDaemonKeepsExplicitStatus() async {
+        let recorder = DockerCommandRecorder(result: .init(
+            terminationStatus: 1,
+            stdout: "",
+            stderr: "Cannot connect to the Docker daemon. Is the docker daemon running?",
+            launchError: nil,
+            wasCancelled: false
+        ))
+        let analyzer = makeDockerAnalyzer(roots: [], recorder: recorder)
+
+        let report = await analyzer.analyze()
+
+        XCTAssertEqual(report.runtimeStatus, .installedDaemonUnavailable)
+        XCTAssertNil(report.runtimeAccounting)
+        XCTAssertTrue(report.issues.contains { $0.kind == .daemonUnavailable })
+        XCTAssertEqual(recorder.recordedRequests.count, 2)
+    }
+
+    func testAvailableDockerParsesAllRuntimeAccountingCategoriesAndCounts() async throws {
+        let recorder = DockerCommandRecorder(result: successfulDockerResult())
+        let report = await makeDockerAnalyzer(roots: [], recorder: recorder).analyze()
+        let accounting = try XCTUnwrap(report.runtimeAccounting)
+
+        XCTAssertEqual(report.runtimeStatus, .installedAndReachable)
+        XCTAssertEqual(accounting.images?.totalBytes, 8_000_000_000)
+        XCTAssertEqual(accounting.images?.objectCount, 10)
+        XCTAssertEqual(accounting.images?.activeCount, 4)
+        XCTAssertEqual(accounting.containers?.totalBytes, 2_000_000_000)
+        XCTAssertEqual(accounting.localVolumes?.totalBytes, 4_000_000_000)
+        XCTAssertEqual(accounting.buildCache?.totalBytes, 1_000_000_000)
+        XCTAssertEqual(report.totalRuntimeReportedBytes, 15_000_000_000)
+        XCTAssertTrue(accounting.isComplete)
+    }
+
+    func testMalformedDockerOutputReturnsPartialStatusWithoutFilesystemFailure() async {
+        let recorder = DockerCommandRecorder(result: .init(
+            terminationStatus: 0,
+            stdout: """
+            not-json
+            {"Type":"Images","TotalCount":"1","Active":"0","Size":"not-a-size","Reclaimable":"0B (0%)"}
+            """,
+            stderr: "",
+            launchError: nil,
+            wasCancelled: false
+        ))
+
+        let report = await makeDockerAnalyzer(roots: [], recorder: recorder).analyze()
+
+        XCTAssertEqual(report.runtimeStatus, .partiallyReadable)
+        XCTAssertNil(report.runtimeAccounting?.images?.totalBytes)
+        XCTAssertTrue(report.issues.contains { $0.kind == .malformedRuntimeOutput })
+        XCTAssertEqual(report.hostFootprint.allocatedSize, 0)
+    }
+
+    func testHostDockerStorageIsReturnedWhenDaemonIsUnavailable() async throws {
+        let temporaryDirectory = try DockerTestDirectory()
+        let payload = temporaryDirectory.url.appendingPathComponent("host-storage.dat")
+        try Data(repeating: 0x21, count: 65_536).write(to: payload)
+        let recorder = DockerCommandRecorder(result: .init(
+            terminationStatus: 1,
+            stdout: "",
+            stderr: "Cannot connect to the Docker daemon",
+            launchError: nil,
+            wasCancelled: false
+        ))
+
+        let report = await makeDockerAnalyzer(
+            roots: [temporaryDirectory.url],
+            recorder: recorder
+        ).analyze()
+
+        XCTAssertEqual(report.runtimeStatus, .installedDaemonUnavailable)
+        XCTAssertEqual(report.hostFootprint.locations.count, 1)
+        XCTAssertGreaterThan(report.hostFootprint.logicalSize, 0)
+        XCTAssertGreaterThan(report.hostFootprint.allocatedSize, 0)
+        XCTAssertNotNil(
+            dockerNode(at: payload.path, in: report.hostFootprint.locations[0].root)
+        )
+    }
+
+    func testDetectsSparseDockerVirtualDiskAndPreservesSparseStatus() async throws {
+        let temporaryDirectory = try DockerTestDirectory()
+        let virtualDisk = temporaryDirectory.url.appendingPathComponent("Docker.raw")
+        XCTAssertTrue(FileManager.default.createFile(atPath: virtualDisk.path, contents: nil))
+        let logicalByteCount: UInt64 = 64 * 1_024 * 1_024
+        let handle = try FileHandle(forWritingTo: virtualDisk)
+        try handle.truncate(atOffset: logicalByteCount)
+        try handle.close()
+
+        let report = await makeDockerAnalyzer(
+            roots: [temporaryDirectory.url],
+            installed: false
+        ).analyze()
+        let disk = try XCTUnwrap(report.virtualDisks.first { $0.absolutePath == virtualDisk.path })
+
+        XCTAssertEqual(disk.format, .raw)
+        XCTAssertEqual(disk.logicalSize, Int64(logicalByteCount))
+        if disk.allocatedSize >= disk.logicalSize {
+            throw XCTSkip("The test filesystem eagerly allocated the sparse virtual disk.")
+        }
+        XCTAssertEqual(disk.sparseState, .sparse)
+    }
+
+    func testVirtualDiskLogicalAndAllocatedSizesMatchFilesystemMetadata() async throws {
+        let temporaryDirectory = try DockerTestDirectory()
+        let virtualDisk = temporaryDirectory.url.appendingPathComponent("desktop.qcow2")
+        try Data(repeating: 0x31, count: 32_768).write(to: virtualDisk)
+        let expected = try dockerStatValues(for: virtualDisk.path)
+
+        let report = await makeDockerAnalyzer(
+            roots: [temporaryDirectory.url],
+            installed: false
+        ).analyze()
+        let disk = try XCTUnwrap(report.virtualDisks.first { $0.absolutePath == virtualDisk.path })
+
+        XCTAssertEqual(disk.logicalSize, expected.logical)
+        XCTAssertEqual(disk.allocatedSize, expected.allocated)
+        XCTAssertEqual(disk.storageNode.ownLogicalSize, expected.logical)
+        XCTAssertEqual(disk.storageNode.ownAllocatedSize, expected.allocated)
+    }
+
+    func testRuntimeTotalsRemainSeparateFromHostMacDiskUsage() async throws {
+        let temporaryDirectory = try DockerTestDirectory()
+        try Data(repeating: 0x41, count: 1_048_576).write(
+            to: temporaryDirectory.url.appendingPathComponent("host.dat")
+        )
+        let recorder = DockerCommandRecorder(result: successfulDockerResult())
+
+        let report = await makeDockerAnalyzer(
+            roots: [temporaryDirectory.url],
+            recorder: recorder
+        ).analyze()
+        let runtimeBytes = try XCTUnwrap(report.totalRuntimeReportedBytes)
+
+        XCTAssertEqual(
+            report.accountingRelationship,
+            .runtimeBreakdownIsNonAdditiveToHostFootprint
+        )
+        XCTAssertEqual(report.macDiskUsageBytes, report.hostFootprint.allocatedSize)
+        XCTAssertNotEqual(
+            report.macDiskUsageBytes,
+            report.hostFootprint.allocatedSize + runtimeBytes
+        )
+    }
+
+    func testOverlappingHostRootsAreScannedOnceWithoutDoubleCounting() async throws {
+        let temporaryDirectory = try DockerTestDirectory()
+        let nested = temporaryDirectory.url.appendingPathComponent("nested", isDirectory: true)
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: false)
+        try Data(repeating: 0x51, count: 8_192).write(
+            to: nested.appendingPathComponent("payload.dat")
+        )
+
+        let report = await makeDockerAnalyzer(
+            roots: [temporaryDirectory.url, nested, temporaryDirectory.url],
+            installed: false
+        ).analyze()
+        let location = try XCTUnwrap(report.hostFootprint.locations.first)
+
+        XCTAssertEqual(report.hostFootprint.locations.count, 1)
+        XCTAssertEqual(location.root.absolutePath, temporaryDirectory.url.path)
+        XCTAssertEqual(report.hostFootprint.logicalSize, location.root.logicalSize)
+        XCTAssertEqual(report.hostFootprint.allocatedSize, location.root.allocatedSize)
+    }
+
+    func testParsesReclaimableBytesAndPercentages() async throws {
+        let report = await makeDockerAnalyzer(
+            roots: [],
+            recorder: DockerCommandRecorder(result: successfulDockerResult())
+        ).analyze()
+        let accounting = try XCTUnwrap(report.runtimeAccounting)
+
+        XCTAssertEqual(accounting.images?.reclaimableBytes, 2_000_000_000)
+        XCTAssertEqual(accounting.images?.reclaimablePercentage, 25)
+        XCTAssertEqual(accounting.buildCache?.reclaimableBytes, 500_000_000)
+        XCTAssertEqual(accounting.buildCache?.reclaimablePercentage, 50)
+        XCTAssertEqual(report.reclaimableBytes, 4_000_000_000)
+        XCTAssertEqual(accounting.reclaimablePercentage ?? 0, 26.666_666, accuracy: 0.001)
+    }
+
+    func testLocalVolumesRemainASeparateApplicationDataRuntimeCategory() async throws {
+        let report = await makeDockerAnalyzer(
+            roots: [],
+            recorder: DockerCommandRecorder(result: successfulDockerResult())
+        ).analyze()
+        let volumes = try XCTUnwrap(report.runtimeAccounting?.localVolumes)
+
+        XCTAssertEqual(volumes.category, .localVolumes)
+        XCTAssertEqual(volumes.totalBytes, 4_000_000_000)
+        XCTAssertEqual(volumes.reclaimableBytes, 1_000_000_000)
+        XCTAssertEqual(volumes.objectCount, 3)
+        XCTAssertEqual(volumes.activeCount, 1)
+        XCTAssertTrue(volumes.isApplicationData)
+    }
+
+    func testPermissionDeniedHostLocationIsPreservedAsFilesystemIssue() async throws {
+        guard geteuid() != 0 else {
+            throw XCTSkip("A root process can read mode-000 test directories.")
+        }
+
+        let temporaryDirectory = try DockerTestDirectory()
+        let inaccessible = temporaryDirectory.url.appendingPathComponent("inaccessible", isDirectory: true)
+        try FileManager.default.createDirectory(at: inaccessible, withIntermediateDirectories: false)
+        try Data(repeating: 0x61, count: 128).write(
+            to: inaccessible.appendingPathComponent("payload.dat")
+        )
+        XCTAssertEqual(chmod(inaccessible.path, 0), 0)
+        defer { _ = chmod(inaccessible.path, mode_t(S_IRWXU)) }
+
+        let report = await makeDockerAnalyzer(
+            roots: [temporaryDirectory.url],
+            installed: false
+        ).analyze()
+        let root = try XCTUnwrap(report.hostFootprint.locations.first?.root)
+        let inaccessibleNode = try XCTUnwrap(dockerNode(at: inaccessible.path, in: root))
+
+        XCTAssertEqual(inaccessibleNode.accessibility, .inaccessible)
+        XCTAssertTrue(inaccessibleNode.scanIssues.contains { $0.kind == .permissionDenied })
+        XCTAssertTrue(report.issues.contains {
+            $0.kind == .filesystem && $0.path == inaccessible.path
+        })
+    }
+
+    func testCancellationReturnsCancelledReportAndCancelsInjectedRunner() async {
+        let analyzer = DockerStorageAnalyzer(
+            hostStorageRoots: [],
+            executableLocator: { fakeDockerURL },
+            commandRunner: { _ in
+                do {
+                    try await Task.sleep(nanoseconds: 10_000_000_000)
+                    return successfulDockerResult()
+                } catch {
+                    return .init(
+                        terminationStatus: -1,
+                        stdout: "",
+                        stderr: "",
+                        launchError: nil,
+                        wasCancelled: true
+                    )
+                }
+            }
+        )
+        let task = Task { await analyzer.analyze() }
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        task.cancel()
+
+        let report = await task.value
+
+        XCTAssertTrue(report.wasCancelled)
+        XCTAssertEqual(report.runtimeStatus, .cancelled)
+        XCTAssertTrue(report.issues.contains { $0.kind == .cancelled })
+    }
+
+    func testCommandFailureDoesNotDiscardHostFilesystemResults() async throws {
+        let temporaryDirectory = try DockerTestDirectory()
+        let hostFile = temporaryDirectory.url.appendingPathComponent("Docker.img")
+        try Data(repeating: 0x71, count: 16_384).write(to: hostFile)
+        let recorder = DockerCommandRecorder(result: .init(
+            terminationStatus: 126,
+            stdout: "",
+            stderr: "Docker command execution denied",
+            launchError: nil,
+            wasCancelled: false
+        ))
+
+        let report = await makeDockerAnalyzer(
+            roots: [temporaryDirectory.url],
+            recorder: recorder
+        ).analyze()
+
+        XCTAssertEqual(report.runtimeStatus, .commandFailed)
+        XCTAssertGreaterThan(report.hostFootprint.allocatedSize, 0)
+        XCTAssertEqual(report.virtualDisks.first?.absolutePath, hostFile.path)
+        XCTAssertTrue(report.issues.contains { $0.kind == .commandFailed })
+    }
+
+    func testEmptyDockerStorageReturnsZeroHostFootprint() async {
+        let report = await makeDockerAnalyzer(roots: [], installed: false).analyze()
+
+        XCTAssertTrue(report.hostFootprint.locations.isEmpty)
+        XCTAssertEqual(report.hostFootprint.logicalSize, 0)
+        XCTAssertEqual(report.hostFootprint.allocatedSize, 0)
+        XCTAssertEqual(report.macDiskUsageBytes, 0)
+        XCTAssertTrue(report.virtualDisks.isEmpty)
+    }
+
+    func testVerifiedLocalUnixSocketContextIsAttributedAsLocal() async {
+        let recorder = DockerCommandRecorder(
+            contextResult: successfulDockerContextResult(
+                name: "desktop-linux",
+                endpoint: "unix:///var/run/docker.sock"
+            ),
+            runtimeResult: successfulDockerResult()
+        )
+
+        let report = await makeDockerAnalyzer(roots: [], recorder: recorder).analyze()
+
+        XCTAssertEqual(report.runtimeContext.name, "desktop-linux")
+        XCTAssertEqual(report.runtimeContext.sanitizedEndpoint, "unix:///var/run/docker.sock")
+        XCTAssertEqual(report.runtimeContext.location, .local)
+        XCTAssertEqual(report.hostRuntimeRelationship, .localRuntimeMayExplainHostFootprint)
+    }
+
+    func testRemoteSSHContextIsAttributedAsRemote() async {
+        let recorder = DockerCommandRecorder(
+            contextResult: successfulDockerContextResult(
+                name: "production",
+                endpoint: "ssh://operator@remote.example.com:2222"
+            ),
+            runtimeResult: successfulDockerResult()
+        )
+
+        let report = await makeDockerAnalyzer(roots: [], recorder: recorder).analyze()
+
+        XCTAssertEqual(report.runtimeContext.location, .remote)
+        XCTAssertEqual(report.runtimeContext.sanitizedEndpoint, "ssh://remote.example.com:2222")
+        XCTAssertEqual(report.hostRuntimeRelationship, .remoteRuntimeNotRelatedToHostFootprint)
+    }
+
+    func testRemoteTCPContextIsAttributedAsRemote() async {
+        let recorder = DockerCommandRecorder(
+            contextResult: successfulDockerContextResult(
+                name: "tcp-engine",
+                endpoint: "tcp://docker.example.net:2376"
+            ),
+            runtimeResult: successfulDockerResult()
+        )
+
+        let report = await makeDockerAnalyzer(roots: [], recorder: recorder).analyze()
+
+        XCTAssertEqual(report.runtimeContext.location, .remote)
+        XCTAssertEqual(report.hostRuntimeRelationship, .remoteRuntimeNotRelatedToHostFootprint)
+    }
+
+    func testUnrecognizedEndpointKeepsRelationshipUnknown() async {
+        let recorder = DockerCommandRecorder(
+            contextResult: successfulDockerContextResult(
+                name: "custom-engine",
+                endpoint: "custom-transport://engine-id/session"
+            ),
+            runtimeResult: successfulDockerResult()
+        )
+
+        let report = await makeDockerAnalyzer(roots: [], recorder: recorder).analyze()
+
+        XCTAssertEqual(report.runtimeContext.location, .unknown)
+        XCTAssertEqual(report.hostRuntimeRelationship, .unknownRelationship)
+        XCTAssertTrue(report.issues.contains { $0.kind == .runtimeLocationUnknown })
+    }
+
+    func testContextInspectionFailureIsReportedWithoutFailingRuntimeAccounting() async {
+        let recorder = DockerCommandRecorder(
+            contextResult: failedDockerContextResult(),
+            runtimeResult: successfulDockerResult()
+        )
+
+        let report = await makeDockerAnalyzer(roots: [], recorder: recorder).analyze()
+
+        XCTAssertEqual(report.runtimeContext.location, .unknown)
+        XCTAssertEqual(report.hostRuntimeRelationship, .unknownRelationship)
+        XCTAssertEqual(report.runtimeStatus, .installedAndReachable)
+        XCTAssertNotNil(report.runtimeAccounting)
+        XCTAssertTrue(report.issues.contains { $0.kind == .contextInspectionFailed })
+    }
+
+    func testRuntimeAccountingRemainsAvailableForUnknownEndpoint() async {
+        let recorder = DockerCommandRecorder(
+            contextResult: successfulDockerContextResult(
+                endpoint: "fd://docker-engine"
+            ),
+            runtimeResult: successfulDockerResult()
+        )
+
+        let report = await makeDockerAnalyzer(roots: [], recorder: recorder).analyze()
+
+        XCTAssertEqual(report.runtimeContext.location, .unknown)
+        XCTAssertEqual(report.totalRuntimeReportedBytes, 15_000_000_000)
+        XCTAssertEqual(report.runtimeStatus, .installedAndReachable)
+    }
+
+    func testHostFilesystemFindingsSurviveContextInspectionFailure() async throws {
+        let temporaryDirectory = try DockerTestDirectory()
+        let hostFile = temporaryDirectory.url.appendingPathComponent("Docker.raw")
+        try Data(repeating: 0x81, count: 32_768).write(to: hostFile)
+        let recorder = DockerCommandRecorder(
+            contextResult: failedDockerContextResult(),
+            runtimeResult: successfulDockerResult()
+        )
+
+        let report = await makeDockerAnalyzer(
+            roots: [temporaryDirectory.url],
+            recorder: recorder
+        ).analyze()
+
+        XCTAssertGreaterThan(report.hostFootprint.allocatedSize, 0)
+        XCTAssertEqual(report.virtualDisks.first?.absolutePath, hostFile.path)
+        XCTAssertNotNil(report.runtimeAccounting)
+    }
+
+    func testRemoteRuntimeIsExplicitlyUnrelatedToLocalHostFootprint() async throws {
+        let temporaryDirectory = try DockerTestDirectory()
+        try Data(repeating: 0x91, count: 16_384).write(
+            to: temporaryDirectory.url.appendingPathComponent("host.dat")
+        )
+        let recorder = DockerCommandRecorder(
+            contextResult: successfulDockerContextResult(endpoint: "ssh://remote.example.com"),
+            runtimeResult: successfulDockerResult()
+        )
+
+        let report = await makeDockerAnalyzer(
+            roots: [temporaryDirectory.url],
+            recorder: recorder
+        ).analyze()
+
+        XCTAssertGreaterThan(report.hostFootprint.allocatedSize, 0)
+        XCTAssertNotNil(report.runtimeAccounting)
+        XCTAssertEqual(report.hostRuntimeRelationship, .remoteRuntimeNotRelatedToHostFootprint)
+    }
+
+    func testLocalRuntimeAccountingRemainsNonAdditiveToHostFootprint() async throws {
+        let temporaryDirectory = try DockerTestDirectory()
+        try Data(repeating: 0xA1, count: 16_384).write(
+            to: temporaryDirectory.url.appendingPathComponent("host.dat")
+        )
+        let report = await makeDockerAnalyzer(
+            roots: [temporaryDirectory.url],
+            recorder: DockerCommandRecorder(result: successfulDockerResult())
+        ).analyze()
+        let runtimeBytes = try XCTUnwrap(report.totalRuntimeReportedBytes)
+
+        XCTAssertEqual(report.runtimeContext.location, .local)
+        XCTAssertEqual(report.hostRuntimeRelationship, .localRuntimeMayExplainHostFootprint)
+        XCTAssertEqual(report.accountingRelationship, .runtimeBreakdownIsNonAdditiveToHostFootprint)
+        XCTAssertEqual(report.macDiskUsageBytes, report.hostFootprint.allocatedSize)
+        XCTAssertNotEqual(report.macDiskUsageBytes, report.hostFootprint.allocatedSize + runtimeBytes)
+    }
+
+    func testEndpointSanitizationRemovesCredentialsAndRemotePathDetails() async {
+        let recorder = DockerCommandRecorder(
+            contextResult: successfulDockerContextResult(
+                endpoint: "ssh://operator:secret@remote.example.com:2222/private/socket?token=abc#fragment"
+            ),
+            runtimeResult: successfulDockerResult()
+        )
+
+        let report = await makeDockerAnalyzer(roots: [], recorder: recorder).analyze()
+        let endpoint = report.runtimeContext.sanitizedEndpoint
+
+        XCTAssertEqual(endpoint, "ssh://remote.example.com:2222")
+        XCTAssertFalse(endpoint?.contains("operator") == true)
+        XCTAssertFalse(endpoint?.contains("secret") == true)
+        XCTAssertFalse(endpoint?.contains("token") == true)
+        XCTAssertFalse(endpoint?.contains("private") == true)
+    }
+
+    func testContextAttributionNeverGeneratesContextSwitchOrMutationCommands() async {
+        let recorder = DockerCommandRecorder(result: successfulDockerResult())
+
+        _ = await makeDockerAnalyzer(roots: [], recorder: recorder).analyze()
+
+        XCTAssertEqual(recorder.recordedRequests.map(\.arguments), [
+            ["context", "inspect", "--format", "json"],
+            ["system", "df", "--format", "json"],
+        ])
+        let arguments = Set(recorder.recordedRequests.flatMap(\.arguments).map { $0.lowercased() })
+        XCTAssertTrue(arguments.isDisjoint(with: ["use", "create", "update", "rm", "prune"]))
+    }
+
+    func testCancellationDuringContextInspectionDoesNotStartRuntimeAccounting() async {
+        let recorder = DockerCancellableCommandRecorder()
+        let analyzer = DockerStorageAnalyzer(
+            hostStorageRoots: [],
+            executableLocator: { fakeDockerURL },
+            commandRunner: { request in await recorder.run(request) }
+        )
+        let task = Task { await analyzer.analyze() }
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        task.cancel()
+
+        let report = await task.value
+
+        XCTAssertTrue(report.wasCancelled)
+        XCTAssertEqual(report.runtimeStatus, .cancelled)
+        XCTAssertEqual(recorder.recordedRequests.map(\.arguments), [
+            ["context", "inspect", "--format", "json"],
+        ])
+    }
+
+    func testAnalyzerOnlyGeneratesStructuredReadOnlyDockerCommand() async {
+        let recorder = DockerCommandRecorder(result: successfulDockerResult())
+        _ = await makeDockerAnalyzer(roots: [], recorder: recorder).analyze()
+        let requests = recorder.recordedRequests
+
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertTrue(requests.allSatisfy { $0.executableURL == fakeDockerURL })
+        XCTAssertEqual(requests[0].arguments, ["context", "inspect", "--format", "json"])
+        XCTAssertEqual(requests[1].arguments, ["system", "df", "--format", "json"])
+
+        let generatedArguments = Set(requests.flatMap(\.arguments).map { $0.lowercased() })
+        let destructiveArguments = Set(["prune", "remove", "delete", "stop", "kill", "rm"])
+        XCTAssertTrue(generatedArguments.isDisjoint(with: destructiveArguments))
+        XCTAssertFalse(requests.contains { $0.arguments.contains("use") })
+    }
+}
+
+private let fakeDockerURL = URL(fileURLWithPath: "/fake/bin/docker")
+
+private final class DockerCommandRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var requests: [DockerCommandRequest] = []
+    private let contextResult: DockerCommandResult
+    private let runtimeResult: DockerCommandResult
+
+    init(result: DockerCommandResult) {
+        contextResult = successfulDockerContextResult()
+        runtimeResult = result
+    }
+
+    init(contextResult: DockerCommandResult, runtimeResult: DockerCommandResult) {
+        self.contextResult = contextResult
+        self.runtimeResult = runtimeResult
+    }
+
+    var recordedRequests: [DockerCommandRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return requests
+    }
+
+    func run(_ request: DockerCommandRequest) async -> DockerCommandResult {
+        record(request)
+        return request.arguments == DockerStorageAnalyzer.contextInspectionArguments
+            ? contextResult
+            : runtimeResult
+    }
+
+    private func record(_ request: DockerCommandRequest) {
+        lock.lock()
+        requests.append(request)
+        lock.unlock()
+    }
+}
+
+private final class DockerCancellableCommandRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var requests: [DockerCommandRequest] = []
+
+    var recordedRequests: [DockerCommandRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return requests
+    }
+
+    func run(_ request: DockerCommandRequest) async -> DockerCommandResult {
+        lock.lock()
+        requests.append(request)
+        lock.unlock()
+        do {
+            try await Task.sleep(nanoseconds: 10_000_000_000)
+            return successfulDockerContextResult()
+        } catch {
+            return DockerCommandResult(
+                terminationStatus: -1,
+                stdout: "",
+                stderr: "",
+                launchError: nil,
+                wasCancelled: true
+            )
+        }
+    }
+}
+
+private final class DockerTestDirectory {
+    let url: URL
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMac-DockerStorageAnalyzerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+private func makeDockerAnalyzer(
+    roots: [URL],
+    installed: Bool = true,
+    recorder: DockerCommandRecorder? = nil
+) -> DockerStorageAnalyzer {
+    let commandRecorder = recorder ?? DockerCommandRecorder(result: successfulDockerResult())
+    return DockerStorageAnalyzer(
+        hostStorageRoots: roots,
+        executableLocator: { installed ? fakeDockerURL : nil },
+        commandRunner: { request in await commandRecorder.run(request) }
+    )
+}
+
+private func successfulDockerResult() -> DockerCommandResult {
+    DockerCommandResult(
+        terminationStatus: 0,
+        stdout: """
+        {"Type":"Images","TotalCount":"10","Active":"4","Size":"8GB","Reclaimable":"2GB (25%)"}
+        {"Type":"Containers","TotalCount":"5","Active":"2","Size":"2GB","Reclaimable":"500MB (25%)"}
+        {"Type":"Local Volumes","TotalCount":"3","Active":"1","Size":"4GB","Reclaimable":"1GB (25%)"}
+        {"Type":"Build Cache","TotalCount":"20","Active":"0","Size":"1GB","Reclaimable":"500MB (50%)"}
+        """,
+        stderr: "",
+        launchError: nil,
+        wasCancelled: false
+    )
+}
+
+private func successfulDockerContextResult(
+    name: String = "desktop-linux",
+    endpoint: String = "unix:///var/run/docker.sock"
+) -> DockerCommandResult {
+    let object: [[String: Any]] = [[
+        "Name": name,
+        "Endpoints": [
+            "docker": ["Host": endpoint],
+        ],
+    ]]
+    let data = try! JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+    return DockerCommandResult(
+        terminationStatus: 0,
+        stdout: String(decoding: data, as: UTF8.self),
+        stderr: "",
+        launchError: nil,
+        wasCancelled: false
+    )
+}
+
+private func failedDockerContextResult() -> DockerCommandResult {
+    DockerCommandResult(
+        terminationStatus: 1,
+        stdout: "",
+        stderr: "unable to inspect Docker context",
+        launchError: nil,
+        wasCancelled: false
+    )
+}
+
+private func dockerNode(at path: String, in root: StorageNode) -> StorageNode? {
+    var pending = [root]
+    while let candidate = pending.popLast() {
+        if candidate.absolutePath == path { return candidate }
+        pending.append(contentsOf: candidate.children)
+    }
+    return nil
+}
+
+private func dockerStatValues(for path: String) throws -> (logical: Int64, allocated: Int64) {
+    var metadata = stat()
+    guard lstat(path, &metadata) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: Darwin.errno) ?? .EIO)
+    }
+    return (
+        logical: Int64(metadata.st_size),
+        allocated: Int64(metadata.st_blocks) * 512
+    )
+}

--- a/PureMacTests/FileTreeScannerTests.swift
+++ b/PureMacTests/FileTreeScannerTests.swift
@@ -177,6 +177,36 @@ final class FileTreeScannerTests: XCTestCase {
             result.root.ownAllocatedSize + originalNode.ownAllocatedSize
         )
     }
+
+    func testPackageBoundaryAggregation() async throws {
+        let temporaryDirectory = try TemporaryTestDirectory()
+        let appDir = temporaryDirectory.url.appendingPathComponent("SampleApp.app", isDirectory: true)
+        let contents = appDir.appendingPathComponent("Contents", isDirectory: true)
+        let macos = contents.appendingPathComponent("MacOS", isDirectory: true)
+        try FileManager.default.createDirectory(at: macos, withIntermediateDirectories: true)
+
+        let binary = macos.appendingPathComponent("sample_bin")
+        let data = Data(repeating: 0x88, count: 16_384)
+        try data.write(to: binary)
+
+        // Without aggregation
+        let fullScanner = FileTreeScanner(configuration: .init(aggregateApplicationPackages: false))
+        let fullResult = await fullScanner.scan(root: temporaryDirectory.url)
+
+        // With aggregation
+        let aggScanner = FileTreeScanner(configuration: .init(aggregateApplicationPackages: true))
+        let aggResult = await aggScanner.scan(root: temporaryDirectory.url)
+
+        let fullApp = try XCTUnwrap(node(at: appDir.path, in: fullResult.root))
+        let aggApp = try XCTUnwrap(node(at: appDir.path, in: aggResult.root))
+
+        XCTAssertEqual(aggApp.allocatedSize, fullApp.allocatedSize)
+        XCTAssertEqual(aggApp.logicalSize, fullApp.logicalSize)
+        XCTAssertEqual(aggApp.children.count, 0)
+        XCTAssertGreaterThan(fullApp.children.count, 0)
+        XCTAssertEqual(aggResult.root.allocatedSize, fullResult.root.allocatedSize)
+        XCTAssertEqual(aggResult.root.logicalSize, fullResult.root.logicalSize)
+    }
 }
 
 private final class TemporaryTestDirectory {

--- a/PureMacTests/FileTreeScannerTests.swift
+++ b/PureMacTests/FileTreeScannerTests.swift
@@ -1,0 +1,224 @@
+import Darwin
+import XCTest
+@testable import PureMac
+
+final class FileTreeScannerTests: XCTestCase {
+    func testScansNormalNestedAndHiddenItemsIntoHierarchy() async throws {
+        let temporaryDirectory = try TemporaryTestDirectory()
+        let nestedDirectory = temporaryDirectory.url.appendingPathComponent("nested", isDirectory: true)
+        let hiddenDirectory = temporaryDirectory.url.appendingPathComponent(".hidden-directory", isDirectory: true)
+        try FileManager.default.createDirectory(at: nestedDirectory, withIntermediateDirectories: false)
+        try FileManager.default.createDirectory(at: hiddenDirectory, withIntermediateDirectories: false)
+
+        let visibleFile = temporaryDirectory.url.appendingPathComponent("visible.txt")
+        let nestedFile = nestedDirectory.appendingPathComponent("child.dat")
+        let hiddenFile = temporaryDirectory.url.appendingPathComponent(".hidden-file")
+        let hiddenChild = hiddenDirectory.appendingPathComponent("inside.txt")
+        try Data(repeating: 0x11, count: 4_096).write(to: visibleFile)
+        try Data(repeating: 0x22, count: 2_048).write(to: nestedFile)
+        try Data(repeating: 0x33, count: 1_024).write(to: hiddenFile)
+        try Data(repeating: 0x44, count: 512).write(to: hiddenChild)
+
+        let result = await FileTreeScanner(
+            configuration: .init(maxConcurrentDirectoryReads: 2)
+        ).scan(root: temporaryDirectory.url)
+
+        XCTAssertFalse(result.wasCancelled)
+        XCTAssertEqual(result.root.itemType, .directory)
+        XCTAssertEqual(node(at: visibleFile.path, in: result.root)?.ownLogicalSize, 4_096)
+        XCTAssertEqual(node(at: nestedFile.path, in: result.root)?.ownLogicalSize, 2_048)
+        XCTAssertEqual(node(at: hiddenFile.path, in: result.root)?.isHidden, true)
+        XCTAssertEqual(node(at: hiddenDirectory.path, in: result.root)?.isHidden, true)
+        XCTAssertNotNil(node(at: hiddenChild.path, in: result.root))
+
+        let nestedNode = try XCTUnwrap(node(at: nestedDirectory.path, in: result.root))
+        XCTAssertEqual(nestedNode.children.map(\.absolutePath), [nestedFile.path])
+
+        let countedLogicalBytes = flattened(result.root)
+            .filter(\.isCountedInParentTotals)
+            .reduce(Int64(0)) { $0 + $1.ownLogicalSize }
+        let countedAllocatedBytes = flattened(result.root)
+            .filter(\.isCountedInParentTotals)
+            .reduce(Int64(0)) { $0 + $1.ownAllocatedSize }
+        XCTAssertEqual(result.root.logicalSize, countedLogicalBytes)
+        XCTAssertEqual(result.root.allocatedSize, countedAllocatedBytes)
+    }
+
+    func testSymbolicLinkIsRepresentedWithoutFollowingItsTarget() async throws {
+        let temporaryDirectory = try TemporaryTestDirectory()
+        let scanRoot = temporaryDirectory.url.appendingPathComponent("scan-root", isDirectory: true)
+        let outsideDirectory = temporaryDirectory.url.appendingPathComponent("outside", isDirectory: true)
+        try FileManager.default.createDirectory(at: scanRoot, withIntermediateDirectories: false)
+        try FileManager.default.createDirectory(at: outsideDirectory, withIntermediateDirectories: false)
+
+        let outsideFile = outsideDirectory.appendingPathComponent("large-target.dat")
+        try Data(repeating: 0x55, count: 1_048_576).write(to: outsideFile)
+        let link = scanRoot.appendingPathComponent("outside-link")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outsideDirectory)
+
+        let result = await FileTreeScanner().scan(root: scanRoot)
+        let linkNode = try XCTUnwrap(node(at: link.path, in: result.root))
+
+        XCTAssertEqual(linkNode.itemType, .symbolicLink)
+        XCTAssertTrue(linkNode.isSymbolicLink)
+        XCTAssertTrue(linkNode.children.isEmpty)
+        XCTAssertNil(node(at: outsideFile.path, in: result.root))
+        XCTAssertEqual(
+            result.root.logicalSize,
+            result.root.ownLogicalSize + linkNode.ownLogicalSize
+        )
+        XCTAssertLessThan(result.root.logicalSize, 1_048_576)
+    }
+
+    func testSparseFileKeepsLogicalAndAllocatedSizesDistinct() async throws {
+        let temporaryDirectory = try TemporaryTestDirectory()
+        let sparseFile = temporaryDirectory.url.appendingPathComponent("virtual-disk.raw")
+        XCTAssertTrue(FileManager.default.createFile(atPath: sparseFile.path, contents: nil))
+
+        let logicalByteCount: UInt64 = 32 * 1_024 * 1_024
+        let handle = try FileHandle(forWritingTo: sparseFile)
+        try handle.truncate(atOffset: logicalByteCount)
+        try handle.close()
+
+        let expected = try statValues(for: sparseFile.path)
+        let result = await FileTreeScanner().scan(root: temporaryDirectory.url)
+        let sparseNode = try XCTUnwrap(node(at: sparseFile.path, in: result.root))
+
+        XCTAssertEqual(sparseNode.ownLogicalSize, expected.logical)
+        XCTAssertEqual(sparseNode.ownAllocatedSize, expected.allocated)
+        XCTAssertEqual(sparseNode.ownLogicalSize, Int64(logicalByteCount))
+        XCTAssertLessThanOrEqual(sparseNode.ownAllocatedSize, sparseNode.ownLogicalSize)
+
+        if sparseNode.ownAllocatedSize >= sparseNode.ownLogicalSize {
+            throw XCTSkip("The test filesystem eagerly allocated the sparse file.")
+        }
+    }
+
+    func testPermissionDeniedDirectoryIsReported() async throws {
+        guard geteuid() != 0 else {
+            throw XCTSkip("A root process can read mode-000 test directories.")
+        }
+
+        let temporaryDirectory = try TemporaryTestDirectory()
+        let inaccessibleDirectory = temporaryDirectory.url.appendingPathComponent("inaccessible", isDirectory: true)
+        try FileManager.default.createDirectory(at: inaccessibleDirectory, withIntermediateDirectories: false)
+        try Data(repeating: 0x66, count: 128).write(
+            to: inaccessibleDirectory.appendingPathComponent("unreadable.dat")
+        )
+
+        XCTAssertEqual(chmod(inaccessibleDirectory.path, 0), 0)
+        defer { _ = chmod(inaccessibleDirectory.path, mode_t(S_IRWXU)) }
+
+        let result = await FileTreeScanner().scan(root: temporaryDirectory.url)
+        let inaccessibleNode = try XCTUnwrap(node(at: inaccessibleDirectory.path, in: result.root))
+
+        XCTAssertEqual(inaccessibleNode.accessibility, .inaccessible)
+        XCTAssertTrue(inaccessibleNode.children.isEmpty)
+        XCTAssertTrue(inaccessibleNode.scanIssues.contains { $0.kind == .permissionDenied })
+        XCTAssertTrue(result.issues.contains {
+            $0.path == inaccessibleDirectory.path && $0.kind == .permissionDenied
+        })
+    }
+
+    func testMissingRootProducesAnErrorNodeInsteadOfThrowing() async {
+        let missingRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("puremac-missing-\(UUID().uuidString)", isDirectory: true)
+
+        let result = await FileTreeScanner().scan(root: missingRoot)
+
+        XCTAssertEqual(result.root.absolutePath, missingRoot.standardizedFileURL.path)
+        XCTAssertEqual(result.root.itemType, .unknown)
+        XCTAssertEqual(result.root.accessibility, .inaccessible)
+        XCTAssertFalse(result.root.isCountedInParentTotals)
+        XCTAssertTrue(result.issues.contains { $0.kind == .metadataUnavailable })
+    }
+
+    func testCancellationReturnsAPartialMarkedResult() async throws {
+        let temporaryDirectory = try TemporaryTestDirectory()
+        for index in 0..<300 {
+            let directory = temporaryDirectory.url.appendingPathComponent("directory-\(index)", isDirectory: true)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+            try Data(repeating: UInt8(index % 255), count: 64).write(
+                to: directory.appendingPathComponent("payload.dat")
+            )
+        }
+
+        let scanner = FileTreeScanner(configuration: .init(maxConcurrentDirectoryReads: 1))
+        let scanTask = Task { await scanner.scan(root: temporaryDirectory.url) }
+        scanTask.cancel()
+        let result = await scanTask.value
+
+        XCTAssertTrue(result.wasCancelled)
+        XCTAssertTrue(result.issues.contains { $0.kind == .cancelled })
+        XCTAssertNotEqual(result.root.accessibility, .accessible)
+    }
+
+    func testHardLinksRemainVisibleWithoutDoubleCountingTheirBytes() async throws {
+        let temporaryDirectory = try TemporaryTestDirectory()
+        let original = temporaryDirectory.url.appendingPathComponent("original.dat")
+        let hardLink = temporaryDirectory.url.appendingPathComponent("hard-link.dat")
+        try Data(repeating: 0x77, count: 8_192).write(to: original)
+        try FileManager.default.linkItem(at: original, to: hardLink)
+
+        let result = await FileTreeScanner().scan(root: temporaryDirectory.url)
+        let originalNode = try XCTUnwrap(node(at: original.path, in: result.root))
+        let hardLinkNode = try XCTUnwrap(node(at: hardLink.path, in: result.root))
+        let linkedNodes = [originalNode, hardLinkNode]
+
+        XCTAssertEqual(linkedNodes.filter(\.isCountedInParentTotals).count, 1)
+        XCTAssertEqual(originalNode.ownLogicalSize, hardLinkNode.ownLogicalSize)
+        XCTAssertEqual(originalNode.ownAllocatedSize, hardLinkNode.ownAllocatedSize)
+        XCTAssertEqual(
+            result.root.logicalSize,
+            result.root.ownLogicalSize + originalNode.ownLogicalSize
+        )
+        XCTAssertEqual(
+            result.root.allocatedSize,
+            result.root.ownAllocatedSize + originalNode.ownAllocatedSize
+        )
+    }
+}
+
+private final class TemporaryTestDirectory {
+    let url: URL
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMac-FileTreeScannerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+private func node(at path: String, in root: StorageNode) -> StorageNode? {
+    var pending = [root]
+    while let candidate = pending.popLast() {
+        if candidate.absolutePath == path { return candidate }
+        pending.append(contentsOf: candidate.children)
+    }
+    return nil
+}
+
+private func flattened(_ root: StorageNode) -> [StorageNode] {
+    var result: [StorageNode] = []
+    var pending = [root]
+    while let node = pending.popLast() {
+        result.append(node)
+        pending.append(contentsOf: node.children)
+    }
+    return result
+}
+
+private func statValues(for path: String) throws -> (logical: Int64, allocated: Int64) {
+    var metadata = stat()
+    guard lstat(path, &metadata) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: Darwin.errno) ?? .EIO)
+    }
+    return (
+        logical: Int64(metadata.st_size),
+        allocated: Int64(metadata.st_blocks) * 512
+    )
+}

--- a/PureMacTests/GroupContainersAnalyzerTests.swift
+++ b/PureMacTests/GroupContainersAnalyzerTests.swift
@@ -1,0 +1,381 @@
+import Darwin
+import XCTest
+@testable import PureMac
+
+final class GroupContainersAnalyzerTests: XCTestCase {
+    func testAnalyzesMultipleGroupContainersAndSortsLargestAllocatedSizeFirst() async throws {
+        let temporaryDirectory = try GroupContainersTestDirectory()
+        try makeGroupContainer(named: "group.com.example.small", fileSize: 4_096, in: temporaryDirectory.url)
+        try makeGroupContainer(named: "group.com.example.medium", fileSize: 131_072, in: temporaryDirectory.url)
+        try makeGroupContainer(named: "group.com.example.large", fileSize: 2_097_152, in: temporaryDirectory.url)
+
+        let result = await makeGroupContainersAnalyzer(root: temporaryDirectory.url).analyze()
+        let groupContainers = result.root.children
+
+        XCTAssertEqual(
+            groupContainers.map(\.name),
+            ["group.com.example.large", "group.com.example.medium", "group.com.example.small"]
+        )
+        XCTAssertTrue(zip(groupContainers, groupContainers.dropFirst()).allSatisfy { left, right in
+            if left.allocatedSize != right.allocatedSize {
+                return left.allocatedSize > right.allocatedSize
+            }
+            if left.logicalSize != right.logicalSize {
+                return left.logicalSize > right.logicalSize
+            }
+            return left.absolutePath < right.absolutePath
+        })
+        XCTAssertEqual(result.root.metadata.storageCategoryIdentifier, "group-containers")
+        XCTAssertEqual(
+            result.root.metadata.attributes[GroupContainersAnalyzer.MetadataKey.directChildCount],
+            "3"
+        )
+    }
+
+    func testPreservesStructurallyValidGroupIdentifiersWithoutTreatingThemAsOwners() async throws {
+        let temporaryDirectory = try GroupContainersTestDirectory()
+        let groupPrefixed = try makeGroupContainer(
+            named: "group.com.example.shared",
+            fileSize: 128,
+            in: temporaryDirectory.url
+        )
+        let teamPrefixed = try makeGroupContainer(
+            named: "ABCDE12345.com.example.shared",
+            fileSize: 128,
+            in: temporaryDirectory.url
+        )
+        let entitlementStyle = try makeGroupContainer(
+            named: "com.example.shared-suite",
+            fileSize: 128,
+            in: temporaryDirectory.url
+        )
+        let invalid = try makeGroupContainer(
+            named: "Not A Group Identifier",
+            fileSize: 128,
+            in: temporaryDirectory.url
+        )
+
+        let result = await makeGroupContainersAnalyzer(root: temporaryDirectory.url).analyze()
+        let groupNode = try XCTUnwrap(groupContainersNode(at: groupPrefixed.path, in: result.root))
+        let teamNode = try XCTUnwrap(groupContainersNode(at: teamPrefixed.path, in: result.root))
+        let entitlementNode = try XCTUnwrap(groupContainersNode(at: entitlementStyle.path, in: result.root))
+        let invalidNode = try XCTUnwrap(groupContainersNode(at: invalid.path, in: result.root))
+
+        XCTAssertEqual(groupNode.metadata.groupContainerIdentifier, groupPrefixed.lastPathComponent)
+        XCTAssertEqual(
+            groupNode.metadata.attributes[GroupContainersAnalyzer.MetadataKey.groupIdentifierSource],
+            "group-prefix-directory-name"
+        )
+        XCTAssertEqual(teamNode.metadata.groupContainerIdentifier, teamPrefixed.lastPathComponent)
+        XCTAssertEqual(
+            teamNode.metadata.attributes[GroupContainersAnalyzer.MetadataKey.groupIdentifierSource],
+            "team-id-prefix-directory-name"
+        )
+        XCTAssertEqual(entitlementNode.metadata.groupContainerIdentifier, entitlementStyle.lastPathComponent)
+        XCTAssertEqual(
+            entitlementNode.metadata.attributes[GroupContainersAnalyzer.MetadataKey.groupIdentifierSource],
+            "entitlement-style-directory-name"
+        )
+
+        for candidate in [groupNode, teamNode, entitlementNode] {
+            XCTAssertNil(candidate.metadata.bundleIdentifier)
+            XCTAssertNil(candidate.metadata.owningApplicationIdentifier)
+            XCTAssertNil(candidate.metadata.owningApplicationName)
+            XCTAssertNil(candidate.metadata.owningApplications)
+            XCTAssertNil(candidate.metadata.confidence)
+        }
+        XCTAssertNil(invalidNode.metadata.groupContainerIdentifier)
+    }
+
+    func testRepresentsMultipleVerifiedOwnersWithoutForcingLegacySingleOwner() async throws {
+        let temporaryDirectory = try GroupContainersTestDirectory()
+        let sharedContainer = try makeGroupContainer(
+            named: "group.com.example.product-suite",
+            fileSize: 16_384,
+            in: temporaryDirectory.url
+        )
+        let analyzer = GroupContainersAnalyzer(
+            groupContainersURL: temporaryDirectory.url,
+            largeAllocatedSizeThreshold: 1,
+            attributionProvider: { identifier in
+                guard identifier == "group.com.example.product-suite" else { return [] }
+                return [
+                    .init(bundleIdentifier: "com.example.helper", displayName: "Example Helper"),
+                    .init(bundleIdentifier: "com.example.main", displayName: "Example App"),
+                    .init(bundleIdentifier: "com.example.main", displayName: "Duplicate"),
+                ]
+            }
+        )
+
+        let result = await analyzer.analyze()
+        let sharedNode = try XCTUnwrap(groupContainersNode(at: sharedContainer.path, in: result.root))
+
+        XCTAssertEqual(
+            sharedNode.metadata.owningApplications,
+            [
+                .init(bundleIdentifier: "com.example.helper", displayName: "Example Helper"),
+                .init(bundleIdentifier: "com.example.main", displayName: "Example App"),
+            ]
+        )
+        XCTAssertNil(sharedNode.metadata.bundleIdentifier)
+        XCTAssertNil(sharedNode.metadata.owningApplicationIdentifier)
+        XCTAssertNil(sharedNode.metadata.owningApplicationName)
+        XCTAssertEqual(sharedNode.metadata.confidence, 1)
+        XCTAssertEqual(sharedNode.metadata.isUnusuallyLarge, true)
+        XCTAssertNil(sharedNode.metadata.safetyClassificationIdentifier)
+        XCTAssertEqual(
+            sharedNode.metadata.attributes[GroupContainersAnalyzer.MetadataKey.ownerCount],
+            "2"
+        )
+    }
+
+    func testIncludesHiddenContentAndPreservesCompleteHierarchy() async throws {
+        let temporaryDirectory = try GroupContainersTestDirectory()
+        let groupContainer = temporaryDirectory.url
+            .appendingPathComponent("group.com.example.hidden", isDirectory: true)
+        let libraryDirectory = groupContainer
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+        let hiddenDirectory = libraryDirectory.appendingPathComponent(".internal-state", isDirectory: true)
+        try FileManager.default.createDirectory(at: hiddenDirectory, withIntermediateDirectories: true)
+        let hiddenFile = hiddenDirectory.appendingPathComponent(".payload")
+        try Data(repeating: 0x21, count: 1_024).write(to: hiddenFile)
+
+        let result = await makeGroupContainersAnalyzer(root: temporaryDirectory.url).analyze()
+        let containerNode = try XCTUnwrap(groupContainersNode(at: groupContainer.path, in: result.root))
+        let libraryNode = try XCTUnwrap(groupContainersNode(at: libraryDirectory.path, in: result.root))
+        let hiddenDirectoryNode = try XCTUnwrap(groupContainersNode(at: hiddenDirectory.path, in: result.root))
+        let hiddenFileNode = try XCTUnwrap(groupContainersNode(at: hiddenFile.path, in: result.root))
+
+        XCTAssertNotNil(groupContainersNode(
+            at: groupContainer.appendingPathComponent("Library").path,
+            in: result.root
+        ))
+        XCTAssertEqual(libraryNode.children.map(\.name), [".internal-state"])
+        XCTAssertTrue(hiddenDirectoryNode.isHidden)
+        XCTAssertTrue(hiddenFileNode.isHidden)
+        XCTAssertEqual(
+            containerNode.metadata.attributes[GroupContainersAnalyzer.MetadataKey.directChildCount],
+            "1"
+        )
+    }
+
+    func testPreservesSparseVirtualDiskLogicalAndAllocatedSizes() async throws {
+        let temporaryDirectory = try GroupContainersTestDirectory()
+        let groupContainer = temporaryDirectory.url
+            .appendingPathComponent("group.com.example.virtualizer", isDirectory: true)
+        try FileManager.default.createDirectory(at: groupContainer, withIntermediateDirectories: false)
+        let virtualDisk = groupContainer.appendingPathComponent("shared-machine.qcow2")
+        XCTAssertTrue(FileManager.default.createFile(atPath: virtualDisk.path, contents: nil))
+
+        let logicalByteCount: UInt64 = 32 * 1_024 * 1_024
+        let handle = try FileHandle(forWritingTo: virtualDisk)
+        try handle.truncate(atOffset: logicalByteCount)
+        try handle.close()
+
+        let expected = try groupContainersStatValues(for: virtualDisk.path)
+        let result = await makeGroupContainersAnalyzer(root: temporaryDirectory.url).analyze()
+        let containerNode = try XCTUnwrap(groupContainersNode(at: groupContainer.path, in: result.root))
+        let diskNode = try XCTUnwrap(groupContainersNode(at: virtualDisk.path, in: result.root))
+
+        XCTAssertEqual(diskNode.ownLogicalSize, expected.logical)
+        XCTAssertEqual(diskNode.ownAllocatedSize, expected.allocated)
+        XCTAssertEqual(diskNode.ownLogicalSize, Int64(logicalByteCount))
+        XCTAssertEqual(
+            containerNode.metadata.attributes[GroupContainersAnalyzer.MetadataKey.virtualDiskImageCount],
+            "1"
+        )
+
+        if diskNode.ownAllocatedSize >= diskNode.ownLogicalSize {
+            throw XCTSkip("The test filesystem eagerly allocated the sparse virtual disk.")
+        }
+    }
+
+    func testPermissionDeniedGroupContainerRemainsVisibleWithIssue() async throws {
+        guard geteuid() != 0 else {
+            throw XCTSkip("A root process can read mode-000 test directories.")
+        }
+
+        let temporaryDirectory = try GroupContainersTestDirectory()
+        let inaccessibleContainer = try makeGroupContainer(
+            named: "group.com.example.inaccessible",
+            fileSize: 128,
+            in: temporaryDirectory.url
+        )
+        XCTAssertEqual(chmod(inaccessibleContainer.path, 0), 0)
+        defer { _ = chmod(inaccessibleContainer.path, mode_t(S_IRWXU)) }
+
+        let result = await makeGroupContainersAnalyzer(root: temporaryDirectory.url).analyze()
+        let inaccessibleNode = try XCTUnwrap(
+            groupContainersNode(at: inaccessibleContainer.path, in: result.root)
+        )
+
+        XCTAssertEqual(inaccessibleNode.accessibility, .inaccessible)
+        XCTAssertTrue(inaccessibleNode.children.isEmpty)
+        XCTAssertTrue(inaccessibleNode.scanIssues.contains { $0.kind == .permissionDenied })
+        XCTAssertTrue(result.issues.contains {
+            $0.path == inaccessibleContainer.path && $0.kind == .permissionDenied
+        })
+    }
+
+    func testSymbolicLinkIsNotFollowedOrAttributedAsGroupContainer() async throws {
+        let temporaryDirectory = try GroupContainersTestDirectory()
+        let outsideDirectory = try GroupContainersTestDirectory()
+        let outsideFile = outsideDirectory.url.appendingPathComponent("outside.dat")
+        try Data(repeating: 0x31, count: 1_048_576).write(to: outsideFile)
+        let link = temporaryDirectory.url.appendingPathComponent("group.com.example.external")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outsideDirectory.url)
+
+        let result = await makeGroupContainersAnalyzer(root: temporaryDirectory.url).analyze()
+        let linkNode = try XCTUnwrap(groupContainersNode(at: link.path, in: result.root))
+
+        XCTAssertEqual(linkNode.itemType, .symbolicLink)
+        XCTAssertTrue(linkNode.isSymbolicLink)
+        XCTAssertTrue(linkNode.children.isEmpty)
+        XCTAssertNil(linkNode.metadata.groupContainerIdentifier)
+        XCTAssertNil(linkNode.metadata.owningApplications)
+        XCTAssertNil(groupContainersNode(at: outsideFile.path, in: result.root))
+        XCTAssertLessThan(result.root.logicalSize, 1_048_576)
+    }
+
+    func testCancellationReturnsPartialMarkedAnalysis() async throws {
+        let temporaryDirectory = try GroupContainersTestDirectory()
+        for index in 0..<300 {
+            try makeGroupContainer(
+                named: "group.com.example.application-\(index)",
+                fileSize: 64,
+                in: temporaryDirectory.url
+            )
+        }
+
+        let analyzer = makeGroupContainersAnalyzer(
+            root: temporaryDirectory.url,
+            scanner: FileTreeScanner(configuration: .init(maxConcurrentDirectoryReads: 1))
+        )
+        let analysisTask = Task { await analyzer.analyze() }
+        analysisTask.cancel()
+        let result = await analysisTask.value
+
+        XCTAssertTrue(result.wasCancelled)
+        XCTAssertTrue(result.issues.contains { $0.kind == .cancelled })
+        XCTAssertNotEqual(result.root.accessibility, .accessible)
+    }
+
+    func testHardLinksAreNotDoubleCounted() async throws {
+        let temporaryDirectory = try GroupContainersTestDirectory()
+        let groupContainer = temporaryDirectory.url
+            .appendingPathComponent("group.com.example.linked", isDirectory: true)
+        try FileManager.default.createDirectory(at: groupContainer, withIntermediateDirectories: false)
+        let original = groupContainer.appendingPathComponent("original.dat")
+        let hardLink = groupContainer.appendingPathComponent("linked.dat")
+        try Data(repeating: 0x41, count: 8_192).write(to: original)
+        try FileManager.default.linkItem(at: original, to: hardLink)
+
+        let result = await makeGroupContainersAnalyzer(root: temporaryDirectory.url).analyze()
+        let containerNode = try XCTUnwrap(groupContainersNode(at: groupContainer.path, in: result.root))
+        let originalNode = try XCTUnwrap(groupContainersNode(at: original.path, in: result.root))
+        let hardLinkNode = try XCTUnwrap(groupContainersNode(at: hardLink.path, in: result.root))
+        let linkedNodes = [originalNode, hardLinkNode]
+        let countedNode = try XCTUnwrap(linkedNodes.first(where: \.isCountedInParentTotals))
+
+        XCTAssertEqual(linkedNodes.filter(\.isCountedInParentTotals).count, 1)
+        XCTAssertEqual(
+            containerNode.logicalSize,
+            containerNode.ownLogicalSize + countedNode.ownLogicalSize
+        )
+        XCTAssertEqual(
+            containerNode.allocatedSize,
+            containerNode.ownAllocatedSize + countedNode.ownAllocatedSize
+        )
+        XCTAssertEqual(result.root.logicalSize, result.root.ownLogicalSize + containerNode.logicalSize)
+        XCTAssertEqual(result.root.allocatedSize, result.root.ownAllocatedSize + containerNode.allocatedSize)
+    }
+
+    func testEmptyGroupContainersDirectoryReturnsNoEntries() async throws {
+        let temporaryDirectory = try GroupContainersTestDirectory()
+
+        let result = await makeGroupContainersAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertFalse(result.wasCancelled)
+        XCTAssertEqual(result.root.itemType, .directory)
+        XCTAssertEqual(result.root.accessibility, .accessible)
+        XCTAssertTrue(result.root.children.isEmpty)
+        XCTAssertEqual(
+            result.root.metadata.attributes[GroupContainersAnalyzer.MetadataKey.directChildCount],
+            "0"
+        )
+    }
+
+    func testMissingGroupContainersDirectoryReturnsUnavailableResult() async {
+        let missingDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMac-Missing-Group-Containers-\(UUID().uuidString)", isDirectory: true)
+
+        let result = await makeGroupContainersAnalyzer(root: missingDirectory).analyze()
+
+        XCTAssertEqual(result.root.absolutePath, missingDirectory.standardizedFileURL.path)
+        XCTAssertEqual(result.root.itemType, .unknown)
+        XCTAssertEqual(result.root.accessibility, .inaccessible)
+        XCTAssertTrue(result.root.children.isEmpty)
+        XCTAssertTrue(result.issues.contains { $0.kind == .metadataUnavailable })
+        XCTAssertEqual(result.root.metadata.storageCategoryIdentifier, "group-containers")
+    }
+}
+
+private final class GroupContainersTestDirectory {
+    let url: URL
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMac-GroupContainersAnalyzerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+private func makeGroupContainersAnalyzer(
+    root: URL,
+    scanner: FileTreeScanner = FileTreeScanner()
+) -> GroupContainersAnalyzer {
+    GroupContainersAnalyzer(
+        groupContainersURL: root,
+        scanner: scanner,
+        attributionProvider: { _ in [] }
+    )
+}
+
+@discardableResult
+private func makeGroupContainer(
+    named name: String,
+    fileSize: Int,
+    in root: URL
+) throws -> URL {
+    let groupContainer = root.appendingPathComponent(name, isDirectory: true)
+    try FileManager.default.createDirectory(at: groupContainer, withIntermediateDirectories: false)
+    try Data(repeating: UInt8(fileSize % 251), count: fileSize).write(
+        to: groupContainer.appendingPathComponent("payload.dat")
+    )
+    return groupContainer
+}
+
+private func groupContainersNode(at path: String, in root: StorageNode) -> StorageNode? {
+    var pending = [root]
+    while let candidate = pending.popLast() {
+        if candidate.absolutePath == path { return candidate }
+        pending.append(contentsOf: candidate.children)
+    }
+    return nil
+}
+
+private func groupContainersStatValues(for path: String) throws -> (logical: Int64, allocated: Int64) {
+    var metadata = stat()
+    guard lstat(path, &metadata) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: Darwin.errno) ?? .EIO)
+    }
+    return (
+        logical: Int64(metadata.st_size),
+        allocated: Int64(metadata.st_blocks) * 512
+    )
+}

--- a/PureMacTests/PrivateStorageAnalyzerTests.swift
+++ b/PureMacTests/PrivateStorageAnalyzerTests.swift
@@ -1,0 +1,607 @@
+import Darwin
+import XCTest
+@testable import PureMac
+
+final class PrivateStorageAnalyzerTests: XCTestCase {
+    func testTopLevelPrivateHierarchyAndCategoriesArePreserved() async throws {
+        XCTAssertEqual(PrivateStorageAnalyzer.defaultPrivateURL.path, "/private")
+        let temporaryDirectory = try PrivateStorageTestDirectory()
+        for name in ["var", "tmp", "etc", "unknown"] {
+            try makePrivateDirectory(named: name, fileSize: 1_024, in: temporaryDirectory.url)
+        }
+
+        let result = await makePrivateStorageAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertEqual(Set(result.root.children.map(\.name)), Set(["var", "tmp", "etc", "unknown"]))
+        XCTAssertEqual(privateNode(named: "var", under: result.root)?.metadata.storageCategoryIdentifier,
+                       PrivateStorageCategory.variableState.rawValue)
+        XCTAssertEqual(privateNode(named: "tmp", under: result.root)?.metadata.storageCategoryIdentifier,
+                       PrivateStorageCategory.temporary.rawValue)
+        XCTAssertEqual(privateNode(named: "etc", under: result.root)?.metadata.storageCategoryIdentifier,
+                       PrivateStorageCategory.configuration.rawValue)
+        XCTAssertEqual(privateNode(named: "unknown", under: result.root)?.metadata.storageCategoryIdentifier,
+                       PrivateStorageCategory.otherTopLevel.rawValue)
+        XCTAssertEqual(result.root.metadata.storageCategoryIdentifier, "private-storage")
+    }
+
+    func testVarDrillDownReusesAndOrdersImmediateChildren() async throws {
+        let temporaryDirectory = try PrivateStorageTestDirectory()
+        let varDirectory = try makeVarDirectory(in: temporaryDirectory.url)
+        try makePrivateDirectory(named: "small", fileSize: 4_096, in: varDirectory)
+        try makePrivateDirectory(named: "medium", fileSize: 262_144, in: varDirectory)
+        let large = try makePrivateDirectory(named: "large", fileSize: 2_097_152, in: varDirectory)
+        let nested = large.appendingPathComponent("nested", isDirectory: true)
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: false)
+        try Data([0x11]).write(to: nested.appendingPathComponent("state.dat"))
+
+        let result = await makePrivateStorageAnalyzer(root: temporaryDirectory.url).analyze()
+        let varNode = try XCTUnwrap(privateNode(at: varDirectory.path, in: result.root))
+
+        XCTAssertEqual(varNode.children.map(\.name), ["large", "medium", "small"])
+        XCTAssertTrue(zip(varNode.children, varNode.children.dropFirst()).allSatisfy {
+            privateStorageOrdering($0, $1)
+        })
+        XCTAssertNotNil(privateNode(at: nested.path, in: result.root))
+        XCTAssertEqual(varNode.metadata.attributes[PrivateStorageAnalyzer.MetadataKey.directChildCount], "3")
+    }
+
+    func testVarFoldersMetadataExplainsMixedManagedState() async throws {
+        let (_, node) = try await analyzeSingleVarChild(named: "folders")
+
+        XCTAssertEqual(node.metadata.storageCategoryIdentifier, PrivateStorageCategory.varFolders.rawValue)
+        XCTAssertEqual(privateManagementKind(of: node), .applicationAndSystemState)
+        XCTAssertTrue(node.metadata.explanation?.contains("Per-user and per-process") == true)
+        XCTAssertNil(node.metadata.safetyClassificationIdentifier)
+    }
+
+    func testVarVMMetadataIsProtectedSystemState() async throws {
+        let (_, node) = try await analyzeSingleVarChild(named: "vm")
+
+        XCTAssertEqual(node.metadata.storageCategoryIdentifier, PrivateStorageCategory.varVirtualMemory.rawValue)
+        XCTAssertEqual(privateManagementKind(of: node), .protectedSystemState)
+        XCTAssertTrue(node.metadata.explanation?.contains("virtual-memory") == true)
+        XCTAssertNil(node.metadata.safetyClassificationIdentifier)
+    }
+
+    func testVarDatabaseMetadataIsProtectedSystemState() async throws {
+        let (_, node) = try await analyzeSingleVarChild(named: "db")
+
+        XCTAssertEqual(node.metadata.storageCategoryIdentifier, PrivateStorageCategory.varDatabases.rawValue)
+        XCTAssertEqual(privateManagementKind(of: node), .protectedSystemState)
+        XCTAssertTrue(node.metadata.explanation?.contains("databases") == true)
+    }
+
+    func testVarLogMetadataIsAttributionOnly() async throws {
+        let (_, node) = try await analyzeSingleVarChild(named: "log")
+
+        XCTAssertEqual(node.metadata.storageCategoryIdentifier, PrivateStorageCategory.varLogs.rawValue)
+        XCTAssertEqual(privateManagementKind(of: node), .systemManaged)
+        XCTAssertTrue(node.metadata.explanation?.contains("storage attribution only") == true)
+        XCTAssertNil(node.metadata.safetyClassificationIdentifier)
+    }
+
+    func testVarTemporaryMetadataDoesNotImplyCleanup() async throws {
+        let (_, node) = try await analyzeSingleVarChild(named: "tmp")
+
+        XCTAssertEqual(node.metadata.storageCategoryIdentifier, PrivateStorageCategory.varTemporary.rawValue)
+        XCTAssertEqual(privateManagementKind(of: node), .temporaryStorage)
+        XCTAssertTrue(node.metadata.explanation?.contains("no cleanup behavior") == true)
+        XCTAssertNil(node.metadata.safetyClassificationIdentifier)
+    }
+
+    func testUnknownVarChildRemainsVisibleWithoutGuessedClassification() async throws {
+        let (_, node) = try await analyzeSingleVarChild(named: "vendor-state")
+
+        XCTAssertEqual(node.metadata.storageCategoryIdentifier, PrivateStorageCategory.otherVarChild.rawValue)
+        XCTAssertEqual(privateManagementKind(of: node), .unclassified)
+        XCTAssertNil(node.metadata.safetyClassificationIdentifier)
+    }
+
+    func testHiddenContentIsIncludedThroughoutPrivateTree() async throws {
+        let temporaryDirectory = try PrivateStorageTestDirectory()
+        let varDirectory = try makeVarDirectory(in: temporaryDirectory.url)
+        let hiddenDirectory = varDirectory.appendingPathComponent(".hidden-state", isDirectory: true)
+        let hiddenFile = hiddenDirectory.appendingPathComponent(".payload")
+        try FileManager.default.createDirectory(at: hiddenDirectory, withIntermediateDirectories: false)
+        try Data(repeating: 0x21, count: 512).write(to: hiddenFile)
+
+        let result = await makePrivateStorageAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertEqual(privateNode(at: hiddenDirectory.path, in: result.root)?.isHidden, true)
+        XCTAssertEqual(privateNode(at: hiddenFile.path, in: result.root)?.isHidden, true)
+    }
+
+    func testLogicalAndAllocatedSizesMatchFilesystemMetadata() async throws {
+        let temporaryDirectory = try PrivateStorageTestDirectory()
+        let varDirectory = try makeVarDirectory(in: temporaryDirectory.url)
+        let db = try makePrivateDirectory(named: "db", fileSize: 0, in: varDirectory)
+        let payload = db.appendingPathComponent("payload.dat")
+        try Data(repeating: 0x31, count: 32_768).write(to: payload)
+        let expected = try privateStatValues(for: payload.path)
+
+        let result = await makePrivateStorageAnalyzer(root: temporaryDirectory.url).analyze()
+        let node = try XCTUnwrap(privateNode(at: payload.path, in: result.root))
+
+        XCTAssertEqual(node.ownLogicalSize, expected.logical)
+        XCTAssertEqual(node.ownAllocatedSize, expected.allocated)
+    }
+
+    func testSparseFilePreservesLogicalAllocatedAndVirtualDiskMetadata() async throws {
+        let temporaryDirectory = try PrivateStorageTestDirectory()
+        let varDirectory = try makeVarDirectory(in: temporaryDirectory.url)
+        let vm = varDirectory.appendingPathComponent("vm", isDirectory: true)
+        try FileManager.default.createDirectory(at: vm, withIntermediateDirectories: false)
+        let disk = vm.appendingPathComponent("swap-image.raw")
+        XCTAssertTrue(FileManager.default.createFile(atPath: disk.path, contents: nil))
+        let logicalByteCount: UInt64 = 64 * 1_024 * 1_024
+        let handle = try FileHandle(forWritingTo: disk)
+        try handle.truncate(atOffset: logicalByteCount)
+        try handle.close()
+
+        let result = await makePrivateStorageAnalyzer(root: temporaryDirectory.url).analyze()
+        let vmNode = try XCTUnwrap(privateNode(at: vm.path, in: result.root))
+        let diskNode = try XCTUnwrap(privateNode(at: disk.path, in: result.root))
+
+        XCTAssertEqual(diskNode.ownLogicalSize, Int64(logicalByteCount))
+        XCTAssertEqual(diskNode.metadata.attributes[PrivateStorageAnalyzer.MetadataKey.virtualDiskFormat], "raw")
+        XCTAssertEqual(vmNode.metadata.attributes[PrivateStorageAnalyzer.MetadataKey.virtualDiskImageCount], "1")
+        if diskNode.ownAllocatedSize >= diskNode.ownLogicalSize {
+            throw XCTSkip("The test filesystem eagerly allocated the sparse file.")
+        }
+        XCTAssertEqual(
+            diskNode.metadata.attributes[PrivateStorageAnalyzer.MetadataKey.virtualDiskSparseState],
+            "sparse"
+        )
+    }
+
+    func testLargeUnknownExtensionFileRemainsOrdinaryVisibleStorage() async throws {
+        let temporaryDirectory = try PrivateStorageTestDirectory()
+        let varDirectory = try makeVarDirectory(in: temporaryDirectory.url)
+        let state = varDirectory.appendingPathComponent("mystery-state", isDirectory: true)
+        try FileManager.default.createDirectory(at: state, withIntermediateDirectories: false)
+        let largeFile = state.appendingPathComponent("critical.unknown-format")
+        try Data(repeating: 0x41, count: 1_048_576).write(to: largeFile)
+
+        let result = await makePrivateStorageAnalyzer(
+            root: temporaryDirectory.url,
+            largeAllocatedSizeThreshold: 1
+        ).analyze()
+        let stateNode = try XCTUnwrap(privateNode(at: state.path, in: result.root))
+        let fileNode = try XCTUnwrap(privateNode(at: largeFile.path, in: result.root))
+
+        XCTAssertEqual(fileNode.itemType, .regularFile)
+        XCTAssertGreaterThan(fileNode.logicalSize, 0)
+        XCTAssertNil(fileNode.metadata.attributes[PrivateStorageAnalyzer.MetadataKey.virtualDiskFormat])
+        XCTAssertNil(fileNode.metadata.safetyClassificationIdentifier)
+        XCTAssertEqual(stateNode.metadata.isUnusuallyLarge, true)
+    }
+
+    func testSymlinkAliasIsVisibleWithoutFollowingOrDoubleCountingTarget() async throws {
+        let temporaryDirectory = try PrivateStorageTestDirectory()
+        let realTmp = try makePrivateDirectory(named: "tmp", fileSize: 1_048_576, in: temporaryDirectory.url)
+        let payload = realTmp.appendingPathComponent("payload.dat")
+        let alias = temporaryDirectory.url.appendingPathComponent("tmp-alias")
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: realTmp)
+
+        let result = await makePrivateStorageAnalyzer(root: temporaryDirectory.url).analyze()
+        let aliasNode = try XCTUnwrap(privateNode(at: alias.path, in: result.root))
+
+        XCTAssertEqual(aliasNode.itemType, .symbolicLink)
+        XCTAssertTrue(aliasNode.isSymbolicLink)
+        XCTAssertTrue(aliasNode.children.isEmpty)
+        XCTAssertNotNil(privateNode(at: payload.path, in: result.root))
+        XCTAssertEqual(aliasNode.metadata.storageCategoryIdentifier, PrivateStorageCategory.otherTopLevel.rawValue)
+    }
+
+    func testHardLinksAcrossVarCategoriesAreDeduplicated() async throws {
+        let temporaryDirectory = try PrivateStorageTestDirectory()
+        let varDirectory = try makeVarDirectory(in: temporaryDirectory.url)
+        let db = try makePrivateDirectory(named: "db", fileSize: 0, in: varDirectory)
+        let log = try makePrivateDirectory(named: "log", fileSize: 0, in: varDirectory)
+        let original = db.appendingPathComponent("shared-state")
+        let linked = log.appendingPathComponent("shared-state")
+        try Data(repeating: 0x51, count: 8_192).write(to: original)
+        try FileManager.default.linkItem(at: original, to: linked)
+
+        let result = await makePrivateStorageAnalyzer(root: temporaryDirectory.url).analyze()
+        let aliases = try [
+            XCTUnwrap(privateNode(at: original.path, in: result.root)),
+            XCTUnwrap(privateNode(at: linked.path, in: result.root)),
+        ]
+
+        XCTAssertEqual(aliases.filter(\.isCountedInParentTotals).count, 1)
+        XCTAssertEqual(aliases[0].ownLogicalSize, aliases[1].ownLogicalSize)
+        XCTAssertEqual(aliases[0].ownAllocatedSize, aliases[1].ownAllocatedSize)
+    }
+
+    func testEnrichmentPreservesFilesystemBoundaryAndExcludesItsBytes() throws {
+        let boundaryPath = "/private/var/external"
+        let boundaryIssue = StorageScanIssue(
+            path: boundaryPath,
+            kind: .differentVolume,
+            message: "Traversal stopped because this item is on a different mounted filesystem.",
+            posixErrorCode: nil
+        )
+        let boundary = syntheticPrivateNode(
+            name: "external",
+            path: boundaryPath,
+            logicalSize: 0,
+            allocatedSize: 0,
+            ownLogicalSize: 8_192,
+            ownAllocatedSize: 8_192,
+            itemType: .volumeBoundary,
+            accessibility: .skippedDifferentVolume,
+            issues: [boundaryIssue],
+            isCounted: false
+        )
+        let varNode = syntheticPrivateNode(
+            name: "var",
+            path: "/private/var",
+            logicalSize: 96,
+            allocatedSize: 4_096,
+            ownLogicalSize: 96,
+            ownAllocatedSize: 4_096,
+            itemType: .directory,
+            children: [boundary]
+        )
+        let root = syntheticPrivateNode(
+            name: "private",
+            path: "/private",
+            logicalSize: 192,
+            allocatedSize: 8_192,
+            ownLogicalSize: 96,
+            ownAllocatedSize: 4_096,
+            itemType: .directory,
+            children: [varNode]
+        )
+        let input = syntheticPrivateResult(root: root, issues: [boundaryIssue])
+
+        let result = PrivateStorageAnalyzer.enrich(input, largeAllocatedSizeThreshold: 1)
+        let preserved = try XCTUnwrap(privateNode(at: boundaryPath, in: result.root))
+
+        XCTAssertEqual(preserved.itemType, .volumeBoundary)
+        XCTAssertEqual(preserved.accessibility, .skippedDifferentVolume)
+        XCTAssertFalse(preserved.isCountedInParentTotals)
+        XCTAssertEqual(privateSizeKnowledge(of: preserved), .excludedDifferentVolume)
+        XCTAssertEqual(result.root.logicalSize, 192)
+        XCTAssertEqual(result.root.allocatedSize, 8_192)
+    }
+
+    func testPermissionDeniedNodePreservesIssueAndPOSIXCode() async throws {
+        guard geteuid() != 0 else { throw XCTSkip("A root process can read mode-000 directories.") }
+        let temporaryDirectory = try PrivateStorageTestDirectory()
+        let varDirectory = try makeVarDirectory(in: temporaryDirectory.url)
+        let protected = try makePrivateDirectory(named: "protected", fileSize: 128, in: varDirectory)
+        XCTAssertEqual(chmod(protected.path, 0), 0)
+        defer { _ = chmod(protected.path, mode_t(S_IRWXU)) }
+
+        let result = await makePrivateStorageAnalyzer(root: temporaryDirectory.url).analyze()
+        let protectedNode = try XCTUnwrap(privateNode(at: protected.path, in: result.root))
+        let issue = try XCTUnwrap(protectedNode.scanIssues.first { $0.kind == .permissionDenied })
+
+        XCTAssertEqual(protectedNode.accessibility, .inaccessible)
+        XCTAssertNotNil(issue.posixErrorCode)
+        XCTAssertTrue(result.issues.contains { $0.path == protected.path && $0.kind == .permissionDenied })
+    }
+
+    func testPermissionFailurePropagatesPartialAccessibilityToAncestors() async throws {
+        guard geteuid() != 0 else { throw XCTSkip("A root process can read mode-000 directories.") }
+        let temporaryDirectory = try PrivateStorageTestDirectory()
+        let varDirectory = try makeVarDirectory(in: temporaryDirectory.url)
+        try makePrivateDirectory(named: "readable", fileSize: 128, in: varDirectory)
+        let inaccessible = try makePrivateDirectory(named: "root", fileSize: 128, in: varDirectory)
+        XCTAssertEqual(chmod(inaccessible.path, 0), 0)
+        defer { _ = chmod(inaccessible.path, mode_t(S_IRWXU)) }
+
+        let result = await makePrivateStorageAnalyzer(root: temporaryDirectory.url).analyze()
+        let varNode = try XCTUnwrap(privateNode(at: varDirectory.path, in: result.root))
+
+        XCTAssertEqual(varNode.accessibility, .partiallyAccessible)
+        XCTAssertEqual(result.root.accessibility, .partiallyAccessible)
+        XCTAssertEqual(privateSizeKnowledge(of: varNode), .incompleteDueToInaccessibility)
+        XCTAssertNotNil(privateNode(at: varDirectory.appendingPathComponent("readable/payload.dat").path,
+                                    in: result.root))
+    }
+
+    func testUnknownDescendantSizeIsDistinctFromAccessibleTrueZero() async throws {
+        guard geteuid() != 0 else { throw XCTSkip("A root process can read mode-000 directories.") }
+        let temporaryDirectory = try PrivateStorageTestDirectory()
+        let varDirectory = try makeVarDirectory(in: temporaryDirectory.url)
+        let folders = varDirectory.appendingPathComponent("folders", isDirectory: true)
+        let protected = varDirectory.appendingPathComponent("protected", isDirectory: true)
+        try FileManager.default.createDirectory(at: folders, withIntermediateDirectories: false)
+        try FileManager.default.createDirectory(at: protected, withIntermediateDirectories: false)
+        let emptyFile = folders.appendingPathComponent("known-zero")
+        XCTAssertTrue(FileManager.default.createFile(atPath: emptyFile.path, contents: nil))
+        try Data(repeating: 0x61, count: 8_192).write(to: protected.appendingPathComponent("unknown.dat"))
+        XCTAssertEqual(chmod(protected.path, 0), 0)
+        defer { _ = chmod(protected.path, mode_t(S_IRWXU)) }
+
+        let result = await makePrivateStorageAnalyzer(root: temporaryDirectory.url).analyze()
+        let zeroNode = try XCTUnwrap(privateNode(at: emptyFile.path, in: result.root))
+        let unknownNode = try XCTUnwrap(privateNode(at: protected.path, in: result.root))
+
+        XCTAssertEqual(zeroNode.ownLogicalSize, 0)
+        XCTAssertEqual(zeroNode.accessibility, .accessible)
+        XCTAssertEqual(privateSizeKnowledge(of: zeroNode), .complete)
+        XCTAssertEqual(unknownNode.accessibility, .inaccessible)
+        XCTAssertEqual(privateSizeKnowledge(of: unknownNode), .incompleteDueToInaccessibility)
+        XCTAssertTrue(unknownNode.scanIssues.contains { $0.kind == .permissionDenied })
+    }
+
+    func testCancellationReturnsPartialMarkedAnalysis() async throws {
+        let temporaryDirectory = try PrivateStorageTestDirectory()
+        let varDirectory = try makeVarDirectory(in: temporaryDirectory.url)
+        for index in 0..<300 {
+            try makePrivateDirectory(named: "state-\(index)", fileSize: 64, in: varDirectory)
+        }
+        let analyzer = makePrivateStorageAnalyzer(
+            root: temporaryDirectory.url,
+            scanner: FileTreeScanner(configuration: .init(maxConcurrentDirectoryReads: 1))
+        )
+        let task = Task { await analyzer.analyze() }
+        task.cancel()
+
+        let result = await task.value
+
+        XCTAssertTrue(result.wasCancelled)
+        XCTAssertTrue(result.issues.contains { $0.kind == .cancelled })
+        XCTAssertNotEqual(result.root.accessibility, .accessible)
+        XCTAssertEqual(privateSizeKnowledge(of: result.root), .incompleteDueToCancellation)
+    }
+
+    func testEmptyRootReturnsAccessibleZeroChildAnalysis() async throws {
+        let temporaryDirectory = try PrivateStorageTestDirectory()
+
+        let result = await makePrivateStorageAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertEqual(result.root.itemType, .directory)
+        XCTAssertEqual(result.root.accessibility, .accessible)
+        XCTAssertTrue(result.root.children.isEmpty)
+        XCTAssertEqual(result.root.metadata.attributes[PrivateStorageAnalyzer.MetadataKey.directChildCount], "0")
+        XCTAssertEqual(privateSizeKnowledge(of: result.root), .complete)
+    }
+
+    func testMissingRootReturnsTypedUnavailableAnalysis() async {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMac-Missing-Private-\(UUID().uuidString)", isDirectory: true)
+
+        let result = await makePrivateStorageAnalyzer(root: missing).analyze()
+
+        XCTAssertEqual(result.root.itemType, .unknown)
+        XCTAssertEqual(result.root.accessibility, .inaccessible)
+        XCTAssertTrue(result.issues.contains { $0.kind == .metadataUnavailable })
+        XCTAssertEqual(privateSizeKnowledge(of: result.root), .incompleteDueToInaccessibility)
+    }
+
+    func testNonDirectoryRootReturnsTypedIssue() async throws {
+        let temporaryDirectory = try PrivateStorageTestDirectory()
+        let file = temporaryDirectory.url.appendingPathComponent("private-file")
+        try Data([0x71]).write(to: file)
+
+        let result = await makePrivateStorageAnalyzer(root: file).analyze()
+
+        XCTAssertEqual(result.root.itemType, .regularFile)
+        XCTAssertEqual(result.root.accessibility, .inaccessible)
+        XCTAssertTrue(result.issues.contains {
+            $0.kind == .notDirectory && $0.posixErrorCode == ENOTDIR
+        })
+    }
+
+    func testAccountingReconcilesToSingleCanonicalTree() async throws {
+        let temporaryDirectory = try PrivateStorageTestDirectory()
+        let varDirectory = try makeVarDirectory(in: temporaryDirectory.url)
+        try makePrivateDirectory(named: "folders", fileSize: 8_192, in: varDirectory)
+        try makePrivateDirectory(named: "db", fileSize: 16_384, in: varDirectory)
+        try makePrivateDirectory(named: "tmp", fileSize: 32_768, in: temporaryDirectory.url)
+
+        let result = await makePrivateStorageAnalyzer(root: temporaryDirectory.url).analyze()
+        let counted = flattenedPrivateTree(result.root).filter(\.isCountedInParentTotals)
+
+        XCTAssertEqual(result.root.logicalSize,
+                       counted.reduce(Int64(0)) { $0 + $1.ownLogicalSize })
+        XCTAssertEqual(result.root.allocatedSize,
+                       counted.reduce(Int64(0)) { $0 + $1.ownAllocatedSize })
+        XCTAssertEqual(result.root.logicalSize,
+                       result.root.ownLogicalSize + result.root.children.reduce(0) { $0 + $1.logicalSize })
+        XCTAssertEqual(result.root.allocatedSize,
+                       result.root.ownAllocatedSize + result.root.children.reduce(0) { $0 + $1.allocatedSize })
+    }
+
+    func testVarDrillDownMetadataDoesNotAddBytesAgain() async throws {
+        let temporaryDirectory = try PrivateStorageTestDirectory()
+        let varDirectory = try makeVarDirectory(in: temporaryDirectory.url)
+        try makePrivateDirectory(named: "folders", fileSize: 8_192, in: varDirectory)
+        try makePrivateDirectory(named: "vm", fileSize: 16_384, in: varDirectory)
+        let scanner = FileTreeScanner()
+        let raw = await scanner.scan(root: temporaryDirectory.url)
+
+        let enriched = PrivateStorageAnalyzer.enrich(raw, largeAllocatedSizeThreshold: 1)
+        let varNode = try XCTUnwrap(privateNode(at: varDirectory.path, in: enriched.root))
+
+        XCTAssertEqual(enriched.root.logicalSize, raw.root.logicalSize)
+        XCTAssertEqual(enriched.root.allocatedSize, raw.root.allocatedSize)
+        XCTAssertEqual(varNode.logicalSize,
+                       varNode.ownLogicalSize + varNode.children.reduce(0) { $0 + $1.logicalSize })
+        XCTAssertEqual(varNode.allocatedSize,
+                       varNode.ownAllocatedSize + varNode.children.reduce(0) { $0 + $1.allocatedSize })
+    }
+
+    func testAnalysisDoesNotMutateOrDeleteContents() async throws {
+        let temporaryDirectory = try PrivateStorageTestDirectory()
+        let varDirectory = try makeVarDirectory(in: temporaryDirectory.url)
+        let db = varDirectory.appendingPathComponent("db", isDirectory: true)
+        try FileManager.default.createDirectory(at: db, withIntermediateDirectories: false)
+        let importantFile = db.appendingPathComponent("critical-state.db")
+        let originalData = Data(repeating: 0x81, count: 4_096)
+        try originalData.write(to: importantFile)
+        let originalMode = try privateStatMode(for: importantFile.path)
+
+        _ = await makePrivateStorageAnalyzer(
+            root: temporaryDirectory.url,
+            largeAllocatedSizeThreshold: 1
+        ).analyze()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: importantFile.path))
+        XCTAssertEqual(try Data(contentsOf: importantFile), originalData)
+        XCTAssertEqual(try privateStatMode(for: importantFile.path), originalMode)
+    }
+}
+
+private final class PrivateStorageTestDirectory {
+    let url: URL
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMac-PrivateStorageAnalyzerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+private func makePrivateStorageAnalyzer(
+    root: URL,
+    scanner: FileTreeScanner = FileTreeScanner(),
+    largeAllocatedSizeThreshold: Int64 = PrivateStorageAnalyzer.defaultLargeAllocatedSizeThreshold
+) -> PrivateStorageAnalyzer {
+    PrivateStorageAnalyzer(
+        privateURL: root,
+        scanner: scanner,
+        largeAllocatedSizeThreshold: largeAllocatedSizeThreshold
+    )
+}
+
+private func makeVarDirectory(in root: URL) throws -> URL {
+    let varDirectory = root.appendingPathComponent("var", isDirectory: true)
+    try FileManager.default.createDirectory(at: varDirectory, withIntermediateDirectories: false)
+    return varDirectory
+}
+
+@discardableResult
+private func makePrivateDirectory(
+    named name: String,
+    fileSize: Int,
+    in root: URL
+) throws -> URL {
+    let directory = root.appendingPathComponent(name, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+    if fileSize > 0 {
+        try Data(repeating: UInt8(fileSize % 251), count: fileSize).write(
+            to: directory.appendingPathComponent("payload.dat")
+        )
+    }
+    return directory
+}
+
+private func analyzeSingleVarChild(
+    named name: String
+) async throws -> (PrivateStorageTestDirectory, StorageNode) {
+    let temporaryDirectory = try PrivateStorageTestDirectory()
+    let varDirectory = try makeVarDirectory(in: temporaryDirectory.url)
+    let child = try makePrivateDirectory(named: name, fileSize: 1_024, in: varDirectory)
+    let result = await makePrivateStorageAnalyzer(root: temporaryDirectory.url).analyze()
+    return (temporaryDirectory, try XCTUnwrap(privateNode(at: child.path, in: result.root)))
+}
+
+private func privateNode(at path: String, in root: StorageNode) -> StorageNode? {
+    var pending = [root]
+    while let candidate = pending.popLast() {
+        if candidate.absolutePath == path { return candidate }
+        pending.append(contentsOf: candidate.children)
+    }
+    return nil
+}
+
+private func privateNode(named name: String, under root: StorageNode) -> StorageNode? {
+    root.children.first { $0.name == name }
+}
+
+private func flattenedPrivateTree(_ root: StorageNode) -> [StorageNode] {
+    var result: [StorageNode] = []
+    var pending = [root]
+    while let node = pending.popLast() {
+        result.append(node)
+        pending.append(contentsOf: node.children)
+    }
+    return result
+}
+
+private func privateStorageOrdering(_ left: StorageNode, _ right: StorageNode) -> Bool {
+    if left.allocatedSize != right.allocatedSize { return left.allocatedSize > right.allocatedSize }
+    if left.logicalSize != right.logicalSize { return left.logicalSize > right.logicalSize }
+    return left.absolutePath < right.absolutePath
+}
+
+private func privateManagementKind(of node: StorageNode) -> PrivateStorageManagementKind? {
+    node.metadata.attributes[PrivateStorageAnalyzer.MetadataKey.managementKind]
+        .flatMap(PrivateStorageManagementKind.init(rawValue:))
+}
+
+private func privateSizeKnowledge(of node: StorageNode) -> PrivateStorageSizeKnowledge? {
+    node.metadata.attributes[PrivateStorageAnalyzer.MetadataKey.sizeKnowledge]
+        .flatMap(PrivateStorageSizeKnowledge.init(rawValue:))
+}
+
+private func syntheticPrivateResult(
+    root: StorageNode,
+    issues: [StorageScanIssue] = []
+) -> StorageAnalysisResult {
+    StorageAnalysisResult(
+        root: root,
+        startedAt: Date(),
+        completedAt: Date(),
+        rootDeviceIdentifier: 1,
+        wasCancelled: false,
+        issues: issues
+    )
+}
+
+private func syntheticPrivateNode(
+    name: String,
+    path: String,
+    logicalSize: Int64,
+    allocatedSize: Int64,
+    ownLogicalSize: Int64,
+    ownAllocatedSize: Int64,
+    itemType: StorageItemType,
+    children: [StorageNode] = [],
+    accessibility: StorageAccessibility = .accessible,
+    issues: [StorageScanIssue] = [],
+    isCounted: Bool = true
+) -> StorageNode {
+    StorageNode(
+        name: name,
+        absolutePath: path,
+        logicalSize: logicalSize,
+        allocatedSize: allocatedSize,
+        ownLogicalSize: ownLogicalSize,
+        ownAllocatedSize: ownAllocatedSize,
+        itemType: itemType,
+        children: children,
+        accessibility: accessibility,
+        scanIssues: issues,
+        isHidden: false,
+        isSymbolicLink: false,
+        isCountedInParentTotals: isCounted,
+        metadata: StorageAnalysisMetadata()
+    )
+}
+
+private func privateStatValues(for path: String) throws -> (logical: Int64, allocated: Int64) {
+    var metadata = stat()
+    guard lstat(path, &metadata) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: Darwin.errno) ?? .EIO)
+    }
+    return (Int64(metadata.st_size), Int64(metadata.st_blocks) * 512)
+}
+
+private func privateStatMode(for path: String) throws -> mode_t {
+    var metadata = stat()
+    guard lstat(path, &metadata) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: Darwin.errno) ?? .EIO)
+    }
+    return metadata.st_mode
+}

--- a/PureMacTests/StorageAnalysisCacheTests.swift
+++ b/PureMacTests/StorageAnalysisCacheTests.swift
@@ -1,0 +1,360 @@
+import XCTest
+@testable import PureMac
+
+final class StorageAnalysisCacheTests: XCTestCase {
+
+    private func makeTestNode(
+        name: String,
+        path: String,
+        allocatedSize: Int64,
+        logicalSize: Int64,
+        itemType: StorageItemType = .directory,
+        children: [StorageNode] = [],
+        issues: [StorageScanIssue] = []
+    ) -> StorageNode {
+        StorageNode(
+            name: name,
+            absolutePath: path,
+            logicalSize: logicalSize,
+            allocatedSize: allocatedSize,
+            ownLogicalSize: itemType == .directory ? 0 : logicalSize,
+            ownAllocatedSize: itemType == .directory ? 0 : allocatedSize,
+            itemType: itemType,
+            children: children,
+            accessibility: issues.isEmpty ? .accessible : .inaccessible,
+            scanIssues: issues,
+            isHidden: false,
+            isSymbolicLink: false,
+            isCountedInParentTotals: true,
+            metadata: StorageAnalysisMetadata()
+        )
+    }
+
+    func testExactPathCacheHit() {
+        let cache = StorageAnalysisCache()
+        let rootNode = makeTestNode(name: "Applications", path: "/Applications", allocatedSize: 1000, logicalSize: 1000)
+        let analysisResult = StorageAnalysisResult(
+            root: rootNode,
+            startedAt: Date(),
+            completedAt: Date(),
+            rootDeviceIdentifier: 1,
+            wasCancelled: false,
+            issues: []
+        )
+
+        cache.store(analysisResult, isFullSubtree: true)
+
+        let cached = cache.get(path: "/Applications")
+        XCTAssertNotNil(cached)
+        XCTAssertEqual(cached?.root.allocatedSize, 1000)
+        let metrics = cache.metrics
+        XCTAssertEqual(metrics.cacheHitCount, 1)
+        XCTAssertEqual(metrics.cacheMissCount, 0)
+    }
+
+    func testFirmlinkPathNormalizationReusesCache() {
+        let cache = StorageAnalysisCache()
+        let rootNode = makeTestNode(name: "Applications", path: "/Applications", allocatedSize: 5000, logicalSize: 5000)
+        let analysisResult = StorageAnalysisResult(
+            root: rootNode,
+            startedAt: Date(),
+            completedAt: Date(),
+            rootDeviceIdentifier: 1,
+            wasCancelled: false,
+            issues: []
+        )
+
+        cache.store(analysisResult, isFullSubtree: true)
+
+        // Querying through the firmlink path /System/Volumes/Data/Applications
+        let cached = cache.get(path: "/System/Volumes/Data/Applications")
+        XCTAssertNotNil(cached)
+        XCTAssertEqual(cached?.root.allocatedSize, 5000)
+        let metrics = cache.metrics
+        XCTAssertEqual(metrics.cacheHitCount, 1)
+        XCTAssertEqual(metrics.avoidedTraversalsCount, 1)
+    }
+
+    func testSubtreeExtractionFromFullParentScan() {
+        let cache = StorageAnalysisCache()
+        let dockerChild = makeTestNode(
+            name: "com.docker.docker",
+            path: "/Users/test/Library/Containers/com.docker.docker",
+            allocatedSize: 2048,
+            logicalSize: 2048,
+            issues: [
+                StorageScanIssue(
+                    path: "/Users/test/Library/Containers/com.docker.docker/data.db",
+                    kind: .permissionDenied,
+                    message: "Permission denied",
+                    posixErrorCode: 13
+                )
+            ]
+        )
+        let parentNode = makeTestNode(
+            name: "Containers",
+            path: "/Users/test/Library/Containers",
+            allocatedSize: 10000,
+            logicalSize: 10000,
+            children: [dockerChild]
+        )
+        let parentResult = StorageAnalysisResult(
+            root: parentNode,
+            startedAt: Date(),
+            completedAt: Date(),
+            rootDeviceIdentifier: 1,
+            wasCancelled: false,
+            issues: dockerChild.scanIssues
+        )
+
+        cache.store(parentResult, isFullSubtree: true)
+
+        // Subtree query for com.docker.docker
+        let subtree = cache.get(path: "/Users/test/Library/Containers/com.docker.docker")
+        XCTAssertNotNil(subtree)
+        XCTAssertEqual(subtree?.root.name, "com.docker.docker")
+        XCTAssertEqual(subtree?.root.allocatedSize, 2048)
+        XCTAssertEqual(subtree?.issues.count, 1)
+        XCTAssertEqual(subtree?.issues.first?.kind, .permissionDenied)
+        let metrics = cache.metrics
+        XCTAssertEqual(metrics.reusedSubtreeCount, 1)
+        XCTAssertEqual(metrics.avoidedTraversalsCount, 1)
+    }
+
+    func testDeepNestedSubtreeExtraction() {
+        let cache = StorageAnalysisCache()
+        let deepFile = makeTestNode(
+            name: "file.txt",
+            path: "/Users/test/Library/Application Support/Docker Desktop/vms/0/data/file.txt",
+            allocatedSize: 512,
+            logicalSize: 512,
+            itemType: .regularFile
+        )
+        let vmsFolder = makeTestNode(
+            name: "vms",
+            path: "/Users/test/Library/Application Support/Docker Desktop/vms",
+            allocatedSize: 512,
+            logicalSize: 512,
+            children: [deepFile]
+        )
+        let dockerAppSupport = makeTestNode(
+            name: "Docker Desktop",
+            path: "/Users/test/Library/Application Support/Docker Desktop",
+            allocatedSize: 512,
+            logicalSize: 512,
+            children: [vmsFolder]
+        )
+        let appSupport = makeTestNode(
+            name: "Application Support",
+            path: "/Users/test/Library/Application Support",
+            allocatedSize: 5000,
+            logicalSize: 5000,
+            children: [dockerAppSupport]
+        )
+
+        let appSupportResult = StorageAnalysisResult(
+            root: appSupport,
+            startedAt: Date(),
+            completedAt: Date(),
+            rootDeviceIdentifier: 1,
+            wasCancelled: false,
+            issues: []
+        )
+        cache.store(appSupportResult, isFullSubtree: true)
+
+        let extracted = cache.get(path: "/Users/test/Library/Application Support/Docker Desktop")
+        XCTAssertNotNil(extracted)
+        XCTAssertEqual(extracted?.root.name, "Docker Desktop")
+        XCTAssertEqual(extracted?.root.allocatedSize, 512)
+        XCTAssertEqual(extracted?.root.children.count, 1)
+        XCTAssertEqual(extracted?.root.children.first?.name, "vms")
+    }
+
+    func testCacheMissForUnrelatedPath() {
+        let cache = StorageAnalysisCache()
+        let rootNode = makeTestNode(name: "Containers", path: "/Users/test/Library/Containers", allocatedSize: 1000, logicalSize: 1000)
+        let analysisResult = StorageAnalysisResult(
+            root: rootNode,
+            startedAt: Date(),
+            completedAt: Date(),
+            rootDeviceIdentifier: 1,
+            wasCancelled: false,
+            issues: []
+        )
+        cache.store(analysisResult, isFullSubtree: true)
+
+        let missing = cache.get(path: "/Users/test/Library/Application Support")
+        XCTAssertNil(missing)
+        let metrics = cache.metrics
+        XCTAssertEqual(metrics.cacheMissCount, 1)
+    }
+
+    func testConcurrentScanOrCoalescePerformsSinglePhysicalTraversal() async throws {
+        let cache = StorageAnalysisCache()
+        var physicalTraversals = 0
+        let lock = NSLock()
+
+        let scanClosure: @Sendable () async throws -> StorageAnalysisResult = {
+            lock.lock()
+            physicalTraversals += 1
+            lock.unlock()
+            try await Task.sleep(nanoseconds: 50_000_000) // 50ms simulated scan
+            let node = StorageNode(
+                name: "shared",
+                absolutePath: "/test/shared",
+                logicalSize: 4096,
+                allocatedSize: 4096,
+                ownLogicalSize: 4096,
+                ownAllocatedSize: 4096,
+                itemType: .directory,
+                children: [],
+                accessibility: .accessible,
+                scanIssues: [],
+                isHidden: false,
+                isSymbolicLink: false,
+                isCountedInParentTotals: true,
+                metadata: StorageAnalysisMetadata()
+            )
+            return StorageAnalysisResult(
+                root: node,
+                startedAt: Date(),
+                completedAt: Date(),
+                rootDeviceIdentifier: 1,
+                wasCancelled: false,
+                issues: []
+            )
+        }
+
+        // Launch 4 concurrent requests for the exact same path
+        async let r1 = cache.scanOrCoalesce(path: "/test/shared", performScan: scanClosure)
+        async let r2 = cache.scanOrCoalesce(path: "/test/shared", performScan: scanClosure)
+        async let r3 = cache.scanOrCoalesce(path: "/test/shared", performScan: scanClosure)
+        async let r4 = cache.scanOrCoalesce(path: "/test/shared", performScan: scanClosure)
+
+        let results = try await [r1, r2, r3, r4]
+
+        XCTAssertEqual(results.count, 4)
+        for res in results {
+            XCTAssertEqual(res.root.allocatedSize, 4096)
+        }
+        XCTAssertEqual(physicalTraversals, 1)
+        let metrics = cache.metrics
+        XCTAssertEqual(metrics.physicalTraversalsCount, 1)
+        XCTAssertGreaterThanOrEqual(metrics.avoidedTraversalsCount, 3)
+    }
+
+    func testCancelledScanDoesNotPoisonCache() async throws {
+        let cache = StorageAnalysisCache()
+
+        let cancelledScan: @Sendable () async throws -> StorageAnalysisResult = {
+            let node = StorageNode(
+                name: "cancelled",
+                absolutePath: "/test/cancelled",
+                logicalSize: 0,
+                allocatedSize: 0,
+                ownLogicalSize: 0,
+                ownAllocatedSize: 0,
+                itemType: .directory,
+                children: [],
+                accessibility: .inaccessible,
+                scanIssues: [],
+                isHidden: false,
+                isSymbolicLink: false,
+                isCountedInParentTotals: true,
+                metadata: StorageAnalysisMetadata()
+            )
+            return StorageAnalysisResult(
+                root: node,
+                startedAt: Date(),
+                completedAt: Date(),
+                rootDeviceIdentifier: 1,
+                wasCancelled: true,
+                issues: []
+            )
+        }
+
+        _ = try await cache.scanOrCoalesce(path: "/test/cancelled", performScan: cancelledScan)
+
+        // Cache must not have stored the cancelled scan
+        let lookup = cache.get(path: "/test/cancelled")
+        XCTAssertNil(lookup)
+    }
+
+    func testPreservesByteCountsAndInvariants() {
+        let cache = StorageAnalysisCache()
+        let child1 = makeTestNode(name: "A", path: "/opt/homebrew/A", allocatedSize: 4096, logicalSize: 3000)
+        let child2 = makeTestNode(name: "B", path: "/opt/homebrew/B", allocatedSize: 8192, logicalSize: 7000)
+        let parent = makeTestNode(
+            name: "homebrew",
+            path: "/opt/homebrew",
+            allocatedSize: 12288,
+            logicalSize: 10000,
+            children: [child1, child2]
+        )
+
+        let parentResult = StorageAnalysisResult(
+            root: parent,
+            startedAt: Date(),
+            completedAt: Date(),
+            rootDeviceIdentifier: 1,
+            wasCancelled: false,
+            issues: []
+        )
+        cache.store(parentResult, isFullSubtree: true)
+
+        let extractedA = cache.get(path: "/opt/homebrew/A")
+        XCTAssertNotNil(extractedA)
+        XCTAssertEqual(extractedA?.root.allocatedSize, 4096)
+        XCTAssertEqual(extractedA?.root.logicalSize, 3000)
+
+        let extractedB = cache.get(path: "/opt/homebrew/B")
+        XCTAssertNotNil(extractedB)
+        XCTAssertEqual(extractedB?.root.allocatedSize, 8192)
+        XCTAssertEqual(extractedB?.root.logicalSize, 7000)
+    }
+
+    func testRealTraversalPipelineReusesSubtreesAndReportsMetrics() async throws {
+        let cache = StorageAnalysisCache()
+        let scanner = FileTreeScanner(cache: cache)
+
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let containersDir = tempDir.appendingPathComponent("Containers")
+        let dockerContainerDir = containersDir.appendingPathComponent("com.docker.docker")
+        let appSupportDir = tempDir.appendingPathComponent("Application Support")
+        let dockerAppSupportDir = appSupportDir.appendingPathComponent("Docker Desktop")
+
+        try FileManager.default.createDirectory(at: dockerContainerDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dockerAppSupportDir, withIntermediateDirectories: true)
+        try "test data 1".write(to: dockerContainerDir.appendingPathComponent("data.txt"), atomically: true, encoding: .utf8)
+        try "test data 2".write(to: dockerAppSupportDir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // 1. Stage 1: ContainersAnalyzer scans ~/Library/Containers
+        let containersAnalyzer = ContainersAnalyzer(containersURL: containersDir, scanner: scanner, cache: cache)
+        let containersResult = await containersAnalyzer.analyze()
+        XCTAssertGreaterThan(containersResult.root.allocatedSize, 0)
+
+        // 2. Stage 2: ApplicationSupportAnalyzer scans ~/Library/Application Support
+        let appSupportAnalyzer = ApplicationSupportAnalyzer(applicationSupportURL: appSupportDir, scanner: scanner, cache: cache)
+        let appSupportResult = await appSupportAnalyzer.analyze()
+        XCTAssertGreaterThan(appSupportResult.root.allocatedSize, 0)
+
+        // 3. Stage 3: DockerStorageAnalyzer inspects its host footprint roots
+        let dockerAnalyzer = DockerStorageAnalyzer(
+            hostStorageRoots: [dockerContainerDir, dockerAppSupportDir],
+            scanner: scanner,
+            cache: cache,
+            executableLocator: { nil }
+        )
+        let dockerReport = await dockerAnalyzer.analyze()
+        XCTAssertEqual(dockerReport.hostFootprint.locations.count, 2)
+
+        // 4. Verify that DockerStorageAnalyzer reused both subtrees from cache with zero disk scans
+        let metrics = cache.metrics
+        XCTAssertEqual(metrics.physicalTraversalsCount, 2) // only Containers & AppSupport were physically traversed
+        XCTAssertGreaterThanOrEqual(metrics.cacheHitCount, 2)
+        XCTAssertGreaterThanOrEqual(metrics.reusedSubtreeCount, 2)
+        XCTAssertGreaterThanOrEqual(metrics.avoidedTraversalsCount, 2)
+    }
+}

--- a/PureMacTests/StorageAnalysisCoordinatorTests.swift
+++ b/PureMacTests/StorageAnalysisCoordinatorTests.swift
@@ -1,0 +1,769 @@
+import XCTest
+@testable import PureMac
+
+final class StorageAnalysisCoordinatorTests: XCTestCase {
+    func testSuccessfulMultiAnalyzerReconciliation() async {
+        let report = await Self.makeCoordinator().analyze()
+
+        XCTAssertEqual(report.coverageStatus, .completeForConfiguredRoots)
+        XCTAssertFalse(report.wasCancelled)
+        XCTAssertEqual(report.progress.completedStages, 11)
+    }
+
+    func testExplainedBytesUseCanonicalAllocatedTotals() async {
+        let report = await Self.makeCoordinator().analyze()
+
+        XCTAssertEqual(report.explainedAllocatedBytes, 360)
+    }
+
+    func testUnexplainedBytesAreUsedMinusExplained() async {
+        let report = await Self.makeCoordinator().analyze()
+
+        XCTAssertEqual(report.usedCapacityBytes, 1_000)
+        XCTAssertEqual(report.unexplainedBytes, 640)
+    }
+
+    func testUnexplainedBytesNeverBecomeNegative() async {
+        var inputs = Inputs.baseline
+        inputs.apfs = Self.apfsReport(used: 100)
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+
+        XCTAssertEqual(report.unexplainedBytes, 0)
+    }
+
+    func testDockerHostInsideContainersIsNotDoubleCounted() async {
+        let report = await Self.makeCoordinator().analyze()
+        let docker = Self.contribution(report, source: .dockerHostOutsideCanonicalRoots)
+
+        XCTAssertEqual(docker?.accountedAllocatedBytes, 0)
+        XCTAssertEqual(docker?.owningPath, "/Users/test/Library/Containers")
+        XCTAssertEqual(report.explainedAllocatedBytes, 360)
+    }
+
+    func testDockerRuntimeAccountingIsNonAdditive() async {
+        var inputs = Inputs.baseline
+        inputs.docker = Self.dockerReport(
+            hostLocations: [],
+            runtimeBytes: 50_000,
+            runtimeLocation: .local
+        )
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+
+        XCTAssertEqual(report.analyzerResults.dockerStorage?.totalRuntimeReportedBytes, 50_000)
+        XCTAssertEqual(report.explainedAllocatedBytes, 360)
+    }
+
+    func testRemoteDockerRuntimeRemainsUnrelatedAndNonAdditive() async {
+        var inputs = Inputs.baseline
+        inputs.docker = Self.dockerReport(
+            hostLocations: [],
+            runtimeBytes: 90_000,
+            runtimeLocation: .remote
+        )
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+
+        XCTAssertEqual(
+            report.analyzerResults.dockerStorage?.hostRuntimeRelationship,
+            .remoteRuntimeNotRelatedToHostFootprint
+        )
+        XCTAssertEqual(report.explainedAllocatedBytes, 360)
+    }
+
+    func testAPFSSnapshotsAreNonAdditive() async {
+        var inputs = Inputs.baseline
+        inputs.apfs = Self.apfsReport(used: 1_000, snapshotSize: 700)
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+
+        XCTAssertEqual(report.analyzerResults.apfsStorage?.snapshots.first?.size, 700)
+        XCTAssertEqual(report.explainedAllocatedBytes, 360)
+        XCTAssertEqual(report.unexplainedBytes, 640)
+    }
+
+    func testPurgeableEstimateRemainsSeparate() async {
+        let report = await Self.makeCoordinator().analyze()
+
+        XCTAssertEqual(report.purgeableEstimateBytes, 100)
+        XCTAssertEqual(report.explainedAllocatedBytes, 360)
+        XCTAssertEqual(report.unexplainedBytes, 640)
+    }
+
+    func testNestedCanonicalPathIsExcluded() async {
+        var inputs = Inputs.baseline
+        inputs.applicationSupport = Self.result(path: "/Users/test/Library", allocated: 100)
+        inputs.containers = Self.result(path: "/Users/test/Library/Containers", allocated: 20)
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+        let containers = Self.contribution(report, source: .containers)
+
+        XCTAssertEqual(containers?.relationship, .excludedNestedPath)
+        XCTAssertEqual(containers?.accountedAllocatedBytes, 0)
+    }
+
+    func testDuplicateCanonicalRootIsCountedOnce() async {
+        var inputs = Inputs.baseline
+        inputs.applicationSupport = Self.result(path: "/same", allocated: 10)
+        inputs.containers = Self.result(path: "/same", allocated: 20)
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+        let duplicate = Self.contribution(report, source: .containers)
+
+        XCTAssertEqual(duplicate?.relationship, .excludedDuplicatePath)
+        XCTAssertTrue(report.analysisIssues.contains { $0.kind == .duplicateRootExcluded })
+    }
+
+    func testMissingOptionalDeveloperRootDoesNotFailCoverage() async {
+        var inputs = Inputs.baseline
+        inputs.developer = Self.developerReport(optState: .missing, optSize: 0)
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+        let opt = report.canonicalRootCoverage.first { $0.root == .opt }
+
+        XCTAssertEqual(opt?.state, .missingOptional)
+        XCTAssertEqual(report.coverageStatus, .completeForConfiguredRoots)
+    }
+
+    func testAnalyzerFailureReturnsPartialReport() async {
+        let report = await Self.makeCoordinator(.baseline, failing: .systemLibrary).analyze()
+
+        XCTAssertNil(report.analyzerResults.systemLibrary)
+        XCTAssertNotNil(report.analyzerResults.containers)
+        XCTAssertEqual(report.coverageStatus, .partialDueToAnalyzerFailure)
+        XCTAssertTrue(report.analysisIssues.contains { $0.kind == .analyzerFailure })
+    }
+
+    func testPermissionIncompleteAnalyzerReportsKnownLowerBound() async {
+        var inputs = Inputs.baseline
+        let issue = StorageScanIssue(
+            path: "/private/secret",
+            kind: .permissionDenied,
+            message: "Permission denied.",
+            posixErrorCode: EACCES
+        )
+        inputs.privateStorage = Self.result(
+            path: "/private",
+            allocated: 50,
+            accessibility: .partiallyAccessible,
+            issues: [issue]
+        )
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+
+        XCTAssertEqual(report.coverageStatus, .partialDueToPermissions)
+        XCTAssertEqual(report.inaccessibleKnownLowerBoundBytes, 50)
+        XCTAssertEqual(report.unreadablePathCount, 1)
+    }
+
+    func testCancelledAnalyzerProducesCancelledCoverage() async {
+        var inputs = Inputs.baseline
+        inputs.containers = Self.result(
+            path: "/Users/test/Library/Containers",
+            allocated: 12,
+            accessibility: .cancelled,
+            wasCancelled: true
+        )
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+
+        XCTAssertTrue(report.wasCancelled)
+        XCTAssertEqual(report.coverageStatus, .partialDueToCancellation)
+        XCTAssertEqual(report.progress.state, .cancelled)
+    }
+
+    func testGlobalCancellationStopsSchedulingAndReturnsPartialReport() async {
+        let coordinator = Self.delayedCoordinator()
+        let task = Task { await coordinator.analyze() }
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        task.cancel()
+
+        let report = await task.value
+
+        XCTAssertTrue(report.wasCancelled)
+        XCTAssertEqual(report.coverageStatus, .partialDueToCancellation)
+        XCTAssertLessThan(report.progress.completedStages, report.progress.totalStages)
+    }
+
+    func testCoverageStatusIsCompleteOnlyForConfiguredRoots() async {
+        let report = await Self.makeCoordinator().analyze()
+
+        XCTAssertEqual(report.coverageStatus, .completeForConfiguredRoots)
+        XCTAssertTrue(report.incompleteCoverage)
+        XCTAssertEqual(report.canonicalRootCoverage.count, 10)
+    }
+
+    func testIssuesAreAggregatedFromAnalyzerResults() async {
+        var inputs = Inputs.baseline
+        let issue = StorageScanIssue(
+            path: "/Library/broken",
+            kind: .unreadable,
+            message: "Unreadable entry.",
+            posixErrorCode: EIO
+        )
+        inputs.systemLibrary = Self.result(
+            path: "/Library",
+            allocated: 40,
+            accessibility: .partiallyAccessible,
+            issues: [issue]
+        )
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+
+        XCTAssertTrue(report.analysisIssues.contains {
+            $0.stage == .systemLibrary && $0.path == "/Library/broken"
+        })
+    }
+
+    func testProgressAccountsForEveryStage() async {
+        let recorder = ProgressRecorder()
+        let report = await Self.makeCoordinator().analyze { progress in
+            await recorder.append(progress)
+        }
+        let values = await recorder.values
+
+        XCTAssertEqual(values.first?.totalStages, 11)
+        XCTAssertEqual(values.last?.completedStages, 11)
+        XCTAssertEqual(values.last?.runningStages, [])
+        XCTAssertEqual(report.progress, values.last)
+    }
+
+    func testZeroUsedSpaceProducesZeroUnexplainedBytes() async {
+        var inputs = Inputs.baseline
+        inputs.apfs = Self.apfsReport(used: 0)
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+
+        XCTAssertEqual(report.unexplainedBytes, 0)
+    }
+
+    func testUsedCapacityGreaterThanExplainedRetainsRemainder() async {
+        var inputs = Inputs.baseline
+        inputs.apfs = Self.apfsReport(used: 10_000)
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+
+        XCTAssertEqual(report.unexplainedBytes, 9_640)
+    }
+
+    func testExplainedGreaterThanUsedIsClampedAndReported() async {
+        var inputs = Inputs.baseline
+        inputs.apfs = Self.apfsReport(used: 100)
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+
+        XCTAssertEqual(report.unexplainedBytes, 0)
+        XCTAssertTrue(report.analysisIssues.contains { $0.kind == .accountingAnomaly })
+    }
+
+    func testHiddenDataVolumeChildrenDoNotDuplicateLibraryOrPrivate() async {
+        var inputs = Inputs.baseline
+        inputs.hidden = Self.result(
+            path: "/System/Volumes/Data",
+            allocated: 22,
+            children: [
+                Self.node(path: "/Library/.hidden", allocated: 11, hidden: true),
+                Self.node(path: "/private/.hidden", allocated: 11, hidden: true),
+            ]
+        )
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+        let hidden = report.filesystemContributions.filter {
+            $0.source == .dataVolumeHiddenStorage
+        }
+
+        XCTAssertEqual(hidden.count, 2)
+        XCTAssertTrue(hidden.allSatisfy { $0.accountedAllocatedBytes == 0 })
+    }
+
+    func testOptAndUsrLocalRemainSeparateContributionsWithSharedLedgerTotal() async {
+        let report = await Self.makeCoordinator().analyze()
+        let opt = Self.contribution(report, source: .opt)
+        let usrLocal = Self.contribution(report, source: .usrLocal)
+
+        XCTAssertEqual(opt?.observedAllocatedBytes, 70)
+        XCTAssertEqual(usrLocal?.observedAllocatedBytes, 80)
+        XCTAssertEqual((opt?.accountedAllocatedBytes ?? 0) + (usrLocal?.accountedAllocatedBytes ?? 0), 150)
+    }
+
+    func testApplicationAttributionMetadataDoesNotAddBytes() async {
+        var inputs = Inputs.baseline
+        inputs.applicationSupport = Self.result(
+            path: "/Users/test/Library/Application Support",
+            allocated: 10,
+            metadata: StorageAnalysisMetadata(
+                owningApplicationIdentifier: "com.example.large",
+                owningApplicationName: "Large App",
+                attributes: ["reportedSize": "999999"]
+            )
+        )
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+
+        XCTAssertEqual(report.explainedAllocatedBytes, 360)
+    }
+
+    func testSparseLogicalCapacityDoesNotAffectExplainedAllocatedBytes() async {
+        var inputs = Inputs.baseline
+        inputs.applicationSupport = Self.result(
+            path: "/Users/test/Library/Application Support",
+            logical: 1_000_000,
+            allocated: 10
+        )
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+
+        XCTAssertEqual(report.explainedAllocatedBytes, 360)
+    }
+
+    func testCrossAnalyzerHardLinkLimitationIsExplicit() async {
+        let report = await Self.makeCoordinator().analyze()
+
+        XCTAssertEqual(report.hardLinkAccountingStatus, .deduplicatedWithinAnalyzerScopesOnly)
+        XCTAssertTrue(report.analysisIssues.contains {
+            $0.kind == .crossAnalyzerHardLinkDeduplicationUnavailable
+        })
+    }
+
+    func testReportOrderingIsDeterministic() async {
+        let first = await Self.makeCoordinator().analyze()
+        let second = await Self.makeCoordinator().analyze()
+
+        XCTAssertEqual(first.filesystemContributions, second.filesystemContributions)
+        XCTAssertEqual(first.canonicalRootCoverage, second.canonicalRootCoverage)
+        XCTAssertEqual(first.analysisIssues, second.analysisIssues)
+    }
+
+    func testCoordinatorSourceReferencesNoCleanupOrDeletionAPIs() throws {
+        let sourceURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("PureMac/Services/StorageAnalysisCoordinator.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        for forbidden in ["CleaningEngine", "removeItem(", "trashItem(", "purgePurgeable", "deleteSnapshot"] {
+            XCTAssertFalse(source.contains(forbidden), "Unexpected mutating API reference: \(forbidden)")
+        }
+    }
+
+    func testAllExistingAnalyzerResultsRemainAccessible() async {
+        let results = await Self.makeCoordinator().analyze().analyzerResults
+
+        XCTAssertNotNil(results.userHomeStorage)
+        XCTAssertNotNil(results.applicationSupport)
+        XCTAssertNotNil(results.containers)
+        XCTAssertNotNil(results.groupContainers)
+        XCTAssertNotNil(results.systemLibrary)
+        XCTAssertNotNil(results.privateStorage)
+        XCTAssertNotNil(results.dataVolumeHiddenStorage)
+        XCTAssertNotNil(results.developerSystemStorage)
+        XCTAssertNotNil(results.dockerStorage)
+        XCTAssertNotNil(results.apfsStorage)
+        XCTAssertNotNil(results.coverageExpansion)
+    }
+
+    func testCoordinatorIncludesVisibleUserHomeBytes() async {
+        var inputs = Inputs.baseline
+        inputs.userHome = Self.userHomeReport(roots: [
+            ("/Users/test/Documents", 100),
+            ("/Users/test/Downloads", 25),
+        ])
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+        let contributions = report.filesystemContributions.filter {
+            $0.source == .userHomeVisibleStorage
+        }
+
+        XCTAssertEqual(contributions.reduce(0) { $0 + $1.accountedAllocatedBytes }, 125)
+        XCTAssertEqual(report.explainedAllocatedBytes, 485)
+    }
+
+    func testUserHomeCannotOverlapApplicationSupport() async {
+        var inputs = Inputs.baseline
+        inputs.userHome = Self.userHomeReport(roots: [
+            ("/Users/test/Library/Application Support", 900),
+        ])
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+
+        XCTAssertEqual(Self.contribution(report, source: .applicationSupport)?.accountedAllocatedBytes, 10)
+        XCTAssertEqual(Self.contribution(report, source: .userHomeVisibleStorage)?.accountedAllocatedBytes, 0)
+        XCTAssertEqual(report.explainedAllocatedBytes, 360)
+    }
+
+    func testUserHomeCannotOverlapContainers() async {
+        var inputs = Inputs.baseline
+        inputs.userHome = Self.userHomeReport(roots: [
+            ("/Users/test/Library/Containers", 900),
+        ])
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+
+        XCTAssertEqual(Self.contribution(report, source: .containers)?.accountedAllocatedBytes, 20)
+        XCTAssertEqual(Self.contribution(report, source: .userHomeVisibleStorage)?.accountedAllocatedBytes, 0)
+        XCTAssertEqual(report.explainedAllocatedBytes, 360)
+    }
+
+    func testUserHomeCannotOverlapGroupContainers() async {
+        var inputs = Inputs.baseline
+        inputs.userHome = Self.userHomeReport(roots: [
+            ("/Users/test/Library/Group Containers", 900),
+        ])
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+
+        XCTAssertEqual(Self.contribution(report, source: .groupContainers)?.accountedAllocatedBytes, 30)
+        XCTAssertEqual(Self.contribution(report, source: .userHomeVisibleStorage)?.accountedAllocatedBytes, 0)
+        XCTAssertEqual(report.explainedAllocatedBytes, 360)
+    }
+
+    func testUserHomeBytesReduceUnexplainedCapacityExactlyOnce() async {
+        let baseline = await Self.makeCoordinator().analyze()
+        var inputs = Inputs.baseline
+        inputs.userHome = Self.userHomeReport(roots: [("/Users/test/Documents", 100)])
+
+        let expanded = await Self.makeCoordinator(inputs).analyze()
+
+        XCTAssertEqual(expanded.explainedAllocatedBytes - baseline.explainedAllocatedBytes, 100)
+        XCTAssertEqual((baseline.unexplainedBytes ?? 0) - (expanded.unexplainedBytes ?? 0), 100)
+    }
+}
+
+// MARK: - Fixtures
+
+private extension StorageAnalysisCoordinatorTests {
+    struct TestFailure: Error {}
+
+    struct Inputs: Sendable {
+        var userHome: UserHomeStorageReport
+        var applicationSupport: StorageAnalysisResult
+        var containers: StorageAnalysisResult
+        var groupContainers: StorageAnalysisResult
+        var systemLibrary: StorageAnalysisResult
+        var privateStorage: StorageAnalysisResult
+        var hidden: StorageAnalysisResult
+        var developer: DeveloperSystemStorageReport
+        var docker: DockerStorageReport
+        var apfs: APFSStorageReport
+        var coverageExpansion: StorageCoverageExpansionReport
+
+        static var baseline: Inputs {
+            Inputs(
+                userHome: userHomeReport(),
+                applicationSupport: result(
+                    path: "/Users/test/Library/Application Support",
+                    allocated: 10
+                ),
+                containers: result(
+                    path: "/Users/test/Library/Containers",
+                    allocated: 20
+                ),
+                groupContainers: result(
+                    path: "/Users/test/Library/Group Containers",
+                    allocated: 30
+                ),
+                systemLibrary: result(path: "/Library", allocated: 40),
+                privateStorage: result(path: "/private", allocated: 50),
+                hidden: result(
+                    path: "/System/Volumes/Data",
+                    allocated: 60,
+                    children: [node(path: "/System/Volumes/Data/.hidden", allocated: 60, hidden: true)]
+                ),
+                developer: developerReport(),
+                docker: dockerReport(hostLocations: [
+                    result(
+                        path: "/Users/test/Library/Containers/com.docker.docker",
+                        allocated: 15
+                    ),
+                ]),
+                apfs: apfsReport(used: 1_000),
+                coverageExpansion: .empty
+            )
+        }
+    }
+
+    static func makeCoordinator(
+        _ inputs: Inputs = .baseline,
+        failing stage: StorageAnalyzerStage? = nil
+    ) -> StorageAnalysisCoordinator {
+        StorageAnalysisCoordinator(
+            userHomeStorageAnalysis: {
+                if stage == .userHomeStorage { throw TestFailure() }
+                return inputs.userHome
+            },
+            applicationSupportAnalysis: {
+                if stage == .applicationSupport { throw TestFailure() }
+                return inputs.applicationSupport
+            },
+            containersAnalysis: {
+                if stage == .containers { throw TestFailure() }
+                return inputs.containers
+            },
+            groupContainersAnalysis: {
+                if stage == .groupContainers { throw TestFailure() }
+                return inputs.groupContainers
+            },
+            systemLibraryAnalysis: {
+                if stage == .systemLibrary { throw TestFailure() }
+                return inputs.systemLibrary
+            },
+            privateStorageAnalysis: {
+                if stage == .privateStorage { throw TestFailure() }
+                return inputs.privateStorage
+            },
+            dataVolumeHiddenStorageAnalysis: {
+                if stage == .dataVolumeHiddenStorage { throw TestFailure() }
+                return inputs.hidden
+            },
+            developerSystemStorageAnalysis: {
+                if stage == .developerSystemStorage { throw TestFailure() }
+                return inputs.developer
+            },
+            dockerStorageAnalysis: {
+                if stage == .dockerStorage { throw TestFailure() }
+                return inputs.docker
+            },
+            apfsStorageAnalysis: {
+                if stage == .apfsVolume { throw TestFailure() }
+                return inputs.apfs
+            },
+            coverageExpansionAnalysis: {
+                if stage == .coverageExpansion { throw TestFailure() }
+                return inputs.coverageExpansion
+            },
+            coverageDiscovery: {
+                .empty(homeDirectoryPath: "/Users/test")
+            }
+        )
+    }
+
+    static func delayedCoordinator() -> StorageAnalysisCoordinator {
+        let delay: @Sendable () async throws -> Void = {
+            try await Task.sleep(nanoseconds: 200_000_000)
+        }
+        let inputs = Inputs.baseline
+        return StorageAnalysisCoordinator(
+            maxConcurrentAnalyzers: 2,
+            userHomeStorageAnalysis: { try await delay(); return inputs.userHome },
+            applicationSupportAnalysis: { try await delay(); return inputs.applicationSupport },
+            containersAnalysis: { try await delay(); return inputs.containers },
+            groupContainersAnalysis: { try await delay(); return inputs.groupContainers },
+            systemLibraryAnalysis: { try await delay(); return inputs.systemLibrary },
+            privateStorageAnalysis: { try await delay(); return inputs.privateStorage },
+            dataVolumeHiddenStorageAnalysis: { try await delay(); return inputs.hidden },
+            developerSystemStorageAnalysis: { try await delay(); return inputs.developer },
+            dockerStorageAnalysis: { try await delay(); return inputs.docker },
+            apfsStorageAnalysis: { try await delay(); return inputs.apfs },
+            coverageExpansionAnalysis: { try await delay(); return inputs.coverageExpansion },
+            coverageDiscovery: { .empty(homeDirectoryPath: "/Users/test") }
+        )
+    }
+
+    static func contribution(
+        _ report: StorageReconciliationReport,
+        source: StorageAccountingSource
+    ) -> StorageFilesystemContribution? {
+        report.filesystemContributions.first { $0.source == source }
+    }
+
+    static func userHomeReport(
+        roots: [(path: String, allocated: Int64)] = []
+    ) -> UserHomeStorageReport {
+        let home = URL(fileURLWithPath: "/Users/test", isDirectory: true)
+        let total = roots.reduce(Int64(0)) { $0 + $1.allocated }
+        let input = result(
+            path: home.path,
+            allocated: total,
+            children: roots.map { node(path: $0.path, allocated: $0.allocated) }
+        )
+        return UserHomeStorageAnalyzer.makeReport(
+            input,
+            homeDirectoryURL: home,
+            largeAllocatedSizeThreshold: 1_073_741_824
+        )
+    }
+
+    static func result(
+        path: String,
+        logical: Int64? = nil,
+        allocated: Int64,
+        accessibility: StorageAccessibility = .accessible,
+        issues: [StorageScanIssue] = [],
+        children: [StorageNode] = [],
+        metadata: StorageAnalysisMetadata = StorageAnalysisMetadata(),
+        wasCancelled: Bool = false
+    ) -> StorageAnalysisResult {
+        let date = Date(timeIntervalSince1970: 1)
+        return StorageAnalysisResult(
+            root: node(
+                path: path,
+                logical: logical,
+                allocated: allocated,
+                accessibility: accessibility,
+                issues: issues,
+                children: children,
+                metadata: metadata
+            ),
+            startedAt: date,
+            completedAt: date,
+            rootDeviceIdentifier: 1,
+            wasCancelled: wasCancelled,
+            issues: issues
+        )
+    }
+
+    static func node(
+        path: String,
+        logical: Int64? = nil,
+        allocated: Int64,
+        accessibility: StorageAccessibility = .accessible,
+        issues: [StorageScanIssue] = [],
+        children: [StorageNode] = [],
+        hidden: Bool = false,
+        metadata: StorageAnalysisMetadata = StorageAnalysisMetadata()
+    ) -> StorageNode {
+        StorageNode(
+            name: URL(fileURLWithPath: path).lastPathComponent,
+            absolutePath: path,
+            logicalSize: logical ?? allocated,
+            allocatedSize: allocated,
+            ownLogicalSize: logical ?? allocated,
+            ownAllocatedSize: allocated,
+            itemType: .directory,
+            children: children,
+            accessibility: accessibility,
+            scanIssues: issues,
+            isHidden: hidden,
+            isSymbolicLink: false,
+            isCountedInParentTotals: true,
+            metadata: metadata
+        )
+    }
+
+    static func developerReport(
+        optState: DeveloperSystemRootState = .present,
+        optSize: Int64 = 70
+    ) -> DeveloperSystemStorageReport {
+        let optResult = result(path: "/opt", allocated: optSize)
+        let usrResult = result(path: "/usr/local", allocated: 80)
+        return DeveloperSystemStorageReport(
+            opt: DeveloperSystemRootAnalysis(
+                canonicalRoot: .opt,
+                configuredPath: "/opt",
+                state: optState,
+                result: optResult
+            ),
+            usrLocal: DeveloperSystemRootAnalysis(
+                canonicalRoot: .usrLocal,
+                configuredPath: "/usr/local",
+                state: .present,
+                result: usrResult
+            ),
+            combinedUniqueLogicalSize: optSize + 80,
+            combinedUniqueAllocatedSize: optSize + 80,
+            combinedSizeKnowledge: .complete,
+            wasCancelled: false,
+            issues: []
+        )
+    }
+
+    static func dockerReport(
+        hostLocations: [StorageAnalysisResult],
+        runtimeBytes: Int64? = nil,
+        runtimeLocation: DockerRuntimeLocation = .local
+    ) -> DockerStorageReport {
+        let runtime = runtimeBytes.map {
+            DockerRuntimeAccounting(
+                images: DockerRuntimeStorageUsage(
+                    category: .images,
+                    totalBytes: $0,
+                    reclaimableBytes: 0,
+                    reclaimablePercentage: 0,
+                    objectCount: 1,
+                    activeCount: 1
+                ),
+                containers: nil,
+                localVolumes: nil,
+                buildCache: nil
+            )
+        }
+        let relationship: DockerHostRuntimeRelationship
+        switch runtimeLocation {
+        case .local: relationship = .localRuntimeMayExplainHostFootprint
+        case .remote: relationship = .remoteRuntimeNotRelatedToHostFootprint
+        case .unknown: relationship = .unknownRelationship
+        }
+        return DockerStorageReport(
+            hostFootprint: DockerHostFootprint(
+                locations: hostLocations,
+                logicalSize: hostLocations.reduce(0) { $0 + $1.root.logicalSize },
+                allocatedSize: hostLocations.reduce(0) { $0 + $1.root.allocatedSize }
+            ),
+            virtualDisks: [],
+            runtimeStatus: runtime == nil ? .notInstalled : .installedAndReachable,
+            runtimeAccounting: runtime,
+            dockerExecutablePath: nil,
+            runtimeContext: DockerRuntimeContext(
+                name: "test",
+                sanitizedEndpoint: runtimeLocation == .remote ? "ssh://remote" : "unix:///local.sock",
+                location: runtimeLocation
+            ),
+            hostRuntimeRelationship: relationship,
+            accountingRelationship: .runtimeBreakdownIsNonAdditiveToHostFootprint,
+            wasCancelled: false,
+            issues: []
+        )
+    }
+
+    static func apfsReport(used: Int64, snapshotSize: Int64? = nil) -> APFSStorageReport {
+        let snapshot = snapshotSize.map {
+            APFSSnapshotInformation(
+                identifier: "snapshot",
+                name: "snapshot",
+                uuid: nil,
+                creationDate: nil,
+                size: $0,
+                sizeKnowledge: .reportedBySystem,
+                type: .timeMachine,
+                source: .diskutil,
+                storageRelationship: .sharedNonAdditive
+            )
+        }
+        return APFSStorageReport(
+            volume: APFSVolumeInformation(
+                name: "Data",
+                volumeIdentifier: "disk-test",
+                volumeUUID: nil,
+                containerIdentifier: nil,
+                volumeGroupIdentifier: nil,
+                filesystemType: "apfs",
+                filesystemKind: .apfs,
+                mountPoint: "/",
+                dataVolumeRelationship: .dataVolume,
+                capacity: APFSVolumeCapacity(
+                    totalCapacity: used + 200,
+                    availableCapacity: 200,
+                    usedCapacity: used,
+                    availableCapacityForImportantUsage: 300,
+                    availableCapacityForOpportunisticUsage: nil,
+                    purgeableEstimate: 100,
+                    purgeableEstimateKnowledge: .estimated
+                )
+            ),
+            snapshots: snapshot.map { [$0] } ?? [],
+            state: .complete,
+            accountingRelationship: .volumeMetadataAndSnapshotsAreNonAdditiveToFilesystemTrees,
+            wasCancelled: false,
+            issues: []
+        )
+    }
+}
+
+private actor ProgressRecorder {
+    private(set) var values: [StorageAnalysisProgress] = []
+
+    func append(_ value: StorageAnalysisProgress) {
+        values.append(value)
+    }
+}

--- a/PureMacTests/StorageAnalysisCoordinatorTests.swift
+++ b/PureMacTests/StorageAnalysisCoordinatorTests.swift
@@ -7,7 +7,7 @@ final class StorageAnalysisCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(report.coverageStatus, .completeForConfiguredRoots)
         XCTAssertFalse(report.wasCancelled)
-        XCTAssertEqual(report.progress.completedStages, 11)
+        XCTAssertEqual(report.progress.completedStages, 12)
     }
 
     func testExplainedBytesUseCanonicalAllocatedTotals() async {
@@ -191,7 +191,7 @@ final class StorageAnalysisCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(report.coverageStatus, .completeForConfiguredRoots)
         XCTAssertTrue(report.incompleteCoverage)
-        XCTAssertEqual(report.canonicalRootCoverage.count, 10)
+        XCTAssertEqual(report.canonicalRootCoverage.count, 11)
     }
 
     func testIssuesAreAggregatedFromAnalyzerResults() async {
@@ -223,8 +223,8 @@ final class StorageAnalysisCoordinatorTests: XCTestCase {
         }
         let values = await recorder.values
 
-        XCTAssertEqual(values.first?.totalStages, 11)
-        XCTAssertEqual(values.last?.completedStages, 11)
+        XCTAssertEqual(values.first?.totalStages, 12)
+        XCTAssertEqual(values.last?.completedStages, 12)
         XCTAssertEqual(values.last?.runningStages, [])
         XCTAssertEqual(report.progress, values.last)
     }
@@ -351,6 +351,7 @@ final class StorageAnalysisCoordinatorTests: XCTestCase {
         let results = await Self.makeCoordinator().analyze().analyzerResults
 
         XCTAssertNotNil(results.userHomeStorage)
+        XCTAssertNotNil(results.applications)
         XCTAssertNotNil(results.applicationSupport)
         XCTAssertNotNil(results.containers)
         XCTAssertNotNil(results.groupContainers)
@@ -361,6 +362,28 @@ final class StorageAnalysisCoordinatorTests: XCTestCase {
         XCTAssertNotNil(results.dockerStorage)
         XCTAssertNotNil(results.apfsStorage)
         XCTAssertNotNil(results.coverageExpansion)
+    }
+
+    func testCoordinatorIncludesApplicationsBytes() async {
+        var inputs = Inputs.baseline
+        inputs.applications = Self.result(path: "/Applications", allocated: 150)
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+        let contribution = Self.contribution(report, source: .applications)
+
+        XCTAssertEqual(contribution?.accountedAllocatedBytes, 150)
+        XCTAssertEqual(report.explainedAllocatedBytes, 510)
+    }
+
+    func testApplicationsDeduplicatedWithDataVolumeApplications() async {
+        var inputs = Inputs.baseline
+        inputs.applications = Self.result(path: "/Applications", allocated: 200)
+
+        let report = await Self.makeCoordinator(inputs).analyze()
+        let contributions = report.filesystemContributions.filter { $0.source == .applications }
+
+        XCTAssertEqual(contributions.count, 1)
+        XCTAssertEqual(contributions.first?.accountedAllocatedBytes, 200)
     }
 
     func testCoordinatorIncludesVisibleUserHomeBytes() async {
@@ -437,6 +460,7 @@ private extension StorageAnalysisCoordinatorTests {
 
     struct Inputs: Sendable {
         var userHome: UserHomeStorageReport
+        var applications: StorageAnalysisResult
         var applicationSupport: StorageAnalysisResult
         var containers: StorageAnalysisResult
         var groupContainers: StorageAnalysisResult
@@ -451,6 +475,7 @@ private extension StorageAnalysisCoordinatorTests {
         static var baseline: Inputs {
             Inputs(
                 userHome: userHomeReport(),
+                applications: result(path: "/Applications", allocated: 0),
                 applicationSupport: result(
                     path: "/Users/test/Library/Application Support",
                     allocated: 10
@@ -491,6 +516,10 @@ private extension StorageAnalysisCoordinatorTests {
             userHomeStorageAnalysis: {
                 if stage == .userHomeStorage { throw TestFailure() }
                 return inputs.userHome
+            },
+            applicationsAnalysis: {
+                if stage == .applications { throw TestFailure() }
+                return inputs.applications
             },
             applicationSupportAnalysis: {
                 if stage == .applicationSupport { throw TestFailure() }
@@ -546,6 +575,7 @@ private extension StorageAnalysisCoordinatorTests {
         return StorageAnalysisCoordinator(
             maxConcurrentAnalyzers: 2,
             userHomeStorageAnalysis: { try await delay(); return inputs.userHome },
+            applicationsAnalysis: { try await delay(); return inputs.applications },
             applicationSupportAnalysis: { try await delay(); return inputs.applicationSupport },
             containersAnalysis: { try await delay(); return inputs.containers },
             groupContainersAnalysis: { try await delay(); return inputs.groupContainers },
@@ -757,6 +787,47 @@ private extension StorageAnalysisCoordinatorTests {
             wasCancelled: false,
             issues: []
         )
+    }
+
+    func testCoordinatorWiresRunCacheAcrossLiveAnalyzersAndRecordsAvoidedTraversals() async throws {
+        let coordinator = StorageAnalysisCoordinator(
+            userHomeStorageAnalysis: {
+                Self.userHomeReport(roots: [("/Users/test/Documents", 1000)])
+            },
+            applicationsAnalysis: {
+                Self.result(path: "/Applications", allocated: 1000)
+            },
+            systemLibraryAnalysis: {
+                Self.result(path: "/Library", allocated: 1000)
+            },
+            privateStorageAnalysis: {
+                Self.result(path: "/private", allocated: 1000)
+            },
+            dataVolumeHiddenStorageAnalysis: {
+                Self.result(path: "/System/Volumes/Data/.hidden", allocated: 1000)
+            },
+            developerSystemStorageAnalysis: {
+                Self.developerReport(optSize: 1000)
+            },
+            apfsStorageAnalysis: {
+                Self.apfsReport(used: 10000)
+            },
+            coverageExpansionAnalysis: {
+                StorageCoverageExpansionReport.empty
+            },
+            coverageDiscovery: {
+                StorageCoverageDiscoveryResult(
+                    homeDirectoryPath: "/Users/test",
+                    hiddenHomeEntries: [],
+                    unspecializedLibraryEntries: [],
+                    issues: [],
+                    wasCancelled: false
+                )
+            }
+        )
+
+        let report = await coordinator.analyze()
+        XCTAssertGreaterThan(report.filesystemContributions.count, 0)
     }
 }
 

--- a/PureMacTests/StorageAnalysisPerformanceDiagnosticsTests.swift
+++ b/PureMacTests/StorageAnalysisPerformanceDiagnosticsTests.swift
@@ -1,0 +1,306 @@
+import XCTest
+@testable import PureMac
+
+final class StorageAnalysisPerformanceDiagnosticsTests: XCTestCase {
+    func testStorageScanMetricsComputation() {
+        let childFile1 = StorageNode(
+            name: "file1.txt",
+            absolutePath: "/test/file1.txt",
+            logicalSize: 1024,
+            allocatedSize: 4096,
+            ownLogicalSize: 1024,
+            ownAllocatedSize: 4096,
+            itemType: .regularFile,
+            children: [],
+            accessibility: .accessible,
+            scanIssues: [],
+            isHidden: false,
+            isSymbolicLink: false,
+            isCountedInParentTotals: true,
+            metadata: StorageAnalysisMetadata()
+        )
+
+        let childFile2 = StorageNode(
+            name: "file2.txt",
+            absolutePath: "/test/sub/file2.txt",
+            logicalSize: 2048,
+            allocatedSize: 8192,
+            ownLogicalSize: 2048,
+            ownAllocatedSize: 8192,
+            itemType: .regularFile,
+            children: [],
+            accessibility: .inaccessible,
+            scanIssues: [StorageScanIssue(path: "/test/sub/file2.txt", kind: .permissionDenied, message: "Denied", posixErrorCode: nil)],
+            isHidden: false,
+            isSymbolicLink: false,
+            isCountedInParentTotals: true,
+            metadata: StorageAnalysisMetadata()
+        )
+
+        let subDir = StorageNode(
+            name: "sub",
+            absolutePath: "/test/sub",
+            logicalSize: 2048,
+            allocatedSize: 8192,
+            ownLogicalSize: 0,
+            ownAllocatedSize: 0,
+            itemType: .directory,
+            children: [childFile2],
+            accessibility: .partiallyAccessible,
+            scanIssues: [],
+            isHidden: false,
+            isSymbolicLink: false,
+            isCountedInParentTotals: true,
+            metadata: StorageAnalysisMetadata()
+        )
+
+        let rootNode = StorageNode(
+            name: "test",
+            absolutePath: "/test",
+            logicalSize: 3072,
+            allocatedSize: 12288,
+            ownLogicalSize: 0,
+            ownAllocatedSize: 0,
+            itemType: .directory,
+            children: [childFile1, subDir],
+            accessibility: .accessible,
+            scanIssues: [],
+            isHidden: false,
+            isSymbolicLink: false,
+            isCountedInParentTotals: true,
+            metadata: StorageAnalysisMetadata()
+        )
+
+        let metrics = StorageScanMetrics.compute(from: rootNode)
+
+        XCTAssertEqual(metrics.totalEntries, 4)
+        XCTAssertEqual(metrics.directoryCount, 2)
+        XCTAssertEqual(metrics.fileCount, 2)
+        XCTAssertEqual(metrics.allocatedBytes, 12288)
+        XCTAssertEqual(metrics.logicalBytes, 3072)
+        XCTAssertEqual(metrics.permissionFailureCount, 1)
+        XCTAssertEqual(metrics.boundarySkipCount, 0)
+    }
+
+    func testPerformanceReportFormatting() {
+        let record1 = StagePerformanceRecord(
+            stageName: "Applications",
+            durationSeconds: 2.80,
+            metrics: StorageScanMetrics(
+                totalEntries: 61210,
+                directoryCount: 5000,
+                fileCount: 56210,
+                otherCount: 0,
+                allocatedBytes: 40_000_000_000,
+                logicalBytes: 38_000_000_000,
+                permissionFailureCount: 0,
+                boundarySkipCount: 0
+            ),
+            customNote: nil
+        )
+
+        let record2 = StagePerformanceRecord(
+            stageName: "Coverage Expansion",
+            durationSeconds: 5.80,
+            metrics: nil,
+            customNote: "185 discovered, 108 roots scanned"
+        )
+
+        let obs = DuplicateScanObservation(
+            path: "/Applications",
+            primaryScanner: "ApplicationsStorageAnalyzer",
+            secondaryScanner: "CoverageExpansionAnalyzer",
+            relationship: "Excluded canonical root"
+        )
+
+        let report = StorageAnalysisPerformanceReport(
+            totalDurationSeconds: 8.60,
+            stageRecords: [record1, record2],
+            duplicateObservations: [obs]
+        )
+
+        let debugString = report.formattedDebugString()
+
+        XCTAssertTrue(debugString.contains("PureMac Storage Analysis Performance"))
+        XCTAssertTrue(debugString.contains("8.60s"))
+        XCTAssertTrue(debugString.contains("Applications"))
+        XCTAssertTrue(debugString.contains("Coverage Expansion"))
+        XCTAssertTrue(debugString.contains("Potential Duplicate / Overlapping Recursive Coverage"))
+        XCTAssertTrue(debugString.contains("/Applications"))
+    }
+
+    func testDuplicateScanAnalysisSurfacesDockerAndFirmlinks() {
+        let node = StorageNode(
+            name: "com.docker.docker",
+            absolutePath: "/Users/test/Library/Containers/com.docker.docker",
+            logicalSize: 100,
+            allocatedSize: 100,
+            ownLogicalSize: 100,
+            ownAllocatedSize: 100,
+            itemType: .directory,
+            children: [],
+            accessibility: .accessible,
+            scanIssues: [],
+            isHidden: false,
+            isSymbolicLink: false,
+            isCountedInParentTotals: true,
+            metadata: StorageAnalysisMetadata()
+        )
+
+        let dockerResult = StorageAnalysisResult(
+            root: node,
+            startedAt: Date(),
+            completedAt: Date(),
+            rootDeviceIdentifier: 1,
+            wasCancelled: false,
+            issues: []
+        )
+
+        let dockerReport = DockerStorageReport(
+            hostFootprint: DockerHostFootprint(locations: [dockerResult], logicalSize: 100, allocatedSize: 100),
+            virtualDisks: [],
+            runtimeStatus: .notInstalled,
+            runtimeAccounting: nil,
+            dockerExecutablePath: nil,
+            runtimeContext: DockerRuntimeContext(name: "test", sanitizedEndpoint: "unix:///test", location: .local),
+            hostRuntimeRelationship: .localRuntimeMayExplainHostFootprint,
+            accountingRelationship: .runtimeBreakdownIsNonAdditiveToHostFootprint,
+            wasCancelled: false,
+            issues: []
+        )
+
+        let results = StorageAnalyzerResults(dockerStorage: dockerReport)
+
+        let duplicates = StorageAnalysisPerformanceDiagnostics.analyzeDuplicates(
+            results: results,
+            expansionReport: nil
+        )
+
+        XCTAssertTrue(duplicates.contains { $0.path.contains("com.docker.docker") })
+        XCTAssertTrue(duplicates.contains { $0.path.contains("/Applications") })
+    }
+
+    func testFindHeaviestSubtrees() {
+        var files: [StorageNode] = []
+        for i in 0..<150 {
+            files.append(StorageNode(
+                name: "file\(i).js",
+                absolutePath: "/Users/test/Projects/my_app/node_modules/pkg/file\(i).js",
+                logicalSize: 100,
+                allocatedSize: 100,
+                ownLogicalSize: 100,
+                ownAllocatedSize: 100,
+                itemType: .regularFile,
+                children: [],
+                accessibility: .accessible,
+                scanIssues: [],
+                isHidden: false,
+                isSymbolicLink: false,
+                isCountedInParentTotals: true,
+                metadata: StorageAnalysisMetadata()
+            ))
+        }
+
+        let nodeModules = StorageNode(
+            name: "node_modules",
+            absolutePath: "/Users/test/Projects/my_app/node_modules",
+            logicalSize: 15000,
+            allocatedSize: 15000,
+            ownLogicalSize: 0,
+            ownAllocatedSize: 0,
+            itemType: .directory,
+            children: files,
+            accessibility: .accessible,
+            scanIssues: [],
+            isHidden: false,
+            isSymbolicLink: false,
+            isCountedInParentTotals: true,
+            metadata: StorageAnalysisMetadata()
+        )
+
+        let root = StorageNode(
+            name: "Projects",
+            absolutePath: "/Users/test/Projects",
+            logicalSize: 15000,
+            allocatedSize: 15000,
+            ownLogicalSize: 0,
+            ownAllocatedSize: 0,
+            itemType: .directory,
+            children: [nodeModules],
+            accessibility: .accessible,
+            scanIssues: [],
+            isHidden: false,
+            isSymbolicLink: false,
+            isCountedInParentTotals: true,
+            metadata: StorageAnalysisMetadata()
+        )
+
+        let heaviest = StorageAnalysisPerformanceDiagnostics.findHeaviestSubtrees(from: [root], limit: 5)
+        XCTAssertEqual(heaviest.count, 1)
+        XCTAssertEqual(heaviest.first?.path, "/Users/test/Projects/my_app/node_modules")
+        XCTAssertEqual(heaviest.first?.totalEntries, 151)
+    }
+
+    func testFormattedDebugStringWithHeaviestSubtreesAndCacheMetrics() {
+        let subtree1 = SlowestSubtreeRecord(
+            path: "/Applications/Xcode.app",
+            totalEntries: 450_000,
+            directoryCount: 60_000,
+            fileCount: 390_000,
+            allocatedBytes: 40_000_000_000,
+            isPackageOrApp: true
+        )
+        let subtree2 = SlowestSubtreeRecord(
+            path: "/Users/test/node_modules",
+            totalEntries: 120_000,
+            directoryCount: 15_000,
+            fileCount: 105_000,
+            allocatedBytes: 2_000_000_000,
+            isPackageOrApp: false
+        )
+
+        let stageRecord = StagePerformanceRecord(
+            stageName: "Applications",
+            durationSeconds: 317.20,
+            metrics: StorageScanMetrics(
+                totalEntries: 457_636,
+                directoryCount: 64_715,
+                fileCount: 379_567,
+                otherCount: 0,
+                allocatedBytes: 43_000_000_000,
+                logicalBytes: 40_000_000_000,
+                permissionFailureCount: 0,
+                boundarySkipCount: 0
+            ),
+            customNote: nil
+        )
+
+        let cacheMetrics = StorageAnalysisCacheMetrics(
+            physicalTraversalsCount: 137,
+            cacheHitCount: 14,
+            cacheMissCount: 148,
+            reusedSubtreeCount: 13,
+            avoidedTraversalsCount: 14
+        )
+
+        let report = StorageAnalysisPerformanceReport(
+            totalDurationSeconds: 386.26,
+            stageRecords: [stageRecord],
+            duplicateObservations: [],
+            cacheMetrics: cacheMetrics,
+            heaviestSubtrees: [subtree1, subtree2]
+        )
+
+        let debugString = report.formattedDebugString()
+
+        XCTAssertTrue(debugString.contains("386.26s"))
+        XCTAssertTrue(debugString.contains("Applications"))
+        XCTAssertTrue(debugString.contains("Scan Cache & Subtree Reuse"))
+        XCTAssertTrue(debugString.contains("Physical Traversals:    137"))
+        XCTAssertTrue(debugString.contains("Top High-Density Subtrees & Application Bundles"))
+        XCTAssertTrue(debugString.contains("[App Bundle]"))
+        XCTAssertTrue(debugString.contains("[Directory]"))
+        XCTAssertTrue(debugString.contains("/Applications/Xcode.app"))
+        XCTAssertTrue(debugString.contains("/Users/test/node_modules"))
+    }
+}

--- a/PureMacTests/StorageAttributionAnalyzerTests.swift
+++ b/PureMacTests/StorageAttributionAnalyzerTests.swift
@@ -1,0 +1,363 @@
+import Darwin
+import XCTest
+@testable import PureMac
+
+final class StorageAttributionAnalyzerTests: XCTestCase {
+    private var tempDirectory: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("StorageAttributionTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempDirectory {
+            try? FileManager.default.removeItem(at: tempDirectory)
+        }
+        super.tearDown()
+    }
+
+    // MARK: - 1. Data-volume root classification
+    func testDataVolumeRootClassification() async throws {
+        let fakeDataVolume = tempDirectory.appendingPathComponent("DataVolume")
+        try FileManager.default.createDirectory(at: fakeDataVolume.appendingPathComponent("Users"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: fakeDataVolume.appendingPathComponent("Library"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: fakeDataVolume.appendingPathComponent("private"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: fakeDataVolume.appendingPathComponent(".DocumentRevisions-V100"), withIntermediateDirectories: true)
+
+        let report = makeStubReport(
+            usedBytes: 100_000_000,
+            explainedBytes: 80_000_000,
+            contributions: [
+                makeContribution(path: "/Users", size: 50_000_000, source: .userHomeVisibleStorage),
+                makeContribution(path: "/Library", size: 20_000_000, source: .systemLibrary),
+                makeContribution(path: "/private", size: 10_000_000, source: .privateStorage),
+            ]
+        )
+
+        let analyzer = StorageAttributionAnalyzer(
+            dataVolumeURL: fakeDataVolume,
+            vmDirectoryURL: tempDirectory.appendingPathComponent("fake-vm")
+        )
+        let attribution = await analyzer.analyze(reconciliationReport: report)
+
+        let names = attribution.dataVolumeRoots.map(\.name)
+        XCTAssertTrue(names.contains("Users"))
+        XCTAssertTrue(names.contains("Library"))
+        XCTAssertTrue(names.contains("private"))
+        XCTAssertTrue(names.contains(".DocumentRevisions-V100"))
+
+        let usersRoot = attribution.dataVolumeRoots.first { $0.name == "Users" }
+        XCTAssertEqual(usersRoot?.classification, .ownedByExistingAnalyzer)
+        XCTAssertEqual(usersRoot?.allocatedBytes, 50_000_000)
+
+        let revisionsRoot = attribution.dataVolumeRoots.first { $0.name == ".DocumentRevisions-V100" }
+        XCTAssertTrue(revisionsRoot?.isProtectedSystem == true)
+    }
+
+    // MARK: - 2. Canonical alias normalization
+    func testCanonicalAliasNormalization() async throws {
+        let fakeDataVolume = tempDirectory.appendingPathComponent("DataVolume")
+        try FileManager.default.createDirectory(at: fakeDataVolume.appendingPathComponent("private"), withIntermediateDirectories: true)
+
+        let report = makeStubReport(
+            usedBytes: 100_000_000,
+            explainedBytes: 10_000_000,
+            contributions: [
+                makeContribution(path: "/private", size: 10_000_000, source: .privateStorage)
+            ]
+        )
+
+        let analyzer = StorageAttributionAnalyzer(
+            dataVolumeURL: fakeDataVolume,
+            vmDirectoryURL: tempDirectory.appendingPathComponent("fake-vm")
+        )
+        let attribution = await analyzer.analyze(reconciliationReport: report)
+
+        let privateRoot = attribution.dataVolumeRoots.first { $0.name == "private" }
+        XCTAssertNotNil(privateRoot)
+        XCTAssertEqual(privateRoot?.normalizedPath, "/private")
+        XCTAssertEqual(privateRoot?.allocatedBytes, 10_000_000)
+    }
+
+    // MARK: - 3. Duplicate ownership prevention
+    func testDuplicateOwnershipPrevention() async {
+        let contributionA = StorageFilesystemContribution(
+            source: .privateStorage,
+            absolutePath: "/private",
+            normalizedPath: "/private",
+            observedAllocatedBytes: 5_000_000,
+            accountedAllocatedBytes: 5_000_000,
+            relationship: .canonicalUnique,
+            owningPath: nil
+        )
+        let contributionB = StorageFilesystemContribution(
+            source: .dataVolumeHiddenStorage,
+            absolutePath: "/System/Volumes/Data/private",
+            normalizedPath: "/private",
+            observedAllocatedBytes: 5_000_000,
+            accountedAllocatedBytes: 0,
+            relationship: .excludedDuplicatePath,
+            owningPath: "/private"
+        )
+
+        let report = makeStubReport(
+            usedBytes: 50_000_000,
+            explainedBytes: 5_000_000,
+            contributions: [contributionA, contributionB]
+        )
+
+        let analyzer = StorageAttributionAnalyzer(
+            dataVolumeURL: tempDirectory.appendingPathComponent("DataVolume"),
+            vmDirectoryURL: tempDirectory.appendingPathComponent("fake-vm")
+        )
+        let attribution = await analyzer.analyze(reconciliationReport: report)
+
+        XCTAssertEqual(attribution.explainedAllocatedBytes, 5_000_000)
+        XCTAssertEqual(attribution.unexplainedBytes, 45_000_000)
+    }
+
+    // MARK: - 4. Virtual Memory (Swap & Sleep Image) attribution
+    func testVirtualMemoryAttribution() async throws {
+        let fakeVM = tempDirectory.appendingPathComponent("vm")
+        try FileManager.default.createDirectory(at: fakeVM, withIntermediateDirectories: true)
+
+        let swapURL = fakeVM.appendingPathComponent("swapfile0")
+        try Data(repeating: 0x53, count: 1024 * 1024).write(to: swapURL)
+
+        let sleepURL = fakeVM.appendingPathComponent("sleepimage")
+        try Data(repeating: 0x5A, count: 2 * 1024 * 1024).write(to: sleepURL)
+
+        let report = makeStubReport(
+            usedBytes: 100_000_000,
+            explainedBytes: 50_000_000
+        )
+
+        let analyzer = StorageAttributionAnalyzer(
+            dataVolumeURL: tempDirectory.appendingPathComponent("DataVolume"),
+            vmDirectoryURL: fakeVM
+        )
+        let attribution = await analyzer.analyze(reconciliationReport: report)
+
+        XCTAssertNotNil(attribution.vmFootprintBytes)
+        XCTAssertNotNil(attribution.sleepImageBytes)
+        XCTAssertGreaterThanOrEqual(attribution.vmFootprintBytes ?? 0, 3 * 1024 * 1024)
+
+        let vmItems = attribution.attributionItems.filter { $0.category == .systemManagedStorage }
+        XCTAssertFalse(vmItems.isEmpty)
+        XCTAssertTrue(vmItems.contains { $0.name.contains("Sleep Image") })
+        XCTAssertTrue(vmItems.contains { $0.name.contains("Swap") })
+    }
+
+    // MARK: - 5. APFS Snapshots and Purgeable Estimate remain non-additive
+    func testAPFSSnapshotsAndPurgeableRemainNonAdditive() async {
+        let apfs = makeAPFSReport(used: 100_000_000, purgeable: 15_000_000, snapshotSize: 20_000_000)
+        let report = makeStubReport(
+            usedBytes: 100_000_000,
+            explainedBytes: 40_000_000,
+            purgeableBytes: 15_000_000,
+            apfsReport: apfs
+        )
+
+        let analyzer = StorageAttributionAnalyzer(
+            dataVolumeURL: tempDirectory.appendingPathComponent("DataVolume"),
+            vmDirectoryURL: tempDirectory.appendingPathComponent("fake-vm")
+        )
+        let attribution = await analyzer.analyze(reconciliationReport: report)
+
+        XCTAssertEqual(attribution.explainedAllocatedBytes, 40_000_000)
+        XCTAssertEqual(attribution.unexplainedBytes, 60_000_000)
+        XCTAssertEqual(attribution.snapshotFootprintBytes, 20_000_000)
+        XCTAssertEqual(attribution.purgeableEstimateBytes, 15_000_000)
+
+        let apfsItems = attribution.attributionItems.filter { $0.category == .apfsAndNonAdditive }
+        XCTAssertTrue(apfsItems.allSatisfy { !$0.isFilesystemAdditive })
+        XCTAssertTrue(apfsItems.contains { $0.status == .nonAdditive })
+        XCTAssertTrue(apfsItems.contains { $0.status == .estimate })
+    }
+
+    // MARK: - 6. Protected system path categorization
+    func testProtectedSystemPathCategorization() async {
+        let report = makeStubReport(
+            usedBytes: 100_000_000,
+            explainedBytes: 30_000_000
+        )
+
+        let analyzer = StorageAttributionAnalyzer(
+            dataVolumeURL: tempDirectory.appendingPathComponent("DataVolume"),
+            vmDirectoryURL: tempDirectory.appendingPathComponent("fake-vm")
+        )
+        let attribution = await analyzer.analyze(reconciliationReport: report)
+
+        let protectedItems = attribution.attributionItems.filter { $0.category == .protectedSystemStorage }
+        XCTAssertFalse(protectedItems.isEmpty)
+        XCTAssertTrue(protectedItems.contains { $0.path == "/private/var/audit" })
+        XCTAssertTrue(protectedItems.contains { $0.path == "/System/Volumes/Data/.DocumentRevisions-V100" })
+    }
+
+    // MARK: - 7. Additive byte invariants
+    func testResidualUnattributedCalculation() async {
+        let report = makeStubReport(
+            usedBytes: 200_000_000,
+            explainedBytes: 120_000_000
+        )
+
+        let analyzer = StorageAttributionAnalyzer(
+            dataVolumeURL: tempDirectory.appendingPathComponent("DataVolume"),
+            vmDirectoryURL: tempDirectory.appendingPathComponent("fake-vm")
+        )
+        let attribution = await analyzer.analyze(reconciliationReport: report)
+
+        XCTAssertEqual(attribution.unexplainedBytes, 80_000_000)
+        XCTAssertEqual(attribution.residualUnattributedBytes, 80_000_000)
+
+        let residualItem = attribution.attributionItems.first { $0.category == .stillUnattributed }
+        XCTAssertNotNil(residualItem)
+        XCTAssertEqual(residualItem?.allocatedBytes, 80_000_000)
+        XCTAssertEqual(residualItem?.status, .unknown)
+    }
+
+    // MARK: - 8. Symlink exclusion in data volume root
+    func testSymlinkRootsAreIntentionallyExcluded() async throws {
+        let fakeDataVolume = tempDirectory.appendingPathComponent("DataVolume")
+        let targetDir = tempDirectory.appendingPathComponent("Target")
+        try FileManager.default.createDirectory(at: fakeDataVolume, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: targetDir, withIntermediateDirectories: true)
+
+        let symlinkPath = fakeDataVolume.appendingPathComponent("LinkedDir").path
+        symlink(targetDir.path, symlinkPath)
+
+        let report = makeStubReport(usedBytes: 50_000_000, explainedBytes: 10_000_000)
+        let analyzer = StorageAttributionAnalyzer(
+            dataVolumeURL: fakeDataVolume,
+            vmDirectoryURL: tempDirectory.appendingPathComponent("fake-vm")
+        )
+        let attribution = await analyzer.analyze(reconciliationReport: report)
+
+        let linked = attribution.dataVolumeRoots.first { $0.name == "LinkedDir" }
+        XCTAssertNotNil(linked)
+        XCTAssertEqual(linked?.classification, .intentionallyExcluded)
+        XCTAssertFalse(linked?.isFilesystemAdditive == true)
+    }
+
+    // MARK: - 9. Cancellation handling
+    func testAttributionHandlesCancellation() async {
+        let task = Task {
+            let analyzer = StorageAttributionAnalyzer(
+                dataVolumeURL: tempDirectory.appendingPathComponent("DataVolume"),
+                vmDirectoryURL: tempDirectory.appendingPathComponent("fake-vm")
+            )
+            let report = makeStubReport(usedBytes: 100_000_000, explainedBytes: 50_000_000, wasCancelled: true)
+            return await analyzer.analyze(reconciliationReport: report)
+        }
+        task.cancel()
+        let attribution = await task.value
+        XCTAssertTrue(attribution.wasCancelled || attribution.dataVolumeRoots.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func makeContribution(
+        path: String,
+        size: Int64,
+        source: StorageAccountingSource
+    ) -> StorageFilesystemContribution {
+        StorageFilesystemContribution(
+            source: source,
+            absolutePath: path,
+            normalizedPath: StoragePathNormalizer.normalize(path),
+            observedAllocatedBytes: size,
+            accountedAllocatedBytes: size,
+            relationship: .canonicalUnique,
+            owningPath: nil
+        )
+    }
+
+    private func makeStubReport(
+        usedBytes: Int64,
+        explainedBytes: Int64,
+        purgeableBytes: Int64? = nil,
+        contributions: [StorageFilesystemContribution] = [],
+        apfsReport: APFSStorageReport? = nil,
+        wasCancelled: Bool = false
+    ) -> StorageReconciliationReport {
+        let apfs = apfsReport ?? makeAPFSReport(used: usedBytes, purgeable: purgeableBytes ?? 0)
+        var results = StorageAnalyzerResults()
+        results.apfsStorage = apfs
+
+        return StorageReconciliationReport(
+            totalCapacityBytes: usedBytes + 100_000_000,
+            usedCapacityBytes: usedBytes,
+            availableCapacityBytes: 100_000_000,
+            purgeableEstimateBytes: purgeableBytes,
+            explainedAllocatedBytes: explainedBytes,
+            unexplainedBytes: max(usedBytes - explainedBytes, 0),
+            inaccessibleKnownLowerBoundBytes: 0,
+            unreadablePathCount: 0,
+            incompleteCoverage: true,
+            coverageStatus: .completeForConfiguredRoots,
+            canonicalRootCoverage: [],
+            filesystemContributions: contributions,
+            hardLinkAccountingStatus: .deduplicatedWithinAnalyzerScopesOnly,
+            analysisIssues: [],
+            analyzerResults: results,
+            coverageDiagnostic: .empty,
+            attributionReport: nil,
+            startedAt: Date(),
+            completedAt: Date(),
+            duration: 0.1,
+            progress: StorageAnalysisProgress(totalStages: 11, completedStages: 11, runningStages: [], state: .completed),
+            wasCancelled: wasCancelled
+        )
+    }
+
+    private func makeAPFSReport(
+        used: Int64,
+        purgeable: Int64 = 0,
+        snapshotSize: Int64? = nil
+    ) -> APFSStorageReport {
+        let snapshot = snapshotSize.map {
+            APFSSnapshotInformation(
+                identifier: "snap-1",
+                name: "com.apple.TimeMachine.snap",
+                uuid: nil,
+                creationDate: Date(),
+                size: $0,
+                sizeKnowledge: .reportedBySystem,
+                type: .timeMachine,
+                source: .diskutil,
+                storageRelationship: .sharedNonAdditive
+            )
+        }
+
+        return APFSStorageReport(
+            volume: APFSVolumeInformation(
+                name: "Data",
+                volumeIdentifier: "disk3s5",
+                volumeUUID: nil,
+                containerIdentifier: nil,
+                volumeGroupIdentifier: nil,
+                filesystemType: "apfs",
+                filesystemKind: .apfs,
+                mountPoint: "/",
+                dataVolumeRelationship: .dataVolume,
+                capacity: APFSVolumeCapacity(
+                    totalCapacity: used + 100_000_000,
+                    availableCapacity: 100_000_000,
+                    usedCapacity: used,
+                    availableCapacityForImportantUsage: 100_000_000,
+                    availableCapacityForOpportunisticUsage: nil,
+                    purgeableEstimate: purgeable,
+                    purgeableEstimateKnowledge: .estimated
+                )
+            ),
+            snapshots: snapshot.map { [$0] } ?? [],
+            state: .complete,
+            accountingRelationship: .volumeMetadataAndSnapshotsAreNonAdditiveToFilesystemTrees,
+            wasCancelled: false,
+            issues: []
+        )
+    }
+}

--- a/PureMacTests/StorageCoverageDiagnosticTests.swift
+++ b/PureMacTests/StorageCoverageDiagnosticTests.swift
@@ -238,9 +238,11 @@ final class StorageCoverageDiagnosticTests: XCTestCase {
 
     func testDiagnosticsNeverFabricateInaccessibleByteCounts() {
         let value = diagnostic(applicationIssues: [issue("/private/unknown-size", .unreadable)])
-        let labels = Mirror(reflecting: value.coverageGaps[0]).children.compactMap(\.label)
+        let gap = value.coverageGaps[0]
 
-        XCTAssertFalse(labels.contains(where: { $0.lowercased().contains("byte") || $0.lowercased().contains("size") }))
+        XCTAssertNil(gap.allocatedBytes)
+        XCTAssertNil(gap.logicalBytes)
+        XCTAssertEqual(gap.confidence, .knownLowerBound)
     }
 
     func testPartialAnalyzerResultIsKnownLowerBound() {

--- a/PureMacTests/StorageCoverageDiagnosticTests.swift
+++ b/PureMacTests/StorageCoverageDiagnosticTests.swift
@@ -1,0 +1,635 @@
+import Darwin
+import XCTest
+@testable import PureMac
+
+final class StorageCoverageDiagnosticTests: XCTestCase {
+    func testPermissionDeniedAggregation() {
+        let issues = [
+            issue("/private/a", .permissionDenied, EACCES),
+            issue("/private/b", .permissionDenied, EPERM),
+        ]
+        let value = diagnostic(applicationIssues: issues)
+
+        XCTAssertEqual(value.permissionDeniedIssueCount, 2)
+        XCTAssertEqual(categoryCount(.permissionDenied, in: value), 2)
+    }
+
+    func testEACCESClassification() {
+        XCTAssertEqual(
+            StorageCoverageDiagnosticBuilder.category(for: issue("/a", .unreadable, EACCES)),
+            .permissionDenied
+        )
+    }
+
+    func testEPERMClassification() {
+        XCTAssertEqual(
+            StorageCoverageDiagnosticBuilder.category(for: issue("/a", .metadataUnavailable, EPERM)),
+            .permissionDenied
+        )
+    }
+
+    func testENOENTIsNotPermissionDenied() {
+        let value = diagnostic(applicationIssues: [
+            issue("/gone", .metadataUnavailable, ENOENT),
+        ])
+
+        XCTAssertEqual(value.permissionDeniedIssueCount, 0)
+        XCTAssertEqual(categoryCount(.concurrentFilesystemChange, in: value), 1)
+    }
+
+    func testDifferentVolumeClassification() {
+        let value = diagnostic(applicationIssues: [issue("/mounted", .differentVolume)])
+
+        XCTAssertEqual(categoryCount(.differentVolumeBoundary, in: value), 1)
+    }
+
+    func testCancellationClassification() {
+        let value = diagnostic(
+            applicationIssues: [issue("/cancelled", .cancelled)],
+            wasCancelled: true
+        )
+
+        XCTAssertEqual(categoryCount(.cancelled, in: value), 1)
+    }
+
+    func testFailedAnalyzerClassification() {
+        let value = diagnostic(analysisIssues: [
+            StorageReconciliationIssue(
+                kind: .analyzerFailure,
+                stage: .containers,
+                path: nil,
+                message: "Synthetic failure"
+            ),
+        ])
+
+        XCTAssertEqual(categoryCount(.failedAnalyzer, in: value), 1)
+    }
+
+    func testMissingOptionalRootClassification() {
+        let value = diagnostic(coverage: [
+            Self.coverage(.opt, "/opt", .missingOptional),
+        ])
+
+        XCTAssertEqual(categoryCount(.missingOptionalRoot, in: value), 1)
+        XCTAssertTrue(value.coverageGaps.contains { $0.category == .missingOptionalRoot })
+    }
+
+    func testUnknownIssueFallback() {
+        let value = diagnostic(analysisIssues: [
+            StorageReconciliationIssue(
+                kind: .analyzerIssue,
+                stage: .containers,
+                path: "/unknown",
+                message: "No structured cause"
+            ),
+        ])
+
+        XCTAssertEqual(categoryCount(.unknown, in: value), 1)
+    }
+
+    func testIssueCountsByAnalyzer() {
+        let value = diagnostic(
+            applicationIssues: [issue("/app/a", .unreadable)],
+            privateIssues: [issue("/private/a", .metadataUnavailable)]
+        )
+
+        XCTAssertEqual(analyzerCount(.applicationSupport, in: value), 1)
+        XCTAssertEqual(analyzerCount(.privateStorage, in: value), 1)
+    }
+
+    func testIssueCountsByErrno() {
+        let value = diagnostic(applicationIssues: [
+            issue("/a", .permissionDenied, EACCES),
+            issue("/b", .permissionDenied, EACCES),
+            issue("/c", .permissionDenied, EPERM),
+        ])
+
+        XCTAssertEqual(value.measurementIssues.errnoCounts.first { $0.errorCode == EACCES }?.count, 2)
+        XCTAssertEqual(value.measurementIssues.errnoCounts.first { $0.errorCode == EPERM }?.count, 1)
+    }
+
+    func testParentPathAggregation() {
+        let value = diagnostic(applicationIssues: [
+            issue("/private/db/a", .unreadable),
+            issue("/private/db/b", .unreadable),
+            issue("/private/other/c", .unreadable),
+        ])
+
+        XCTAssertEqual(value.measurementIssues.topAffectedParentPaths.first?.parentPath, "/private/db")
+        XCTAssertEqual(value.measurementIssues.topAffectedParentPaths.first?.count, 2)
+    }
+
+    func testRepresentativePathLimiting() {
+        let issues = (0..<12).map { issue("/root/item\($0)", .unreadable) }
+        let value = diagnostic(applicationIssues: issues, representativePathLimit: 3)
+
+        XCTAssertEqual(value.measurementIssues.groups.first?.count, 12)
+        XCTAssertEqual(value.measurementIssues.groups.first?.representativePaths.count, 3)
+    }
+
+    @MainActor
+    func testFullDiskAccessGrantedWithoutPermissionErrorsDoesNotRecommendFDA() async {
+        let state = StorageIntelligenceState(analysisRunner: { _ in
+            Self.report(diagnostic: .empty)
+        })
+        state.analyze()
+        await state.waitForAnalysis()
+
+        XCTAssertNil(state.permissionGuidance(fullDiskAccessGranted: true))
+    }
+
+    @MainActor
+    func testFullDiskAccessGrantedWithPermissionErrorsExposesEvidenceBasedGuidance() async {
+        let value = diagnostic(applicationIssues: [issue("/private/denied", .permissionDenied, EACCES)])
+        let state = StorageIntelligenceState(analysisRunner: { _ in Self.report(diagnostic: value) })
+        state.analyze()
+        await state.waitForAnalysis()
+
+        XCTAssertEqual(
+            state.permissionGuidance(fullDiskAccessGranted: true)?.kind,
+            .permissionDenialsRemainWithFullDiskAccess
+        )
+    }
+
+    func testHiddenHomeCoverageGapDetection() throws {
+        let home = try makeHomeFixture()
+        try FileManager.default.createDirectory(
+            at: home.appendingPathComponent(".cache"),
+            withIntermediateDirectories: false
+        )
+
+        let result = StorageCoverageGapDiscovery.discoverSynchronously(homeDirectoryURL: home)
+
+        XCTAssertEqual(result.hiddenHomeEntries.map(\.name), [".cache"])
+        XCTAssertTrue(result.hiddenHomeEntries.allSatisfy { $0.confidence == .unmeasured })
+    }
+
+    func testUnspecializedLibraryCoverageGapDetection() throws {
+        let home = try makeHomeFixture()
+        let library = home.appendingPathComponent("Library")
+        for name in ["Caches", "Mail", "Messages"] {
+            try FileManager.default.createDirectory(
+                at: library.appendingPathComponent(name),
+                withIntermediateDirectories: false
+            )
+        }
+
+        let result = StorageCoverageGapDiscovery.discoverSynchronously(homeDirectoryURL: home)
+
+        XCTAssertEqual(result.unspecializedLibraryEntries.map(\.name), ["Caches", "Mail", "Messages"])
+    }
+
+    func testSpecializedLibraryRootsAreNotReportedAsUncovered() throws {
+        let home = try makeHomeFixture()
+        let library = home.appendingPathComponent("Library")
+        for name in ["Application Support", "Containers", "Group Containers"] {
+            try FileManager.default.createDirectory(
+                at: library.appendingPathComponent(name),
+                withIntermediateDirectories: false
+            )
+        }
+
+        let result = StorageCoverageGapDiscovery.discoverSynchronously(homeDirectoryURL: home)
+
+        XCTAssertTrue(result.unspecializedLibraryEntries.isEmpty)
+    }
+
+    func testAPFSSnapshotsRemainNonAdditive() {
+        let value = diagnostic(apfs: apfsReport(purgeable: nil, snapshotSize: 500))
+
+        XCTAssertTrue(value.coverageMap.contains {
+            $0.state == .nonAdditive && $0.confidence == .nonAdditiveMetadata
+        })
+        XCTAssertTrue(value.unexplainedSpaceExplanations.contains {
+            $0.category == .nonAdditiveAPFSStorage
+        })
+    }
+
+    func testPurgeableRemainsNonAdditive() {
+        let value = diagnostic(apfs: apfsReport(purgeable: 250), purgeable: 250)
+
+        XCTAssertTrue(value.unexplainedSpaceExplanations.contains {
+            $0.title == "Purgeable capacity is an estimate"
+        })
+        XCTAssertFalse(value.coverageMap.contains { $0.identifier.contains("purgeable:250") })
+    }
+
+    @MainActor
+    func testExplainedBytesAreUnchangedByDiagnosticPreparation() async {
+        let original: Int64 = 118_520
+        let report = Self.report(explained: original, diagnostic: diagnostic())
+        let state = StorageIntelligenceState(analysisRunner: { _ in report })
+        state.analyze()
+        await state.waitForAnalysis()
+
+        XCTAssertEqual(state.summary?.explainedAllocatedBytes, original)
+    }
+
+    @MainActor
+    func testUnexplainedBytesAreUnchangedByDiagnosticPreparation() async {
+        let original: Int64 = 98_240
+        let report = Self.report(unexplained: original, diagnostic: diagnostic())
+        let state = StorageIntelligenceState(analysisRunner: { _ in report })
+        state.analyze()
+        await state.waitForAnalysis()
+
+        XCTAssertEqual(state.summary?.unexplainedBytes, original)
+    }
+
+    func testDiagnosticsNeverFabricateInaccessibleByteCounts() {
+        let value = diagnostic(applicationIssues: [issue("/private/unknown-size", .unreadable)])
+        let labels = Mirror(reflecting: value.coverageGaps[0]).children.compactMap(\.label)
+
+        XCTAssertFalse(labels.contains(where: { $0.lowercased().contains("byte") || $0.lowercased().contains("size") }))
+    }
+
+    func testPartialAnalyzerResultIsKnownLowerBound() {
+        let value = diagnostic(coverage: [
+            Self.coverage(.applicationSupport, "/Users/test/Library/Application Support", .partiallyCompleted),
+        ])
+
+        XCTAssertEqual(
+            value.analyzerStatuses.first { $0.analyzer == .applicationSupport }?.confidence,
+            .knownLowerBound
+        )
+    }
+
+    func testCompleteAnalyzerResultIsComplete() {
+        let value = diagnostic(coverage: [
+            Self.coverage(.applicationSupport, "/Users/test/Library/Application Support", .completed),
+        ])
+
+        XCTAssertEqual(
+            value.analyzerStatuses.first { $0.analyzer == .applicationSupport }?.confidence,
+            .completeMeasurement
+        )
+    }
+
+    func testCancellationProducesPartialDiagnosticResults() {
+        let value = diagnostic(
+            applicationIssues: [issue("/measured/before-cancel", .unreadable)],
+            wasCancelled: true
+        )
+
+        XCTAssertEqual(categoryCount(.inaccessible, in: value), 1)
+        XCTAssertEqual(categoryCount(.cancelled, in: value), 1)
+        XCTAssertEqual(value.explainedStorageConfidence, .knownLowerBound)
+    }
+
+    func testDiagnosticPreparationDoesNotMutateAnalyzerResults() {
+        let before = analyzerResults(applicationIssues: [issue("/a", .unreadable)])
+        _ = StorageCoverageDiagnosticBuilder().build(
+            analyzerResults: before,
+            canonicalRootCoverage: Self.defaultCoverage,
+            filesystemContributions: [],
+            analysisIssues: [],
+            discovery: .empty(homeDirectoryPath: "/Users/test"),
+            unexplainedBytes: 10,
+            purgeableEstimateBytes: nil,
+            incompleteCoverage: true,
+            wasCancelled: false
+        )
+
+        XCTAssertEqual(before, analyzerResults(applicationIssues: [issue("/a", .unreadable)]))
+    }
+
+    @MainActor
+    func testNoCleanupActionIsExposed() {
+        let actions = StorageIntelligenceState().availableActions.map(\.rawValue)
+
+        XCTAssertFalse(actions.contains(where: {
+            $0.localizedCaseInsensitiveContains("clean")
+                || $0.localizedCaseInsensitiveContains("delete")
+                || $0.localizedCaseInsensitiveContains("trash")
+        }))
+    }
+
+    func testLargeIssueCollectionsAggregateCorrectly() {
+        let issues = (0..<1_000).map { issue("/large/entry-\($0)", .unreadable) }
+        let value = diagnostic(applicationIssues: issues)
+
+        XCTAssertEqual(value.measurementIssues.totalIssueCount, 1_000)
+        XCTAssertEqual(categoryCount(.inaccessible, in: value), 1_000)
+        XCTAssertLessThanOrEqual(value.measurementIssues.groups.first?.representativePaths.count ?? 0, 5)
+    }
+
+    @MainActor
+    func testStateHandlesZeroIssues() async {
+        let state = StorageIntelligenceState(analysisRunner: { _ in Self.report(diagnostic: .empty) })
+        state.analyze()
+        await state.waitForAnalysis()
+
+        XCTAssertEqual(state.coverage?.measurementIssueCount, 0)
+        XCTAssertEqual(state.lifecycle, .completed)
+    }
+
+    @MainActor
+    func testStateHandlesHundredsOfIssues() async {
+        let issues = (0..<401).map { issue("/realistic/entry-\($0)", .unreadable) }
+        let value = diagnostic(applicationIssues: issues)
+        let state = StorageIntelligenceState(analysisRunner: { _ in Self.report(diagnostic: value) })
+        state.analyze()
+        await state.waitForAnalysis()
+
+        XCTAssertEqual(state.coverage?.measurementIssueCount, 401)
+        XCTAssertEqual(state.coverageDiagnostic?.measurementIssues.groups.count, 1)
+    }
+
+    @MainActor
+    func testSearchAndDiagnosticDrillDownDoNotTriggerRescanning() async {
+        let counter = CallCounter()
+        let value = diagnostic()
+        let state = StorageIntelligenceState(analysisRunner: { _ in
+            await counter.increment()
+            return Self.report(diagnostic: value)
+        })
+        state.analyze()
+        await state.waitForAnalysis()
+        state.showDiagnostics()
+        state.updateSearch("cache")
+        await state.waitForSearch()
+
+        let callCount = await counter.value
+        XCTAssertEqual(callCount, 1)
+        XCTAssertTrue(state.isShowingDiagnostics)
+    }
+
+    func testDiagnosticOrderingIsDeterministic() {
+        let issues = [
+            issue("/z", .unreadable),
+            issue("/a", .metadataUnavailable),
+            issue("/m", .permissionDenied, EACCES),
+        ]
+
+        XCTAssertEqual(
+            diagnostic(applicationIssues: issues),
+            diagnostic(applicationIssues: Array(issues.reversed()))
+        )
+    }
+
+    func testDuplicateIssuePathsAreAggregatedSafely() {
+        let duplicate = issue("/same/path", .permissionDenied, EACCES)
+        let value = diagnostic(applicationIssues: [duplicate, duplicate, duplicate])
+
+        XCTAssertEqual(value.measurementIssues.totalIssueCount, 1)
+        XCTAssertEqual(value.permissionDeniedIssueCount, 1)
+    }
+
+    @MainActor
+    func testExistingStorageIntelligencePresentationRemainsCompatible() async {
+        let state = StorageIntelligenceState(analysisRunner: { _ in
+            Self.report(explained: 65, unexplained: 735, diagnostic: .empty)
+        })
+        state.analyze()
+        await state.waitForAnalysis()
+
+        XCTAssertEqual(state.summary?.explainedAllocatedBytes, 65)
+        XCTAssertEqual(state.summary?.unexplainedBytes, 735)
+        XCTAssertTrue(state.availableActions.contains(.analyze))
+        XCTAssertTrue(state.availableActions.contains(.viewDiagnostics))
+    }
+}
+
+private extension StorageCoverageDiagnosticTests {
+    actor CallCounter {
+        private(set) var value = 0
+        func increment() { value += 1 }
+    }
+
+    static let defaultCoverage = [
+        StorageCanonicalRootCoverage(
+            root: .applicationSupport,
+            configuredPath: "/Users/test/Library/Application Support",
+            state: .completed,
+            knownAllocatedBytes: 10,
+            unreadablePathCount: 0
+        ),
+    ]
+
+    func issue(
+        _ path: String,
+        _ kind: StorageScanIssueKind,
+        _ errorCode: Int32? = nil
+    ) -> StorageScanIssue {
+        StorageScanIssue(
+            path: path,
+            kind: kind,
+            message: "Synthetic \(kind.rawValue)",
+            posixErrorCode: errorCode
+        )
+    }
+
+    static func coverage(
+        _ root: StorageCanonicalRoot,
+        _ path: String,
+        _ state: StorageCanonicalRootState
+    ) -> StorageCanonicalRootCoverage {
+        StorageCanonicalRootCoverage(
+            root: root,
+            configuredPath: path,
+            state: state,
+            knownAllocatedBytes: state == .missingOptional ? 0 : 10,
+            unreadablePathCount: state == .partiallyCompleted ? 1 : 0
+        )
+    }
+
+    func diagnostic(
+        applicationIssues: [StorageScanIssue] = [],
+        privateIssues: [StorageScanIssue] = [],
+        coverage: [StorageCanonicalRootCoverage]? = nil,
+        analysisIssues: [StorageReconciliationIssue] = [],
+        apfs: APFSStorageReport? = nil,
+        purgeable: Int64? = nil,
+        wasCancelled: Bool = false,
+        representativePathLimit: Int = 5
+    ) -> StorageCoverageDiagnostic {
+        StorageCoverageDiagnosticBuilder(
+            representativePathLimit: representativePathLimit
+        ).build(
+            analyzerResults: analyzerResults(
+                applicationIssues: applicationIssues,
+                privateIssues: privateIssues,
+                apfs: apfs
+            ),
+            canonicalRootCoverage: coverage ?? Self.defaultCoverage,
+            filesystemContributions: [],
+            analysisIssues: analysisIssues,
+            discovery: .empty(homeDirectoryPath: "/Users/test"),
+            unexplainedBytes: 100,
+            purgeableEstimateBytes: purgeable,
+            incompleteCoverage: true,
+            wasCancelled: wasCancelled
+        )
+    }
+
+    func analyzerResults(
+        applicationIssues: [StorageScanIssue] = [],
+        privateIssues: [StorageScanIssue] = [],
+        apfs: APFSStorageReport? = nil
+    ) -> StorageAnalyzerResults {
+        StorageAnalyzerResults(
+            userHomeStorage: nil,
+            applicationSupport: result(
+                path: "/Users/test/Library/Application Support",
+                issues: applicationIssues
+            ),
+            containers: nil,
+            groupContainers: nil,
+            systemLibrary: nil,
+            privateStorage: privateIssues.isEmpty ? nil : result(path: "/private", issues: privateIssues),
+            dataVolumeHiddenStorage: nil,
+            developerSystemStorage: nil,
+            dockerStorage: nil,
+            apfsStorage: apfs
+        )
+    }
+
+    func result(path: String, issues: [StorageScanIssue]) -> StorageAnalysisResult {
+        let accessibility: StorageAccessibility = issues.isEmpty ? .accessible : .partiallyAccessible
+        let node = StorageNode(
+            name: URL(fileURLWithPath: path).lastPathComponent,
+            absolutePath: path,
+            logicalSize: 10,
+            allocatedSize: 10,
+            ownLogicalSize: 0,
+            ownAllocatedSize: 0,
+            itemType: .directory,
+            children: [],
+            accessibility: accessibility,
+            scanIssues: issues,
+            isHidden: false,
+            isSymbolicLink: false,
+            isCountedInParentTotals: true,
+            metadata: StorageAnalysisMetadata()
+        )
+        return StorageAnalysisResult(
+            root: node,
+            startedAt: Date(timeIntervalSince1970: 1),
+            completedAt: Date(timeIntervalSince1970: 2),
+            rootDeviceIdentifier: 1,
+            wasCancelled: issues.contains { $0.kind == .cancelled },
+            issues: issues
+        )
+    }
+
+    func apfsReport(
+        purgeable: Int64?,
+        snapshotSize: Int64? = nil
+    ) -> APFSStorageReport {
+        let snapshot = APFSSnapshotInformation(
+            identifier: "snapshot",
+            name: "com.apple.TimeMachine.2026-01-01-000000.local",
+            uuid: "UUID",
+            creationDate: Date(timeIntervalSince1970: 3),
+            size: snapshotSize,
+            sizeKnowledge: snapshotSize == nil ? .unavailable : .reportedBySystem,
+            type: .timeMachine,
+            source: .diskutil,
+            storageRelationship: snapshotSize == nil ? .sizeUnavailable : .sharedNonAdditive
+        )
+        return APFSStorageReport(
+            volume: APFSVolumeInformation(
+                name: "Data",
+                volumeIdentifier: "disk3s1",
+                volumeUUID: nil,
+                containerIdentifier: nil,
+                volumeGroupIdentifier: nil,
+                filesystemType: "apfs",
+                filesystemKind: .apfs,
+                mountPoint: "/",
+                dataVolumeRelationship: .dataVolume,
+                capacity: APFSVolumeCapacity(
+                    totalCapacity: 1_000,
+                    availableCapacity: 200,
+                    usedCapacity: 800,
+                    availableCapacityForImportantUsage: purgeable.map { 200 + $0 },
+                    availableCapacityForOpportunisticUsage: nil,
+                    purgeableEstimate: purgeable,
+                    purgeableEstimateKnowledge: purgeable == nil ? .unavailable : .estimated
+                )
+            ),
+            snapshots: [snapshot],
+            state: .complete,
+            accountingRelationship: .volumeMetadataAndSnapshotsAreNonAdditiveToFilesystemTrees,
+            wasCancelled: false,
+            issues: []
+        )
+    }
+
+    func categoryCount(
+        _ category: StorageCoverageDiagnosticCategory,
+        in diagnostic: StorageCoverageDiagnostic
+    ) -> Int {
+        diagnostic.measurementIssues.categoryCounts.first { $0.category == category }?.count ?? 0
+    }
+
+    func analyzerCount(
+        _ analyzer: StorageAnalyzerStage,
+        in diagnostic: StorageCoverageDiagnostic
+    ) -> Int {
+        diagnostic.measurementIssues.analyzerCounts.first { $0.analyzer == analyzer }?.count ?? 0
+    }
+
+    func makeHomeFixture() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("StorageCoverageDiagnosticTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("Library"),
+            withIntermediateDirectories: false
+        )
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+
+    static func report(
+        explained: Int64 = 65,
+        unexplained: Int64? = 735,
+        diagnostic: StorageCoverageDiagnostic
+    ) -> StorageReconciliationReport {
+        let now = Date(timeIntervalSince1970: 1)
+        return StorageReconciliationReport(
+            totalCapacityBytes: 1_000,
+            usedCapacityBytes: 800,
+            availableCapacityBytes: 200,
+            purgeableEstimateBytes: 100,
+            explainedAllocatedBytes: explained,
+            unexplainedBytes: unexplained,
+            inaccessibleKnownLowerBoundBytes: 0,
+            unreadablePathCount: diagnostic.measurementIssues.totalIssueCount,
+            incompleteCoverage: true,
+            coverageStatus: diagnostic.permissionDeniedIssueCount > 0
+                ? .partialDueToPermissions
+                : diagnostic.measurementIssues.totalIssueCount > 0
+                    ? .partialDueToMeasurementIssues
+                    : .completeForConfiguredRoots,
+            canonicalRootCoverage: [],
+            filesystemContributions: [],
+            hardLinkAccountingStatus: .deduplicatedWithinAnalyzerScopesOnly,
+            analysisIssues: [],
+            analyzerResults: StorageAnalyzerResults(
+                userHomeStorage: nil,
+                applicationSupport: nil,
+                containers: nil,
+                groupContainers: nil,
+                systemLibrary: nil,
+                privateStorage: nil,
+                dataVolumeHiddenStorage: nil,
+                developerSystemStorage: nil,
+                dockerStorage: nil,
+                apfsStorage: nil
+            ),
+            coverageDiagnostic: diagnostic,
+            startedAt: now,
+            completedAt: now,
+            duration: 0,
+            progress: StorageAnalysisProgress(
+                totalStages: 10,
+                completedStages: 10,
+                runningStages: [],
+                state: .completed
+            ),
+            wasCancelled: false
+        )
+    }
+}

--- a/PureMacTests/StorageIntelligenceStateTests.swift
+++ b/PureMacTests/StorageIntelligenceStateTests.swift
@@ -352,6 +352,89 @@ final class StorageIntelligenceStateTests: XCTestCase {
         XCTAssertFalse(state.isRunning)
         XCTAssertEqual(state.progress?.state, .completed)
     }
+
+    func testSyntheticLargeHierarchyDoesNotEagerlyCreatePresentationObjectsForAllDescendants() async {
+        // Build a synthetic tree with deep nesting (1000 nodes)
+        var leafNodes: [StorageNode] = []
+        for i in 0..<100 {
+            leafNodes.append(Self.node(path: "/Library/Application Support/App/deep/file\(i)", allocated: 100))
+        }
+        let middleNode = Self.node(path: "/Library/Application Support/App/deep", allocated: 10_000, children: leafNodes)
+        let appNode = Self.node(path: "/Library/Application Support/App", allocated: 10_000, children: [middleNode])
+        let rootNode = Self.node(path: "/Library/Application Support", allocated: 10_000, children: [appNode])
+
+        let appSupport = StorageAnalysisResult(
+            root: rootNode,
+            startedAt: Date(),
+            completedAt: Date(),
+            rootDeviceIdentifier: 1,
+            wasCancelled: false,
+            issues: []
+        )
+
+        let report = Self.report(explained: 10_000, applicationSupport: appSupport)
+        let prepared = StorageIntelligenceState.prepare(report: report, sortOrder: .sizeDescending)
+
+        // StorageNode count received should reflect full recursive count (> 100)
+        XCTAssertGreaterThan(prepared.storageNodeCountReceived, 100)
+        // Presentation nodes created upfront should ONLY reflect top-level roots (1 category root)
+        XCTAssertLessThanOrEqual(prepared.presentationNodeCountCreated, 5)
+        // Search index should not be built eagerly at scan completion
+        XCTAssertEqual(prepared.searchIndex.count, 0)
+    }
+
+    func testExpandingNodeMaterializesOnlyImmediateChildren() {
+        let child1 = Self.node(path: "/Users/test/Documents/A", allocated: 200)
+        let child2 = Self.node(path: "/Users/test/Documents/B", allocated: 500)
+        let parent = Self.node(path: "/Users/test/Documents", allocated: 700, children: [child1, child2])
+
+        let state = Self.makeState()
+        let sorted = state.sortedChildren(of: parent)
+
+        XCTAssertEqual(sorted.count, 2)
+        XCTAssertEqual(sorted.first?.name, "B")
+        XCTAssertEqual(sorted.last?.name, "A")
+    }
+
+    func testOnDemandSearchFindsDeepDescendantWithoutEagerIndex() async {
+        let deepLeaf = Self.node(path: "/Library/Application Support/App/deep/nested_target.dat", allocated: 100)
+        let middle = Self.node(path: "/Library/Application Support/App/deep", allocated: 100, children: [deepLeaf])
+        let app = Self.node(path: "/Library/Application Support/App", allocated: 100, children: [middle])
+        let root = Self.node(path: "/Library/Application Support", allocated: 100, children: [app])
+
+        let appSupport = StorageAnalysisResult(
+            root: root,
+            startedAt: Date(),
+            completedAt: Date(),
+            rootDeviceIdentifier: 1,
+            wasCancelled: false,
+            issues: []
+        )
+
+        let report = Self.report(explained: 100, applicationSupport: appSupport)
+        let state = Self.makeState(report: report)
+
+        await Self.analyze(state)
+
+        state.updateSearch("nested_target")
+        await state.waitForSearch()
+
+        XCTAssertEqual(state.searchResults.count, 1)
+        XCTAssertEqual(state.searchResults.first?.node.name, "nested_target.dat")
+        XCTAssertEqual(state.searchResults.first?.node.absolutePath, "/Library/Application Support/App/deep/nested_target.dat")
+    }
+
+    func testSearchCancellationWhenQueryChanges() async {
+        let state = Self.makeState()
+        await Self.analyze(state)
+
+        state.updateSearch("query_one")
+        state.updateSearch("query_two")
+        state.updateSearch("Beta")
+        await state.waitForSearch()
+
+        XCTAssertEqual(state.searchResults.map(\.node.name), ["Beta"])
+    }
 }
 
 // MARK: - Fixtures
@@ -391,14 +474,15 @@ private extension StorageIntelligenceStateTests {
         unreadablePathCount: Int = 0,
         knownLowerBound: Int64 = 0,
         docker: DockerStorageReport? = nil,
-        apfs: APFSStorageReport? = nil
+        apfs: APFSStorageReport? = nil,
+        applicationSupport: StorageAnalysisResult? = nil
     ) -> StorageReconciliationReport {
-        let applicationSupport = applicationSupportResult()
+        let appSupport = applicationSupport ?? applicationSupportResult()
         let contribution = StorageFilesystemContribution(
             source: .applicationSupport,
-            absolutePath: applicationSupport.root.absolutePath,
-            normalizedPath: applicationSupport.root.absolutePath,
-            observedAllocatedBytes: applicationSupport.root.allocatedSize,
+            absolutePath: appSupport.root.absolutePath,
+            normalizedPath: appSupport.root.absolutePath,
+            observedAllocatedBytes: appSupport.root.allocatedSize,
             accountedAllocatedBytes: explained,
             relationship: .canonicalUnique,
             owningPath: nil
@@ -421,7 +505,7 @@ private extension StorageIntelligenceStateTests {
             analysisIssues: [],
             analyzerResults: StorageAnalyzerResults(
                 userHomeStorage: nil,
-                applicationSupport: applicationSupport,
+                applicationSupport: appSupport,
                 containers: nil,
                 groupContainers: nil,
                 systemLibrary: nil,

--- a/PureMacTests/StorageIntelligenceStateTests.swift
+++ b/PureMacTests/StorageIntelligenceStateTests.swift
@@ -1,0 +1,625 @@
+import XCTest
+@testable import PureMac
+
+@MainActor
+final class StorageIntelligenceStateTests: XCTestCase {
+    func testInitialStateIsIdle() {
+        let state = Self.makeState()
+
+        XCTAssertEqual(state.lifecycle, .idle)
+        XCTAssertNil(state.report)
+        XCTAssertTrue(state.canAnalyze)
+        XCTAssertFalse(state.canCancel)
+    }
+
+    func testScanStarts() async {
+        let report = Self.report()
+        let state = StorageIntelligenceState(analysisRunner: { _ in
+            try await Task.sleep(nanoseconds: 500_000_000)
+            return report
+        })
+
+        state.analyze()
+
+        XCTAssertEqual(state.lifecycle, .running)
+        XCTAssertTrue(state.canCancel)
+        state.cancel()
+        await state.waitForAnalysis()
+    }
+
+    func testProgressUpdatesWhileScanRuns() async {
+        let report = Self.report()
+        let update = StorageAnalysisProgress(
+            totalStages: 10,
+            completedStages: 3,
+            runningStages: [.containers],
+            state: .running
+        )
+        let state = StorageIntelligenceState(analysisRunner: { progress in
+            await progress(update)
+            try await Task.sleep(nanoseconds: 500_000_000)
+            return report
+        })
+
+        state.analyze()
+        await Self.waitUntil { state.progress == update }
+
+        XCTAssertEqual(state.progress, update)
+        state.cancel()
+        await state.waitForAnalysis()
+    }
+
+    func testSuccessfulReportCompletes() async {
+        let expected = Self.report()
+        let state = Self.makeState(report: expected)
+
+        state.analyze()
+        await state.waitForAnalysis()
+
+        XCTAssertEqual(state.lifecycle, .completed)
+        XCTAssertEqual(state.report, expected)
+        XCTAssertTrue(state.hasCompletedReport)
+        XCTAssertNil(state.errorMessage)
+    }
+
+    func testPartialReportIsPresentedAsIncompleteCoverage() async {
+        let expected = Self.report(
+            coverage: .partialDueToPermissions,
+            unreadablePathCount: 3,
+            knownLowerBound: 5
+        )
+        let state = Self.makeState(report: expected)
+
+        state.analyze()
+        await state.waitForAnalysis()
+
+        XCTAssertEqual(state.coverage?.status, .partialDueToPermissions)
+        XCTAssertEqual(state.coverage?.unreadablePathCount, 3)
+        XCTAssertEqual(state.coverage?.knownLowerBoundBytes, 5)
+        XCTAssertEqual(state.coverage?.isPartial, true)
+    }
+
+    func testCancellationProducesCancelledState() async {
+        let report = Self.report()
+        let state = StorageIntelligenceState(analysisRunner: { _ in
+            try await Task.sleep(nanoseconds: 500_000_000)
+            return report
+        })
+
+        state.analyze()
+        state.cancel()
+        await state.waitForAnalysis()
+
+        XCTAssertEqual(state.lifecycle, .cancelled)
+        XCTAssertEqual(state.progress?.state, .cancelled)
+        XCTAssertFalse(state.isRunning)
+    }
+
+    func testAnalyzerFailureIsPresented() async {
+        struct ExpectedFailure: LocalizedError {
+            var errorDescription: String? { "Fixture failed" }
+        }
+        let state = StorageIntelligenceState(analysisRunner: { _ in
+            throw ExpectedFailure()
+        })
+
+        state.analyze()
+        await state.waitForAnalysis()
+
+        XCTAssertEqual(state.lifecycle, .failed)
+        XCTAssertTrue(state.errorMessage?.contains("Fixture failed") == true)
+        XCTAssertNil(state.report)
+    }
+
+    func testExplainedAndUnexplainedUseReportAllocatedSemantics() async {
+        let state = Self.makeState(report: Self.report(
+            total: 1_000,
+            used: 800,
+            free: 200,
+            explained: 325,
+            unexplained: 475
+        ))
+
+        state.analyze()
+        await state.waitForAnalysis()
+
+        XCTAssertEqual(state.summary?.explainedAllocatedBytes, 325)
+        XCTAssertEqual(state.summary?.unexplainedBytes, 475)
+        XCTAssertEqual(state.summary?.usedBytes, 800)
+    }
+
+    func testPurgeableEstimateRemainsSeparate() async {
+        let state = Self.makeState(report: Self.report(
+            explained: 65,
+            unexplained: 735,
+            purgeable: 120
+        ))
+
+        state.analyze()
+        await state.waitForAnalysis()
+
+        XCTAssertEqual(state.summary?.purgeableEstimateBytes, 120)
+        XCTAssertEqual(state.summary?.explainedAllocatedBytes, 65)
+        XCTAssertEqual(state.summary?.unexplainedBytes, 735)
+    }
+
+    func testDockerRuntimeDoesNotAlterLocalTotal() async {
+        let docker = Self.dockerReport(runtimeBytes: 50_000, location: .local)
+        let expected = Self.report(explained: 65, docker: docker)
+        let state = Self.makeState(report: expected)
+
+        state.analyze()
+        await state.waitForAnalysis()
+
+        XCTAssertEqual(state.summary?.explainedAllocatedBytes, 65)
+        XCTAssertEqual(state.dockerPresentation?.localFootprintBytes, 15)
+        XCTAssertEqual(state.dockerPresentation?.runtimeReportedBytes, 50_000)
+        XCTAssertEqual(state.dockerPresentation?.runtimeIsNonAdditive, true)
+    }
+
+    func testRemoteDockerRuntimeMessaging() async {
+        let state = Self.makeState(report: Self.report(
+            docker: Self.dockerReport(runtimeBytes: 90_000, location: .remote)
+        ))
+
+        state.analyze()
+        await state.waitForAnalysis()
+
+        XCTAssertEqual(state.dockerPresentation?.runtimeLocation, .remote)
+        XCTAssertEqual(
+            state.dockerPresentation?.relationshipMessage,
+            "Remote Docker context. Runtime storage is not stored on this Mac."
+        )
+    }
+
+    func testAPFSSnapshotWithUnknownSizeStaysUnknown() async {
+        let state = Self.makeState(report: Self.report(apfs: Self.apfsReport(snapshotSize: nil)))
+
+        state.analyze()
+        await state.waitForAnalysis()
+
+        let snapshot = state.apfsPresentation?.snapshots.first
+        XCTAssertNil(snapshot?.sizeBytes)
+        XCTAssertEqual(snapshot?.sizeIsReliable, false)
+        XCTAssertEqual(snapshot?.isNonAdditive, true)
+    }
+
+    func testSortingByAllocatedSizeDescending() async {
+        let state = Self.makeState()
+
+        state.analyze()
+        await state.waitForAnalysis()
+
+        let roots = state.categories.first { $0.id == .applicationSupport }?.roots
+        XCTAssertEqual(roots?.map(\.name), ["rootfs.img", "Beta", "Alpha", "Secret"])
+    }
+
+    func testSortingByName() async {
+        let state = Self.makeState()
+        state.analyze()
+        await state.waitForAnalysis()
+
+        state.updateSortOrder(.name)
+        await state.waitForPresentation()
+
+        let roots = state.categories.first { $0.id == .applicationSupport }?.roots
+        XCTAssertEqual(roots?.map(\.name), ["Alpha", "Beta", "rootfs.img", "Secret"])
+    }
+
+    func testSearchMatchesNodeName() async {
+        let state = Self.makeState()
+        await Self.analyze(state)
+
+        state.updateSearch("rootfs")
+        await state.waitForSearch()
+
+        XCTAssertEqual(state.searchResults.map(\.node.name), ["rootfs.img"])
+    }
+
+    func testSearchMatchesPath() async {
+        let state = Self.makeState()
+        await Self.analyze(state)
+
+        state.updateSearch("/application support/secret")
+        await state.waitForSearch()
+
+        XCTAssertEqual(state.searchResults.map(\.node.name), ["Secret"])
+    }
+
+    func testSearchMatchesOwningApplication() async {
+        let state = Self.makeState()
+        await Self.analyze(state)
+
+        state.updateSearch("verified app")
+        await state.waitForSearch()
+
+        XCTAssertEqual(state.searchResults.map(\.node.name), ["Beta"])
+    }
+
+    func testSearchDoesNotMutateReport() async {
+        let expected = Self.report()
+        let state = Self.makeState(report: expected)
+        await Self.analyze(state)
+
+        state.updateSearch("alpha")
+        await state.waitForSearch()
+        state.updateSearch("beta")
+        await state.waitForSearch()
+
+        XCTAssertEqual(state.report, expected)
+    }
+
+    func testUnusuallyLargeMetadataIsPresented() async {
+        let state = Self.makeState()
+        await Self.analyze(state)
+
+        let prominent = state.categories
+            .first { $0.id == .applicationSupport }?
+            .prominentNode
+        XCTAssertEqual(prominent?.name, "rootfs.img")
+        XCTAssertEqual(prominent?.isUnusuallyLarge, true)
+    }
+
+    func testInaccessibleNodeIsPresentedAsIncomplete() async {
+        let state = Self.makeState()
+        await Self.analyze(state)
+        state.updateSearch("secret")
+        await state.waitForSearch()
+
+        let node = state.searchResults.first?.node
+        XCTAssertEqual(node?.accessibility, .inaccessible)
+        XCTAssertEqual(node?.hasIncompleteMeasurement, true)
+        XCTAssertEqual(node?.issueCount, 1)
+    }
+
+    func testSparseVirtualDiskPreservesLogicalAndAllocatedValues() async {
+        let state = Self.makeState()
+        await Self.analyze(state)
+        state.updateSearch("rootfs")
+        await state.waitForSearch()
+
+        let node = state.searchResults.first?.node
+        XCTAssertEqual(node?.allocatedSize, 30)
+        XCTAssertEqual(node?.logicalSize, 3_000_000)
+        XCTAssertEqual(node?.isVirtualDisk, true)
+        XCTAssertEqual(node?.isSparseVirtualDisk, true)
+        XCTAssertEqual(node?.hasMaterialLogicalDifference, true)
+    }
+
+    func testRevealInFinderEligibilityUsesPathExistence() {
+        let node = StorageNodePresentation(node: Self.node(path: "/exists", allocated: 1))
+        let existing = StorageIntelligenceState(
+            analysisRunner: { _ in Self.report() },
+            pathExists: { $0 == "/exists" }
+        )
+        let missing = StorageIntelligenceState(
+            analysisRunner: { _ in Self.report() },
+            pathExists: { _ in false }
+        )
+
+        XCTAssertTrue(existing.canRevealInFinder(node))
+        XCTAssertFalse(missing.canRevealInFinder(node))
+    }
+
+    func testStateExposesNoCleanupAction() {
+        let state = Self.makeState()
+
+        XCTAssertEqual(state.availableActions, [
+            .analyze,
+            .cancel,
+            .search,
+            .sort,
+            .navigate,
+            .revealInFinder,
+            .permissionGuidance,
+            .viewDiagnostics,
+        ])
+    }
+
+    func testRescanReplacesPriorReport() async {
+        let first = Self.report(used: 700, explained: 65, unexplained: 635)
+        let second = Self.report(used: 900, explained: 165, unexplained: 735)
+        let sequence = ReportSequence([first, second])
+        let state = StorageIntelligenceState(analysisRunner: { _ in
+            await sequence.next()
+        })
+
+        await Self.analyze(state)
+        XCTAssertEqual(state.summary?.usedBytes, 700)
+        await Self.analyze(state)
+
+        XCTAssertEqual(state.report, second)
+        XCTAssertEqual(state.summary?.usedBytes, 900)
+        XCTAssertEqual(state.summary?.explainedAllocatedBytes, 165)
+    }
+
+    func testCancellationDoesNotRetainStaleRunningState() async {
+        let report = Self.report()
+        let state = StorageIntelligenceState(analysisRunner: { _ in
+            do {
+                try await Task.sleep(nanoseconds: 500_000_000)
+            } catch {
+                // Simulate a dependency that returns a partial report after cancellation.
+            }
+            return report
+        })
+
+        state.analyze()
+        state.cancel()
+        await state.waitForAnalysis()
+
+        XCTAssertEqual(state.lifecycle, .cancelled)
+        XCTAssertFalse(state.isRunning)
+        XCTAssertEqual(state.progress?.state, .completed)
+    }
+}
+
+// MARK: - Fixtures
+
+private extension StorageIntelligenceStateTests {
+    static func makeState() -> StorageIntelligenceState {
+        Self.makeState(report: Self.report())
+    }
+
+    static func makeState(
+        report: StorageReconciliationReport
+    ) -> StorageIntelligenceState {
+        StorageIntelligenceState(analysisRunner: { _ in report })
+    }
+
+    static func analyze(_ state: StorageIntelligenceState) async {
+        state.analyze()
+        await state.waitForAnalysis()
+    }
+
+    static func waitUntil(
+        _ condition: @MainActor () -> Bool
+    ) async {
+        for _ in 0..<100 where !condition() {
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+    }
+
+    nonisolated static func report(
+        total: Int64 = 1_000,
+        used: Int64 = 800,
+        free: Int64 = 200,
+        explained: Int64 = 65,
+        unexplained: Int64? = 735,
+        purgeable: Int64? = 100,
+        coverage: StorageCoverageStatus = .completeForConfiguredRoots,
+        unreadablePathCount: Int = 0,
+        knownLowerBound: Int64 = 0,
+        docker: DockerStorageReport? = nil,
+        apfs: APFSStorageReport? = nil
+    ) -> StorageReconciliationReport {
+        let applicationSupport = applicationSupportResult()
+        let contribution = StorageFilesystemContribution(
+            source: .applicationSupport,
+            absolutePath: applicationSupport.root.absolutePath,
+            normalizedPath: applicationSupport.root.absolutePath,
+            observedAllocatedBytes: applicationSupport.root.allocatedSize,
+            accountedAllocatedBytes: explained,
+            relationship: .canonicalUnique,
+            owningPath: nil
+        )
+        let now = Date(timeIntervalSince1970: 1)
+        return StorageReconciliationReport(
+            totalCapacityBytes: total,
+            usedCapacityBytes: used,
+            availableCapacityBytes: free,
+            purgeableEstimateBytes: purgeable,
+            explainedAllocatedBytes: explained,
+            unexplainedBytes: unexplained,
+            inaccessibleKnownLowerBoundBytes: knownLowerBound,
+            unreadablePathCount: unreadablePathCount,
+            incompleteCoverage: coverage != .completeForConfiguredRoots,
+            coverageStatus: coverage,
+            canonicalRootCoverage: [],
+            filesystemContributions: [contribution],
+            hardLinkAccountingStatus: .deduplicatedWithinAnalyzerScopesOnly,
+            analysisIssues: [],
+            analyzerResults: StorageAnalyzerResults(
+                userHomeStorage: nil,
+                applicationSupport: applicationSupport,
+                containers: nil,
+                groupContainers: nil,
+                systemLibrary: nil,
+                privateStorage: nil,
+                dataVolumeHiddenStorage: nil,
+                developerSystemStorage: nil,
+                dockerStorage: docker,
+                apfsStorage: apfs
+            ),
+            coverageDiagnostic: .empty,
+            startedAt: now,
+            completedAt: now,
+            duration: 0,
+            progress: StorageAnalysisProgress(
+                totalStages: 10,
+                completedStages: 10,
+                runningStages: [],
+                state: .completed
+            ),
+            wasCancelled: false
+        )
+    }
+
+    nonisolated static func applicationSupportResult() -> StorageAnalysisResult {
+        let issue = StorageScanIssue(
+            path: "/Users/test/Library/Application Support/Secret",
+            kind: .permissionDenied,
+            message: "Permission denied.",
+            posixErrorCode: EACCES
+        )
+        let children = [
+            node(path: "/Users/test/Library/Application Support/Alpha", allocated: 10),
+            node(
+                path: "/Users/test/Library/Application Support/Beta",
+                allocated: 20,
+                metadata: StorageAnalysisMetadata(owningApplicationName: "Verified App")
+            ),
+            node(
+                path: "/Users/test/Library/Application Support/rootfs.img",
+                logical: 3_000_000,
+                allocated: 30,
+                itemType: .regularFile,
+                metadata: StorageAnalysisMetadata(isUnusuallyLarge: true)
+            ),
+            node(
+                path: issue.path,
+                allocated: 5,
+                accessibility: .inaccessible,
+                issues: [issue]
+            ),
+        ]
+        let root = node(
+            path: "/Users/test/Library/Application Support",
+            logical: 3_000_035,
+            allocated: 65,
+            children: children
+        )
+        let now = Date(timeIntervalSince1970: 1)
+        return StorageAnalysisResult(
+            root: root,
+            startedAt: now,
+            completedAt: now,
+            rootDeviceIdentifier: 1,
+            wasCancelled: false,
+            issues: [issue]
+        )
+    }
+
+    nonisolated static func node(
+        path: String,
+        logical: Int64? = nil,
+        allocated: Int64,
+        itemType: StorageItemType = .directory,
+        accessibility: StorageAccessibility = .accessible,
+        issues: [StorageScanIssue] = [],
+        children: [StorageNode] = [],
+        metadata: StorageAnalysisMetadata = StorageAnalysisMetadata()
+    ) -> StorageNode {
+        StorageNode(
+            name: URL(fileURLWithPath: path).lastPathComponent,
+            absolutePath: path,
+            logicalSize: logical ?? allocated,
+            allocatedSize: allocated,
+            ownLogicalSize: logical ?? allocated,
+            ownAllocatedSize: allocated,
+            itemType: itemType,
+            children: children,
+            accessibility: accessibility,
+            scanIssues: issues,
+            isHidden: URL(fileURLWithPath: path).lastPathComponent.hasPrefix("."),
+            isSymbolicLink: false,
+            isCountedInParentTotals: true,
+            metadata: metadata
+        )
+    }
+
+    nonisolated static func dockerReport(
+        runtimeBytes: Int64,
+        location: DockerRuntimeLocation
+    ) -> DockerStorageReport {
+        let host = StorageAnalysisResult(
+            root: node(path: "/Users/test/Docker.raw", logical: 64_000, allocated: 15),
+            startedAt: Date(timeIntervalSince1970: 1),
+            completedAt: Date(timeIntervalSince1970: 1),
+            rootDeviceIdentifier: 1,
+            wasCancelled: false,
+            issues: []
+        )
+        let usage = DockerRuntimeStorageUsage(
+            category: .images,
+            totalBytes: runtimeBytes,
+            reclaimableBytes: nil,
+            reclaimablePercentage: nil,
+            objectCount: 2,
+            activeCount: 1
+        )
+        let relationship: DockerHostRuntimeRelationship = location == .remote
+            ? .remoteRuntimeNotRelatedToHostFootprint
+            : .localRuntimeMayExplainHostFootprint
+        return DockerStorageReport(
+            hostFootprint: DockerHostFootprint(
+                locations: [host],
+                logicalSize: 64_000,
+                allocatedSize: 15
+            ),
+            virtualDisks: [],
+            runtimeStatus: .installedAndReachable,
+            runtimeAccounting: DockerRuntimeAccounting(
+                images: usage,
+                containers: nil,
+                localVolumes: nil,
+                buildCache: nil
+            ),
+            dockerExecutablePath: nil,
+            runtimeContext: DockerRuntimeContext(
+                name: location == .remote ? "remote" : "desktop-linux",
+                sanitizedEndpoint: location == .remote ? "ssh://remote" : "unix:///local.sock",
+                location: location
+            ),
+            hostRuntimeRelationship: relationship,
+            accountingRelationship: .runtimeBreakdownIsNonAdditiveToHostFootprint,
+            wasCancelled: false,
+            issues: []
+        )
+    }
+
+    nonisolated static func apfsReport(snapshotSize: Int64?) -> APFSStorageReport {
+        let sizeKnowledge: APFSSnapshotSizeKnowledge = snapshotSize == nil
+            ? .unavailable
+            : .reportedBySystem
+        return APFSStorageReport(
+            volume: APFSVolumeInformation(
+                name: "Data",
+                volumeIdentifier: "disk-test",
+                volumeUUID: nil,
+                containerIdentifier: nil,
+                volumeGroupIdentifier: nil,
+                filesystemType: "apfs",
+                filesystemKind: .apfs,
+                mountPoint: "/",
+                dataVolumeRelationship: .dataVolume,
+                capacity: APFSVolumeCapacity(
+                    totalCapacity: 1_000,
+                    availableCapacity: 200,
+                    usedCapacity: 800,
+                    availableCapacityForImportantUsage: 300,
+                    availableCapacityForOpportunisticUsage: nil,
+                    purgeableEstimate: 100,
+                    purgeableEstimateKnowledge: .estimated
+                )
+            ),
+            snapshots: [APFSSnapshotInformation(
+                identifier: "snapshot-1",
+                name: "com.apple.TimeMachine.2026-01-01",
+                uuid: nil,
+                creationDate: nil,
+                size: snapshotSize,
+                sizeKnowledge: sizeKnowledge,
+                type: .timeMachine,
+                source: .diskutil,
+                storageRelationship: snapshotSize == nil ? .sizeUnavailable : .sharedNonAdditive
+            )],
+            state: .complete,
+            accountingRelationship: .volumeMetadataAndSnapshotsAreNonAdditiveToFilesystemTrees,
+            wasCancelled: false,
+            issues: []
+        )
+    }
+}
+
+private actor ReportSequence {
+    private var reports: [StorageReconciliationReport]
+
+    init(_ reports: [StorageReconciliationReport]) {
+        self.reports = reports
+    }
+
+    func next() -> StorageReconciliationReport {
+        reports.removeFirst()
+    }
+}

--- a/PureMacTests/StoragePathNormalizerTests.swift
+++ b/PureMacTests/StoragePathNormalizerTests.swift
@@ -575,6 +575,7 @@ final class StoragePathNormalizerTests: XCTestCase {
 
     private func makeCoordinator(
         userHome: UserHomeStorageReport? = nil,
+        applications: StorageAnalysisResult? = nil,
         applicationSupport: StorageAnalysisResult? = nil,
         containers: StorageAnalysisResult? = nil,
         groupContainers: StorageAnalysisResult? = nil,
@@ -589,6 +590,10 @@ final class StoragePathNormalizerTests: XCTestCase {
         StorageAnalysisCoordinator(
             userHomeStorageAnalysis: {
                 if let userHome { return userHome }
+                throw TestStageNotRun()
+            },
+            applicationsAnalysis: {
+                if let applications { return applications }
                 throw TestStageNotRun()
             },
             applicationSupportAnalysis: {

--- a/PureMacTests/StoragePathNormalizerTests.swift
+++ b/PureMacTests/StoragePathNormalizerTests.swift
@@ -1,0 +1,637 @@
+import Darwin
+import XCTest
+@testable import PureMac
+
+final class StoragePathNormalizerTests: XCTestCase {
+    // MARK: - 1. /System/Volumes/Data/private/var/x and /private/var/x
+    func testDataVolumePrivateVarNormalizesToPrivateVar() {
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/System/Volumes/Data/private/var/agentx"),
+            "/private/var/agentx"
+        )
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/private/var/agentx"),
+            "/private/var/agentx"
+        )
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/System/Volumes/Data/private/var/agentx"),
+            StoragePathNormalizer.normalize("/private/var/agentx")
+        )
+    }
+
+    // MARK: - 2. /var/x and /private/var/x macOS canonical alias semantics
+    func testVarNormalizesToPrivateVar() {
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/var/agentx"),
+            "/private/var/agentx"
+        )
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/var"),
+            "/private/var"
+        )
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/var/log/system.log"),
+            "/private/var/log/system.log"
+        )
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/var/agentx"),
+            StoragePathNormalizer.normalize("/private/var/agentx")
+        )
+    }
+
+    // MARK: - 3. /etc/x and /private/etc/x
+    func testEtcNormalizesToPrivateEtc() {
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/etc/cups/certs"),
+            "/private/etc/cups/certs"
+        )
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/etc"),
+            "/private/etc"
+        )
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/System/Volumes/Data/private/etc/cups/certs"),
+            "/private/etc/cups/certs"
+        )
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/etc/cups/certs"),
+            StoragePathNormalizer.normalize("/private/etc/cups/certs")
+        )
+    }
+
+    // MARK: - 4. /tmp/x and /private/tmp/x
+    func testTmpNormalizesToPrivateTmp() {
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/tmp/scratch.txt"),
+            "/private/tmp/scratch.txt"
+        )
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/tmp"),
+            "/private/tmp"
+        )
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/System/Volumes/Data/private/tmp/scratch.txt"),
+            "/private/tmp/scratch.txt"
+        )
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/tmp/scratch.txt"),
+            StoragePathNormalizer.normalize("/private/tmp/scratch.txt")
+        )
+    }
+
+    // MARK: - 5. /System/Volumes/Data/Users/... and /Users/...
+    func testDataVolumeUsersNormalizesToUsers() {
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/System/Volumes/Data/Users/alice/Library"),
+            "/Users/alice/Library"
+        )
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/System/Volumes/Data/Users"),
+            "/Users"
+        )
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/Users/alice/Library"),
+            "/Users/alice/Library"
+        )
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/System/Volumes/Data/Users/alice"),
+            StoragePathNormalizer.normalize("/Users/alice")
+        )
+    }
+
+    func testOtherDataVolumeFirmlinks() {
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/System/Volumes/Data/Library/Preferences"),
+            "/Library/Preferences"
+        )
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/System/Volumes/Data/Applications/PureMac.app"),
+            "/Applications/PureMac.app"
+        )
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/System/Volumes/Data/opt/homebrew"),
+            "/opt/homebrew"
+        )
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/System/Volumes/Data/usr/local/bin"),
+            "/usr/local/bin"
+        )
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/System/Volumes/Data/.Spotlight-V100"),
+            "/System/Volumes/Data/.Spotlight-V100"
+        )
+        XCTAssertEqual(
+            StoragePathNormalizer.normalize("/System/Volumes/Data/.DocumentRevisions-V100"),
+            "/System/Volumes/Data/.DocumentRevisions-V100"
+        )
+    }
+
+    // MARK: - 6. Similar prefixes are NOT treated as aliases
+    func testSimilarPrefixesAreNotTreatedAsAliases() {
+        XCTAssertEqual(StoragePathNormalizer.normalize("/private2"), "/private2")
+        XCTAssertEqual(StoragePathNormalizer.normalize("/private2/var"), "/private2/var")
+        XCTAssertEqual(StoragePathNormalizer.normalize("/various"), "/various")
+        XCTAssertEqual(StoragePathNormalizer.normalize("/various/sub"), "/various/sub")
+        XCTAssertEqual(StoragePathNormalizer.normalize("/var_log"), "/var_log")
+        XCTAssertEqual(StoragePathNormalizer.normalize("/etc2"), "/etc2")
+        XCTAssertEqual(StoragePathNormalizer.normalize("/etc_hosts"), "/etc_hosts")
+        XCTAssertEqual(StoragePathNormalizer.normalize("/tmp_file"), "/tmp_file")
+        XCTAssertEqual(StoragePathNormalizer.normalize("/tmp2/test"), "/tmp2/test")
+        XCTAssertEqual(StoragePathNormalizer.normalize("/System/Volumes/Database"), "/System/Volumes/Database")
+        XCTAssertEqual(StoragePathNormalizer.normalize("/System/Volumes/Data2/private"), "/System/Volumes/Data2/private")
+        XCTAssertEqual(StoragePathNormalizer.normalize("/System/Volumes/Data/private2"), "/System/Volumes/Data/private2")
+        XCTAssertEqual(StoragePathNormalizer.normalize("/System/Volumes/Data/Users2"), "/System/Volumes/Data/Users2")
+    }
+
+    // MARK: - 7. Arbitrary symlinks are not resolved/followed
+    func testArbitrarySymlinksAreNotResolved() {
+        let path = "/Users/alice/my_symlink/target"
+        XCTAssertEqual(StoragePathNormalizer.normalize(path), "/Users/alice/my_symlink/target")
+    }
+
+    // MARK: - 8. Equivalent permission-denied paths reached by two analyzers
+    func testEquivalentPermissionDeniedPathsRepresentedAsOneDiagnosticLocation() {
+        let issue1 = StorageScanIssue(
+            path: "/System/Volumes/Data/private/var/agentx",
+            kind: .permissionDenied,
+            message: "Permission denied.",
+            posixErrorCode: EACCES
+        )
+        let issue2 = StorageScanIssue(
+            path: "/private/var/agentx",
+            kind: .permissionDenied,
+            message: "Permission denied.",
+            posixErrorCode: EACCES
+        )
+
+        var results = StorageAnalyzerResults()
+        results.dataVolumeHiddenStorage = makeResult(path: "/System/Volumes/Data", issues: [issue1])
+        results.privateStorage = makeResult(path: "/private", issues: [issue2])
+
+        let coverage = [
+            StorageCanonicalRootCoverage(root: .dataVolumeHiddenStorage, configuredPath: "/System/Volumes/Data", state: .completed, knownAllocatedBytes: 10, unreadablePathCount: 1),
+            StorageCanonicalRootCoverage(root: .privateStorage, configuredPath: "/private", state: .completed, knownAllocatedBytes: 10, unreadablePathCount: 1),
+        ]
+
+        let diagnostic = StorageCoverageDiagnosticBuilder().build(
+            analyzerResults: results,
+            canonicalRootCoverage: coverage,
+            filesystemContributions: [],
+            analysisIssues: [],
+            discovery: .empty(homeDirectoryPath: "/Users/test"),
+            unexplainedBytes: 0,
+            purgeableEstimateBytes: nil,
+            incompleteCoverage: false,
+            wasCancelled: false
+        )
+
+        XCTAssertEqual(diagnostic.measurementIssues.totalIssueCount, 1)
+        XCTAssertEqual(diagnostic.permissionDeniedIssueCount, 1)
+        XCTAssertEqual(diagnostic.measurementIssues.groups.count, 1)
+
+        let group = diagnostic.measurementIssues.groups[0]
+        XCTAssertEqual(group.count, 1)
+        XCTAssertEqual(group.posixErrorCode, EACCES)
+        XCTAssertEqual(group.category, .permissionDenied)
+        XCTAssertEqual(group.contributingSources.count, 2)
+        XCTAssertTrue(group.contributingSources.contains(.analyzer(.dataVolumeHiddenStorage)))
+        XCTAssertTrue(group.contributingSources.contains(.analyzer(.privateStorage)))
+        XCTAssertTrue(group.representativePaths.contains("/System/Volumes/Data/private/var/agentx") || group.representativePaths.contains("/private/var/agentx"))
+    }
+
+    // MARK: - 9. Different errno values are not incorrectly merged
+    func testDifferentErrnoValuesAreNotMerged() {
+        let issueEaccess = StorageScanIssue(
+            path: "/private/var/agentx",
+            kind: .permissionDenied,
+            message: "Permission denied.",
+            posixErrorCode: EACCES
+        )
+        let issueEperm = StorageScanIssue(
+            path: "/private/var/agentx",
+            kind: .permissionDenied,
+            message: "Operation not permitted.",
+            posixErrorCode: EPERM
+        )
+
+        var results = StorageAnalyzerResults()
+        results.privateStorage = makeResult(path: "/private", issues: [issueEaccess, issueEperm])
+
+        let coverage = [
+            StorageCanonicalRootCoverage(root: .privateStorage, configuredPath: "/private", state: .completed, knownAllocatedBytes: 10, unreadablePathCount: 2),
+        ]
+
+        let diagnostic = StorageCoverageDiagnosticBuilder().build(
+            analyzerResults: results,
+            canonicalRootCoverage: coverage,
+            filesystemContributions: [],
+            analysisIssues: [],
+            discovery: .empty(homeDirectoryPath: "/Users/test"),
+            unexplainedBytes: 0,
+            purgeableEstimateBytes: nil,
+            incompleteCoverage: false,
+            wasCancelled: false
+        )
+
+        XCTAssertEqual(diagnostic.measurementIssues.totalIssueCount, 2)
+        XCTAssertEqual(diagnostic.measurementIssues.errnoCounts.count, 2)
+        XCTAssertTrue(diagnostic.measurementIssues.errnoCounts.contains { $0.errorCode == EACCES && $0.count == 1 })
+        XCTAssertTrue(diagnostic.measurementIssues.errnoCounts.contains { $0.errorCode == EPERM && $0.count == 1 })
+    }
+
+    // MARK: - 10. Different issue categories are not incorrectly merged
+    func testDifferentCategoriesAreNotMerged() {
+        let issueDenied = StorageScanIssue(
+            path: "/private/var/db",
+            kind: .permissionDenied,
+            message: "Permission denied.",
+            posixErrorCode: EACCES
+        )
+        let issueEnumFailed = StorageScanIssue(
+            path: "/private/var/db",
+            kind: .directoryEnumerationFailed,
+            message: "Directory enumeration failed.",
+            posixErrorCode: EIO
+        )
+
+        var results = StorageAnalyzerResults()
+        results.privateStorage = makeResult(path: "/private", issues: [issueDenied, issueEnumFailed])
+
+        let coverage = [
+            StorageCanonicalRootCoverage(root: .privateStorage, configuredPath: "/private", state: .completed, knownAllocatedBytes: 10, unreadablePathCount: 2),
+        ]
+
+        let diagnostic = StorageCoverageDiagnosticBuilder().build(
+            analyzerResults: results,
+            canonicalRootCoverage: coverage,
+            filesystemContributions: [],
+            analysisIssues: [],
+            discovery: .empty(homeDirectoryPath: "/Users/test"),
+            unexplainedBytes: 0,
+            purgeableEstimateBytes: nil,
+            incompleteCoverage: false,
+            wasCancelled: false
+        )
+
+        XCTAssertEqual(diagnostic.measurementIssues.totalIssueCount, 2)
+        XCTAssertEqual(diagnostic.permissionDeniedIssueCount, 1)
+        XCTAssertEqual(diagnostic.measurementIssues.categoryCounts.first { $0.category == .enumerationFailure }?.count, 1)
+    }
+
+    // MARK: - 11. Original/display paths remain available
+    func testOriginalDisplayPathsRemainAvailable() {
+        let originalPath = "/System/Volumes/Data/private/etc/cups/certs"
+        let issue = StorageScanIssue(
+            path: originalPath,
+            kind: .permissionDenied,
+            message: "Permission denied.",
+            posixErrorCode: EACCES
+        )
+
+        var results = StorageAnalyzerResults()
+        results.dataVolumeHiddenStorage = makeResult(path: "/System/Volumes/Data", issues: [issue])
+
+        let coverage = [
+            StorageCanonicalRootCoverage(root: .dataVolumeHiddenStorage, configuredPath: "/System/Volumes/Data", state: .completed, knownAllocatedBytes: 10, unreadablePathCount: 1),
+        ]
+
+        let diagnostic = StorageCoverageDiagnosticBuilder().build(
+            analyzerResults: results,
+            canonicalRootCoverage: coverage,
+            filesystemContributions: [],
+            analysisIssues: [],
+            discovery: .empty(homeDirectoryPath: "/Users/test"),
+            unexplainedBytes: 0,
+            purgeableEstimateBytes: nil,
+            incompleteCoverage: false,
+            wasCancelled: false
+        )
+
+        let group = diagnostic.measurementIssues.groups.first
+        XCTAssertNotNil(group)
+        XCTAssertTrue(group?.representativePaths.contains(originalPath) == true)
+    }
+
+    // MARK: - 12. Canonical accounting ownership prevents duplicate additive bytes
+    func testCanonicalAccountingOwnershipPreventsDuplicateBytes() async {
+        let coordinator = makeCoordinator(
+            privateStorage: self.makeResult(path: "/private", allocated: 100),
+            hidden: self.makeResult(path: "/System/Volumes/Data", allocated: 100, children: [
+                self.makeNode(path: "/System/Volumes/Data/private", allocated: 100)
+            ])
+        )
+        let report = await coordinator.analyze()
+
+        let privateContrib = report.filesystemContributions.first { $0.source == .privateStorage }
+        let dataVolumeContrib = report.filesystemContributions.first { $0.source == .dataVolumeHiddenStorage }
+
+        XCTAssertEqual(dataVolumeContrib?.relationship, .canonicalUnique)
+        XCTAssertEqual(dataVolumeContrib?.accountedAllocatedBytes, 100)
+
+        XCTAssertEqual(privateContrib?.relationship, .excludedDuplicatePath)
+        XCTAssertEqual(privateContrib?.accountedAllocatedBytes, 0)
+        XCTAssertEqual(privateContrib?.owningPath, "/private")
+    }
+
+    // MARK: - 13. explainedAllocatedBytes does not increase due to alias normalization
+    func testExplainedAllocatedBytesDoesNotIncreaseDueToAliasNormalization() async {
+        let coordinator = makeCoordinator(
+            privateStorage: self.makeResult(path: "/private", allocated: 50),
+            hidden: self.makeResult(path: "/System/Volumes/Data", allocated: 50, children: [
+                self.makeNode(path: "/System/Volumes/Data/private", allocated: 50)
+            ])
+        )
+        let report = await coordinator.analyze()
+
+        XCTAssertEqual(report.explainedAllocatedBytes, 50)
+    }
+
+    // MARK: - 14. unexplained-byte arithmetic remains max(volumeUsed - explained, 0)
+    func testUnexplainedBytesArithmeticRemainsMaxUsedMinusExplained() async {
+        let coordinator = makeCoordinator(
+            privateStorage: self.makeResult(path: "/private", allocated: 80)
+        )
+        let report = await coordinator.analyze()
+
+        if let used = report.usedCapacityBytes {
+            XCTAssertEqual(report.unexplainedBytes, max(used - report.explainedAllocatedBytes, 0))
+        } else {
+            XCTAssertNil(report.unexplainedBytes)
+        }
+    }
+
+    // MARK: - 15. Docker overlap checks respect normalized canonical identities
+    func testDockerOverlapRespectsNormalizedCanonicalIdentities() async {
+        let node = self.makeNode(path: "/System/Volumes/Data/private/var/run/docker.sock", allocated: 10)
+        let location = StorageAnalysisResult(root: node, startedAt: Date(), completedAt: Date(), rootDeviceIdentifier: nil, wasCancelled: false, issues: [])
+        let footprint = DockerHostFootprint(locations: [location], logicalSize: 10, allocatedSize: 10)
+        let dockerReport = DockerStorageReport(
+            hostFootprint: footprint,
+            virtualDisks: [],
+            runtimeStatus: .installedAndReachable,
+            runtimeAccounting: nil,
+            dockerExecutablePath: nil,
+            runtimeContext: DockerRuntimeContext(
+                name: "default",
+                sanitizedEndpoint: "unix:///var/run/docker.sock",
+                location: .local
+            ),
+            hostRuntimeRelationship: .localRuntimeMayExplainHostFootprint,
+            accountingRelationship: .runtimeBreakdownIsNonAdditiveToHostFootprint,
+            wasCancelled: false,
+            issues: []
+        )
+
+        let coordinator = makeCoordinator(
+            privateStorage: self.makeResult(path: "/private", allocated: 40),
+            docker: dockerReport
+        )
+        let report = await coordinator.analyze()
+
+        let dockerContrib = report.filesystemContributions.first { $0.source == .dockerHostOutsideCanonicalRoots }
+        XCTAssertNotNil(dockerContrib)
+        XCTAssertEqual(dockerContrib?.relationship, .excludedNestedPath)
+        XCTAssertEqual(dockerContrib?.accountedAllocatedBytes, 0)
+        XCTAssertEqual(dockerContrib?.owningPath, "/private")
+    }
+
+    // MARK: - 17. FDA granted + EACCES does not generate "grant FDA" guidance
+    @MainActor
+    func testFDAGrantedWithEACCESDoesNotRecommendGrantingFDA() {
+        let state = StorageIntelligenceState(analysisRunner: { _ in
+            StorageReconciliationReport(
+                totalCapacityBytes: 1_000,
+                usedCapacityBytes: 800,
+                availableCapacityBytes: 200,
+                purgeableEstimateBytes: nil,
+                explainedAllocatedBytes: 100,
+                unexplainedBytes: 700,
+                inaccessibleKnownLowerBoundBytes: 0,
+                unreadablePathCount: 0,
+                incompleteCoverage: false,
+                coverageStatus: .completeForConfiguredRoots,
+                canonicalRootCoverage: [],
+                filesystemContributions: [],
+                hardLinkAccountingStatus: .deduplicatedWithinAnalyzerScopesOnly,
+                analysisIssues: [],
+                analyzerResults: StorageAnalyzerResults(),
+                coverageDiagnostic: .empty,
+                startedAt: Date(),
+                completedAt: Date(),
+                duration: 0,
+                progress: StorageAnalysisProgress(totalStages: 10, completedStages: 10, runningStages: [], state: .completed),
+                wasCancelled: false
+            )
+        })
+        let guidance = state.permissionGuidance(fullDiskAccessGranted: true)
+        XCTAssertNil(guidance)
+    }
+
+    // MARK: - 19. Known protected-system paths receive appropriate explanatory classification
+    func testSystemProtectedLocationsClassification() {
+        XCTAssertTrue(StoragePathNormalizer.isSystemProtectedLocation("/System/Volumes/Data/.DocumentRevisions-V100"))
+        XCTAssertTrue(StoragePathNormalizer.isSystemProtectedLocation("/System/Volumes/Data/.Spotlight-V100"))
+        XCTAssertTrue(StoragePathNormalizer.isSystemProtectedLocation("/System/Volumes/Data/.fseventsd"))
+        XCTAssertTrue(StoragePathNormalizer.isSystemProtectedLocation("/private/var/audit"))
+        XCTAssertTrue(StoragePathNormalizer.isSystemProtectedLocation("/var/audit"))
+        XCTAssertTrue(StoragePathNormalizer.isSystemProtectedLocation("/System/Volumes/Data/private/var/agentx"))
+        XCTAssertTrue(StoragePathNormalizer.isSystemProtectedLocation("/private/etc/cups/certs"))
+        XCTAssertTrue(StoragePathNormalizer.isSystemProtectedLocation("/etc/cups/certs"))
+
+        XCTAssertFalse(StoragePathNormalizer.isSystemProtectedLocation("/Users/alice/Documents"))
+        XCTAssertFalse(StoragePathNormalizer.isSystemProtectedLocation("/private/tmp/scratch"))
+        XCTAssertFalse(StoragePathNormalizer.isSystemProtectedLocation("/opt/homebrew"))
+    }
+
+    func testSystemProtectedLocationReceivesAccurateExplanation() {
+        let issue = StorageScanIssue(
+            path: "/private/var/audit",
+            kind: .permissionDenied,
+            message: "Permission denied.",
+            posixErrorCode: EACCES
+        )
+
+        var results = StorageAnalyzerResults()
+        results.privateStorage = makeResult(path: "/private", issues: [issue])
+
+        let coverage = [
+            StorageCanonicalRootCoverage(root: .privateStorage, configuredPath: "/private", state: .completed, knownAllocatedBytes: 10, unreadablePathCount: 1),
+        ]
+
+        let diagnostic = StorageCoverageDiagnosticBuilder().build(
+            analyzerResults: results,
+            canonicalRootCoverage: coverage,
+            filesystemContributions: [],
+            analysisIssues: [],
+            discovery: .empty(homeDirectoryPath: "/Users/test"),
+            unexplainedBytes: 0,
+            purgeableEstimateBytes: nil,
+            incompleteCoverage: false,
+            wasCancelled: false
+        )
+
+        let group = diagnostic.measurementIssues.groups.first
+        XCTAssertNotNil(group)
+        XCTAssertTrue(group?.explanation.contains("system-managed") == true)
+    }
+
+    // MARK: - 20. Unknown inaccessible paths remain unknown/inaccessible rather than being guessed
+    func testUnknownInaccessiblePathIsNotClassifiedAsProtected() {
+        let issue = StorageScanIssue(
+            path: "/Users/alice/secret_custom_folder",
+            kind: .permissionDenied,
+            message: "Permission denied.",
+            posixErrorCode: EACCES
+        )
+
+        var results = StorageAnalyzerResults()
+        results.userHomeStorage = UserHomeStorageAnalyzer.makeReport(
+            makeResult(path: "/Users/alice", issues: [issue]),
+            homeDirectoryURL: URL(fileURLWithPath: "/Users/alice"),
+            largeAllocatedSizeThreshold: 1_073_741_824
+        )
+
+        let coverage = [
+            StorageCanonicalRootCoverage(root: .userHomeVisibleStorage, configuredPath: "/Users/alice", state: .completed, knownAllocatedBytes: 10, unreadablePathCount: 1),
+        ]
+
+        let diagnostic = StorageCoverageDiagnosticBuilder().build(
+            analyzerResults: results,
+            canonicalRootCoverage: coverage,
+            filesystemContributions: [],
+            analysisIssues: [],
+            discovery: .empty(homeDirectoryPath: "/Users/alice"),
+            unexplainedBytes: 0,
+            purgeableEstimateBytes: nil,
+            incompleteCoverage: false,
+            wasCancelled: false
+        )
+
+        let group = diagnostic.measurementIssues.groups.first
+        XCTAssertNotNil(group)
+        XCTAssertEqual(group?.explanation, StorageCoverageDiagnosticBuilder.explanation(for: .permissionDenied))
+        XCTAssertFalse(group?.explanation.contains("system-managed") == true)
+    }
+
+    // MARK: - Path containment and overlap helpers
+    func testPathContainmentAndOverlap() {
+        XCTAssertTrue(StoragePathNormalizer.contains(parent: "/private", child: "/private/var/agentx"))
+        XCTAssertTrue(StoragePathNormalizer.contains(parent: "/private", child: "/System/Volumes/Data/private/var/agentx"))
+        XCTAssertTrue(StoragePathNormalizer.contains(parent: "/private", child: "/var/agentx"))
+        XCTAssertTrue(StoragePathNormalizer.contains(parent: "/System/Volumes/Data/private", child: "/private/var/agentx"))
+        XCTAssertTrue(StoragePathNormalizer.contains(parent: "/Users", child: "/System/Volumes/Data/Users/alice"))
+
+        XCTAssertFalse(StoragePathNormalizer.contains(parent: "/private", child: "/private2"))
+        XCTAssertFalse(StoragePathNormalizer.contains(parent: "/private", child: "/Users/alice"))
+
+        XCTAssertTrue(StoragePathNormalizer.pathsOverlap("/private", "/private/var"))
+        XCTAssertTrue(StoragePathNormalizer.pathsOverlap("/private/var", "/private"))
+        XCTAssertTrue(StoragePathNormalizer.pathsOverlap("/System/Volumes/Data/private", "/var/log"))
+        XCTAssertFalse(StoragePathNormalizer.pathsOverlap("/private", "/Users"))
+
+        XCTAssertEqual(StoragePathNormalizer.parentPath(of: "/System/Volumes/Data/private/var/agentx"), "/private/var")
+        XCTAssertEqual(StoragePathNormalizer.parentPath(of: "/var/agentx"), "/private/var")
+        XCTAssertEqual(StoragePathNormalizer.parentPath(of: "/private/etc/cups/certs"), "/private/etc/cups")
+        XCTAssertEqual(StoragePathNormalizer.parentPath(of: "/"), "/")
+    }
+
+    // MARK: - Helpers
+    private func makeNode(path: String, allocated: Int64 = 0, children: [StorageNode] = []) -> StorageNode {
+        StorageNode(
+            name: URL(fileURLWithPath: path).lastPathComponent,
+            absolutePath: path,
+            logicalSize: allocated,
+            allocatedSize: allocated,
+            ownLogicalSize: allocated,
+            ownAllocatedSize: allocated,
+            itemType: .directory,
+            children: children,
+            accessibility: .accessible,
+            scanIssues: [],
+            isHidden: false,
+            isSymbolicLink: false,
+            isCountedInParentTotals: true,
+            metadata: StorageAnalysisMetadata()
+        )
+    }
+
+    private func makeResult(
+        path: String,
+        allocated: Int64 = 0,
+        issues: [StorageScanIssue] = [],
+        children: [StorageNode] = []
+    ) -> StorageAnalysisResult {
+        StorageAnalysisResult(
+            root: makeNode(path: path, allocated: allocated, children: children),
+            startedAt: Date(),
+            completedAt: Date(),
+            rootDeviceIdentifier: 1,
+            wasCancelled: false,
+            issues: issues
+        )
+    }
+
+    struct TestStageNotRun: Error {}
+
+    private func makeCoordinator(
+        userHome: UserHomeStorageReport? = nil,
+        applicationSupport: StorageAnalysisResult? = nil,
+        containers: StorageAnalysisResult? = nil,
+        groupContainers: StorageAnalysisResult? = nil,
+        systemLibrary: StorageAnalysisResult? = nil,
+        privateStorage: StorageAnalysisResult? = nil,
+        hidden: StorageAnalysisResult? = nil,
+        developer: DeveloperSystemStorageReport? = nil,
+        docker: DockerStorageReport? = nil,
+        apfs: APFSStorageReport? = nil,
+        coverageExpansion: StorageCoverageExpansionReport? = nil
+    ) -> StorageAnalysisCoordinator {
+        StorageAnalysisCoordinator(
+            userHomeStorageAnalysis: {
+                if let userHome { return userHome }
+                throw TestStageNotRun()
+            },
+            applicationSupportAnalysis: {
+                if let applicationSupport { return applicationSupport }
+                throw TestStageNotRun()
+            },
+            containersAnalysis: {
+                if let containers { return containers }
+                throw TestStageNotRun()
+            },
+            groupContainersAnalysis: {
+                if let groupContainers { return groupContainers }
+                throw TestStageNotRun()
+            },
+            systemLibraryAnalysis: {
+                if let systemLibrary { return systemLibrary }
+                throw TestStageNotRun()
+            },
+            privateStorageAnalysis: {
+                if let privateStorage { return privateStorage }
+                throw TestStageNotRun()
+            },
+            dataVolumeHiddenStorageAnalysis: {
+                if let hidden { return hidden }
+                throw TestStageNotRun()
+            },
+            developerSystemStorageAnalysis: {
+                if let developer { return developer }
+                throw TestStageNotRun()
+            },
+            dockerStorageAnalysis: {
+                if let docker { return docker }
+                throw TestStageNotRun()
+            },
+            apfsStorageAnalysis: {
+                if let apfs { return apfs }
+                throw TestStageNotRun()
+            },
+            coverageExpansionAnalysis: {
+                if let coverageExpansion { return coverageExpansion }
+                return .empty
+            },
+            coverageDiscovery: { .empty(homeDirectoryPath: "/Users/test") }
+        )
+    }
+}

--- a/PureMacTests/SystemLibraryAnalyzerTests.swift
+++ b/PureMacTests/SystemLibraryAnalyzerTests.swift
@@ -1,0 +1,598 @@
+import Darwin
+import XCTest
+@testable import PureMac
+
+final class SystemLibraryAnalyzerTests: XCTestCase {
+    func testAnalyzesMultipleTopLevelDirectoriesAndSortsByAllocatedSize() async throws {
+        let temporaryDirectory = try SystemLibraryTestDirectory()
+        try makeSystemLibraryDirectory(named: "Small", fileSize: 4_096, in: temporaryDirectory.url)
+        try makeSystemLibraryDirectory(named: "Medium", fileSize: 262_144, in: temporaryDirectory.url)
+        try makeSystemLibraryDirectory(named: "Large", fileSize: 2_097_152, in: temporaryDirectory.url)
+
+        let result = await makeSystemLibraryAnalyzer(root: temporaryDirectory.url).analyze()
+        let entries = result.root.children
+
+        XCTAssertEqual(entries.map(\.name), ["Large", "Medium", "Small"])
+        XCTAssertTrue(zip(entries, entries.dropFirst()).allSatisfy {
+            systemLibraryOrdering($0, $1)
+        })
+        XCTAssertEqual(result.root.metadata.storageCategoryIdentifier, "system-library")
+        XCTAssertEqual(
+            result.root.metadata.attributes[SystemLibraryAnalyzer.MetadataKey.directChildCount],
+            "3"
+        )
+    }
+
+    func testPreservesCompleteHierarchyAndHiddenEntries() async throws {
+        let temporaryDirectory = try SystemLibraryTestDirectory()
+        let developer = temporaryDirectory.url.appendingPathComponent("Developer", isDirectory: true)
+        let nested = developer
+            .appendingPathComponent("SDKs", isDirectory: true)
+            .appendingPathComponent("Nested", isDirectory: true)
+        let hiddenDirectory = nested.appendingPathComponent(".metadata", isDirectory: true)
+        let hiddenFile = hiddenDirectory.appendingPathComponent(".index")
+        try FileManager.default.createDirectory(at: hiddenDirectory, withIntermediateDirectories: true)
+        try Data(repeating: 0x11, count: 2_048).write(to: hiddenFile)
+
+        let result = await makeSystemLibraryAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertNotNil(systemLibraryNode(at: developer.path, in: result.root))
+        XCTAssertNotNil(systemLibraryNode(at: nested.path, in: result.root))
+        XCTAssertEqual(systemLibraryNode(at: hiddenDirectory.path, in: result.root)?.isHidden, true)
+        XCTAssertEqual(systemLibraryNode(at: hiddenFile.path, in: result.root)?.isHidden, true)
+        XCTAssertEqual(
+            systemLibraryNode(at: developer.path, in: result.root)?.metadata.storageCategoryIdentifier,
+            SystemLibraryStorageCategory.developer.rawValue
+        )
+    }
+
+    func testAddsTypedMetadataForKnownSystemLibraryCategories() async throws {
+        let temporaryDirectory = try SystemLibraryTestDirectory()
+        let expected: [(String, SystemLibraryStorageCategory)] = [
+            ("Application Support", .applicationSupport),
+            ("Caches", .caches),
+            ("Developer", .developer),
+            ("Logs", .logs),
+            ("Frameworks", .frameworks),
+            ("LaunchAgents", .launchAgents),
+            ("LaunchDaemons", .launchDaemons),
+            ("PrivilegedHelperTools", .privilegedHelperTools),
+            ("Preferences", .preferences),
+            ("Extensions", .extensions),
+            ("Updates", .updates),
+            ("Audio", .audio),
+            ("Fonts", .fonts),
+        ]
+        for (name, _) in expected {
+            try FileManager.default.createDirectory(
+                at: temporaryDirectory.url.appendingPathComponent(name, isDirectory: true),
+                withIntermediateDirectories: false
+            )
+        }
+
+        let result = await makeSystemLibraryAnalyzer(root: temporaryDirectory.url).analyze()
+
+        for (name, category) in expected {
+            let path = temporaryDirectory.url.appendingPathComponent(name).path
+            let node = try XCTUnwrap(systemLibraryNode(at: path, in: result.root))
+            XCTAssertEqual(node.metadata.storageCategoryIdentifier, category.rawValue)
+            XCTAssertEqual(node.metadata.explanation, category.explanation)
+            XCTAssertEqual(
+                node.metadata.attributes[SystemLibraryAnalyzer.MetadataKey.storageScope],
+                "system-wide"
+            )
+            XCTAssertNil(node.metadata.safetyClassificationIdentifier)
+        }
+    }
+
+    func testUnknownTopLevelDirectoryRemainsVisibleAsOtherStorage() async throws {
+        let temporaryDirectory = try SystemLibraryTestDirectory()
+        let unknown = try makeSystemLibraryDirectory(
+            named: "VendorSpecificData",
+            fileSize: 1_024,
+            in: temporaryDirectory.url
+        )
+
+        let result = await makeSystemLibraryAnalyzer(
+            root: temporaryDirectory.url,
+            largeAllocatedSizeThreshold: 1
+        ).analyze()
+        let node = try XCTUnwrap(systemLibraryNode(at: unknown.path, in: result.root))
+
+        XCTAssertEqual(node.metadata.storageCategoryIdentifier, SystemLibraryStorageCategory.other.rawValue)
+        XCTAssertTrue(node.metadata.explanation?.contains("Other storage") == true)
+        XCTAssertEqual(node.metadata.isUnusuallyLarge, true)
+        XCTAssertEqual(
+            node.metadata.attributes[SystemLibraryAnalyzer.MetadataKey.largeAllocatedSizeThreshold],
+            "1"
+        )
+        XCTAssertNil(node.metadata.safetyClassificationIdentifier)
+    }
+
+    func testSystemWideApplicationSupportIsDistinctFromUserApplicationSupport() async throws {
+        let temporaryDirectory = try SystemLibraryTestDirectory()
+        let applicationSupport = try makeSystemLibraryDirectory(
+            named: "Application Support",
+            fileSize: 4_096,
+            in: temporaryDirectory.url
+        )
+
+        let result = await makeSystemLibraryAnalyzer(root: temporaryDirectory.url).analyze()
+        let node = try XCTUnwrap(systemLibraryNode(at: applicationSupport.path, in: result.root))
+
+        XCTAssertEqual(
+            node.metadata.storageCategoryIdentifier,
+            SystemLibraryStorageCategory.applicationSupport.rawValue
+        )
+        XCTAssertNotEqual(
+            node.metadata.storageCategoryIdentifier,
+            ApplicationSupportAnalyzer.storageCategoryIdentifier
+        )
+        XCTAssertTrue(node.metadata.explanation?.contains("System-wide shared application data") == true)
+        XCTAssertEqual(
+            node.metadata.attributes[SystemLibraryAnalyzer.MetadataKey.storageScope],
+            "system-wide"
+        )
+    }
+
+    func testLogicalAndAllocatedSizesMatchFilesystemMetadata() async throws {
+        let temporaryDirectory = try SystemLibraryTestDirectory()
+        let caches = temporaryDirectory.url.appendingPathComponent("Caches", isDirectory: true)
+        try FileManager.default.createDirectory(at: caches, withIntermediateDirectories: false)
+        let payload = caches.appendingPathComponent("cache.dat")
+        try Data(repeating: 0x21, count: 32_768).write(to: payload)
+        let expected = try systemLibraryStatValues(for: payload.path)
+
+        let result = await makeSystemLibraryAnalyzer(root: temporaryDirectory.url).analyze()
+        let node = try XCTUnwrap(systemLibraryNode(at: payload.path, in: result.root))
+
+        XCTAssertEqual(node.ownLogicalSize, expected.logical)
+        XCTAssertEqual(node.ownAllocatedSize, expected.allocated)
+    }
+
+    func testSparseVirtualDiskPreservesSizesAndSparseMetadata() async throws {
+        let temporaryDirectory = try SystemLibraryTestDirectory()
+        let applicationSupport = temporaryDirectory.url
+            .appendingPathComponent("Application Support", isDirectory: true)
+        try FileManager.default.createDirectory(at: applicationSupport, withIntermediateDirectories: false)
+        let virtualDisk = applicationSupport.appendingPathComponent("machine.qcow2")
+        XCTAssertTrue(FileManager.default.createFile(atPath: virtualDisk.path, contents: nil))
+        let logicalByteCount: UInt64 = 64 * 1_024 * 1_024
+        let handle = try FileHandle(forWritingTo: virtualDisk)
+        try handle.truncate(atOffset: logicalByteCount)
+        try handle.close()
+
+        let result = await makeSystemLibraryAnalyzer(root: temporaryDirectory.url).analyze()
+        let parent = try XCTUnwrap(systemLibraryNode(at: applicationSupport.path, in: result.root))
+        let disk = try XCTUnwrap(systemLibraryNode(at: virtualDisk.path, in: result.root))
+
+        XCTAssertEqual(disk.ownLogicalSize, Int64(logicalByteCount))
+        XCTAssertEqual(
+            disk.metadata.attributes[SystemLibraryAnalyzer.MetadataKey.virtualDiskFormat],
+            "qcow2"
+        )
+        XCTAssertEqual(
+            parent.metadata.attributes[SystemLibraryAnalyzer.MetadataKey.virtualDiskImageCount],
+            "1"
+        )
+        if disk.ownAllocatedSize >= disk.ownLogicalSize {
+            throw XCTSkip("The test filesystem eagerly allocated the sparse virtual disk.")
+        }
+        XCTAssertEqual(
+            disk.metadata.attributes[SystemLibraryAnalyzer.MetadataKey.virtualDiskSparseState],
+            "sparse"
+        )
+    }
+
+    func testRecognizesAllSupportedVirtualDiskFormatsWithoutInspectingContents() async throws {
+        let temporaryDirectory = try SystemLibraryTestDirectory()
+        let support = temporaryDirectory.url.appendingPathComponent("VM Storage", isDirectory: true)
+        try FileManager.default.createDirectory(at: support, withIntermediateDirectories: false)
+        let expected = ["raw", "img", "qcow2", "vmdk"]
+        for pathExtension in expected {
+            try Data([0x31]).write(to: support.appendingPathComponent("disk.\(pathExtension)"))
+        }
+        let sparseBundle = support.appendingPathComponent("disk.sparsebundle", isDirectory: true)
+        try FileManager.default.createDirectory(at: sparseBundle, withIntermediateDirectories: false)
+
+        let result = await makeSystemLibraryAnalyzer(root: temporaryDirectory.url).analyze()
+        let supportNode = try XCTUnwrap(systemLibraryNode(at: support.path, in: result.root))
+
+        for pathExtension in expected {
+            let path = support.appendingPathComponent("disk.\(pathExtension)").path
+            XCTAssertEqual(
+                systemLibraryNode(at: path, in: result.root)?
+                    .metadata.attributes[SystemLibraryAnalyzer.MetadataKey.virtualDiskFormat],
+                pathExtension
+            )
+        }
+        XCTAssertEqual(
+            systemLibraryNode(at: sparseBundle.path, in: result.root)?
+                .metadata.attributes[SystemLibraryAnalyzer.MetadataKey.virtualDiskFormat],
+            "sparsebundle"
+        )
+        XCTAssertEqual(
+            supportNode.metadata.attributes[SystemLibraryAnalyzer.MetadataKey.virtualDiskImageCount],
+            "5"
+        )
+    }
+
+    func testSymbolicLinksRemainVisibleAndAreNeverFollowed() async throws {
+        let temporaryDirectory = try SystemLibraryTestDirectory()
+        let outsideDirectory = try SystemLibraryTestDirectory()
+        let outsideFile = outsideDirectory.url.appendingPathComponent("outside.raw")
+        try Data(repeating: 0x41, count: 1_048_576).write(to: outsideFile)
+        let link = temporaryDirectory.url.appendingPathComponent("Caches")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outsideDirectory.url)
+
+        let result = await makeSystemLibraryAnalyzer(root: temporaryDirectory.url).analyze()
+        let linkNode = try XCTUnwrap(systemLibraryNode(at: link.path, in: result.root))
+
+        XCTAssertEqual(linkNode.itemType, .symbolicLink)
+        XCTAssertTrue(linkNode.isSymbolicLink)
+        XCTAssertTrue(linkNode.children.isEmpty)
+        XCTAssertEqual(linkNode.metadata.storageCategoryIdentifier, SystemLibraryStorageCategory.other.rawValue)
+        XCTAssertNil(systemLibraryNode(at: outsideFile.path, in: result.root))
+    }
+
+    func testEnrichmentPreservesScannerVolumeBoundaryWithoutCountingItsBytes() throws {
+        let rootPath = "/Library"
+        let boundaryPath = "/Library/ExternalVolume"
+        let boundaryIssue = StorageScanIssue(
+            path: boundaryPath,
+            kind: .differentVolume,
+            message: "Traversal stopped because this item is on a different mounted filesystem.",
+            posixErrorCode: nil
+        )
+        let boundary = syntheticSystemLibraryNode(
+            name: "ExternalVolume",
+            path: boundaryPath,
+            logicalSize: 0,
+            allocatedSize: 0,
+            ownLogicalSize: 8_192,
+            ownAllocatedSize: 8_192,
+            itemType: .volumeBoundary,
+            accessibility: .skippedDifferentVolume,
+            issues: [boundaryIssue],
+            isCounted: false
+        )
+        let root = syntheticSystemLibraryNode(
+            name: "Library",
+            path: rootPath,
+            logicalSize: 128,
+            allocatedSize: 4_096,
+            ownLogicalSize: 128,
+            ownAllocatedSize: 4_096,
+            itemType: .directory,
+            children: [boundary]
+        )
+        let input = StorageAnalysisResult(
+            root: root,
+            startedAt: Date(),
+            completedAt: Date(),
+            rootDeviceIdentifier: 1,
+            wasCancelled: false,
+            issues: [boundaryIssue]
+        )
+
+        let result = SystemLibraryAnalyzer.enrich(input, largeAllocatedSizeThreshold: 1)
+        let preserved = try XCTUnwrap(result.root.children.first)
+
+        XCTAssertEqual(preserved.itemType, .volumeBoundary)
+        XCTAssertEqual(preserved.accessibility, .skippedDifferentVolume)
+        XCTAssertFalse(preserved.isCountedInParentTotals)
+        XCTAssertEqual(result.root.logicalSize, 128)
+        XCTAssertEqual(result.root.allocatedSize, 4_096)
+        XCTAssertTrue(result.issues.contains { $0.kind == .differentVolume })
+    }
+
+    func testPermissionDeniedChildProducesPartialResultAndPreservesPOSIXError() async throws {
+        guard geteuid() != 0 else {
+            throw XCTSkip("A root process can read mode-000 test directories.")
+        }
+        let temporaryDirectory = try SystemLibraryTestDirectory()
+        try makeSystemLibraryDirectory(named: "Readable", fileSize: 128, in: temporaryDirectory.url)
+        let inaccessible = try makeSystemLibraryDirectory(
+            named: "PrivilegedHelperTools",
+            fileSize: 128,
+            in: temporaryDirectory.url
+        )
+        XCTAssertEqual(chmod(inaccessible.path, 0), 0)
+        defer { _ = chmod(inaccessible.path, mode_t(S_IRWXU)) }
+
+        let result = await makeSystemLibraryAnalyzer(root: temporaryDirectory.url).analyze()
+        let inaccessibleNode = try XCTUnwrap(systemLibraryNode(at: inaccessible.path, in: result.root))
+        let issue = try XCTUnwrap(inaccessibleNode.scanIssues.first { $0.kind == .permissionDenied })
+
+        XCTAssertEqual(inaccessibleNode.accessibility, .inaccessible)
+        XCTAssertTrue(inaccessibleNode.children.isEmpty)
+        XCTAssertNotNil(issue.posixErrorCode)
+        XCTAssertEqual(result.root.accessibility, .partiallyAccessible)
+        XCTAssertNotNil(systemLibraryNode(
+            at: temporaryDirectory.url.appendingPathComponent("Readable/payload.dat").path,
+            in: result.root
+        ))
+    }
+
+    func testCancellationReturnsAVisiblePartialMarkedTree() async throws {
+        let temporaryDirectory = try SystemLibraryTestDirectory()
+        for index in 0..<300 {
+            try makeSystemLibraryDirectory(
+                named: "Component-\(index)",
+                fileSize: 64,
+                in: temporaryDirectory.url
+            )
+        }
+        let analyzer = makeSystemLibraryAnalyzer(
+            root: temporaryDirectory.url,
+            scanner: FileTreeScanner(configuration: .init(maxConcurrentDirectoryReads: 1))
+        )
+        let task = Task { await analyzer.analyze() }
+        task.cancel()
+
+        let result = await task.value
+
+        XCTAssertTrue(result.wasCancelled)
+        XCTAssertTrue(result.issues.contains { $0.kind == .cancelled })
+        XCTAssertNotEqual(result.root.accessibility, .accessible)
+    }
+
+    func testEmptyRootReturnsAnAccessibleEmptyAnalysis() async throws {
+        let temporaryDirectory = try SystemLibraryTestDirectory()
+
+        let result = await makeSystemLibraryAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertEqual(result.root.itemType, .directory)
+        XCTAssertEqual(result.root.accessibility, .accessible)
+        XCTAssertTrue(result.root.children.isEmpty)
+        XCTAssertEqual(
+            result.root.metadata.attributes[SystemLibraryAnalyzer.MetadataKey.directChildCount],
+            "0"
+        )
+    }
+
+    func testMissingRootReturnsTypedUnavailableAnalysis() async {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMac-Missing-System-Library-\(UUID().uuidString)", isDirectory: true)
+
+        let result = await makeSystemLibraryAnalyzer(root: missing).analyze()
+
+        XCTAssertEqual(result.root.absolutePath, missing.standardizedFileURL.path)
+        XCTAssertEqual(result.root.itemType, .unknown)
+        XCTAssertEqual(result.root.accessibility, .inaccessible)
+        XCTAssertTrue(result.issues.contains { $0.kind == .metadataUnavailable })
+        XCTAssertEqual(result.root.metadata.storageCategoryIdentifier, "system-library")
+    }
+
+    func testNonDirectoryRootReturnsTypedNotDirectoryIssue() async throws {
+        let temporaryDirectory = try SystemLibraryTestDirectory()
+        let file = temporaryDirectory.url.appendingPathComponent("Library-file")
+        try Data([0x51]).write(to: file)
+
+        let result = await makeSystemLibraryAnalyzer(root: file).analyze()
+
+        XCTAssertEqual(result.root.itemType, .regularFile)
+        XCTAssertEqual(result.root.accessibility, .inaccessible)
+        XCTAssertTrue(result.root.scanIssues.contains {
+            $0.kind == .notDirectory && $0.posixErrorCode == ENOTDIR
+        })
+        XCTAssertTrue(result.issues.contains { $0.kind == .notDirectory })
+    }
+
+    func testAccountingReconcilesToOneCanonicalTree() async throws {
+        let temporaryDirectory = try SystemLibraryTestDirectory()
+        try makeSystemLibraryDirectory(named: "Caches", fileSize: 8_192, in: temporaryDirectory.url)
+        try makeSystemLibraryDirectory(named: "Logs", fileSize: 16_384, in: temporaryDirectory.url)
+        try makeSystemLibraryDirectory(
+            named: "Application Support",
+            fileSize: 32_768,
+            in: temporaryDirectory.url
+        )
+
+        let result = await makeSystemLibraryAnalyzer(root: temporaryDirectory.url).analyze()
+        let counted = flattenedSystemLibraryTree(result.root).filter(\.isCountedInParentTotals)
+        let logical = counted.reduce(Int64(0)) { $0 + $1.ownLogicalSize }
+        let allocated = counted.reduce(Int64(0)) { $0 + $1.ownAllocatedSize }
+
+        XCTAssertEqual(result.root.logicalSize, logical)
+        XCTAssertEqual(result.root.allocatedSize, allocated)
+        XCTAssertEqual(
+            result.root.logicalSize,
+            result.root.ownLogicalSize + result.root.children.reduce(0) { $0 + $1.logicalSize }
+        )
+        XCTAssertEqual(
+            result.root.allocatedSize,
+            result.root.ownAllocatedSize + result.root.children.reduce(0) { $0 + $1.allocatedSize }
+        )
+        XCTAssertTrue(result.root.children.allSatisfy {
+            $0.logicalSize <= result.root.logicalSize && $0.allocatedSize <= result.root.allocatedSize
+        })
+    }
+
+    func testHardLinkedBytesAcrossConceptualCategoriesAreCountedOnlyOnce() async throws {
+        let temporaryDirectory = try SystemLibraryTestDirectory()
+        let caches = temporaryDirectory.url.appendingPathComponent("Caches", isDirectory: true)
+        let logs = temporaryDirectory.url.appendingPathComponent("Logs", isDirectory: true)
+        try FileManager.default.createDirectory(at: caches, withIntermediateDirectories: false)
+        try FileManager.default.createDirectory(at: logs, withIntermediateDirectories: false)
+        let original = caches.appendingPathComponent("shared.dat")
+        let linked = logs.appendingPathComponent("shared.dat")
+        try Data(repeating: 0x61, count: 8_192).write(to: original)
+        try FileManager.default.linkItem(at: original, to: linked)
+
+        let result = await makeSystemLibraryAnalyzer(root: temporaryDirectory.url).analyze()
+        let originalNode = try XCTUnwrap(systemLibraryNode(at: original.path, in: result.root))
+        let linkedNode = try XCTUnwrap(systemLibraryNode(at: linked.path, in: result.root))
+        let aliases = [originalNode, linkedNode]
+        let countedNode = try XCTUnwrap(aliases.first(where: \.isCountedInParentTotals))
+
+        XCTAssertEqual(aliases.filter(\.isCountedInParentTotals).count, 1)
+        XCTAssertEqual(
+            systemLibraryNode(at: caches.path, in: result.root)?.metadata.storageCategoryIdentifier,
+            SystemLibraryStorageCategory.caches.rawValue
+        )
+        XCTAssertEqual(
+            systemLibraryNode(at: logs.path, in: result.root)?.metadata.storageCategoryIdentifier,
+            SystemLibraryStorageCategory.logs.rawValue
+        )
+        XCTAssertEqual(
+            result.root.logicalSize,
+            result.root.ownLogicalSize
+                + systemLibraryNode(at: caches.path, in: result.root)!.ownLogicalSize
+                + systemLibraryNode(at: logs.path, in: result.root)!.ownLogicalSize
+                + countedNode.ownLogicalSize
+        )
+    }
+
+    func testCanonicalPathIsPreservedWithoutDataVolumeRewriting() async throws {
+        XCTAssertEqual(SystemLibraryAnalyzer.defaultSystemLibraryURL.path, "/Library")
+        let temporaryDirectory = try SystemLibraryTestDirectory()
+
+        let result = await makeSystemLibraryAnalyzer(root: temporaryDirectory.url).analyze()
+
+        XCTAssertEqual(result.root.absolutePath, temporaryDirectory.url.standardizedFileURL.path)
+        XCTAssertEqual(
+            result.root.metadata.attributes[SystemLibraryAnalyzer.MetadataKey.canonicalUserFacingPath],
+            temporaryDirectory.url.standardizedFileURL.path
+        )
+        XCTAssertFalse(result.root.absolutePath.contains("/System/Volumes/Data"))
+    }
+
+    func testAnalysisDoesNotDeleteOrModifyFilesystemContents() async throws {
+        let temporaryDirectory = try SystemLibraryTestDirectory()
+        let logs = temporaryDirectory.url.appendingPathComponent("Logs", isDirectory: true)
+        try FileManager.default.createDirectory(at: logs, withIntermediateDirectories: false)
+        let file = logs.appendingPathComponent("important.log")
+        let originalData = Data(repeating: 0x71, count: 4_096)
+        try originalData.write(to: file)
+        let originalMode = try systemLibraryStatMode(for: file.path)
+
+        _ = await makeSystemLibraryAnalyzer(
+            root: temporaryDirectory.url,
+            largeAllocatedSizeThreshold: 1
+        ).analyze()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: file.path))
+        XCTAssertEqual(try Data(contentsOf: file), originalData)
+        XCTAssertEqual(try systemLibraryStatMode(for: file.path), originalMode)
+    }
+}
+
+private final class SystemLibraryTestDirectory {
+    let url: URL
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMac-SystemLibraryAnalyzerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+private func makeSystemLibraryAnalyzer(
+    root: URL,
+    scanner: FileTreeScanner = FileTreeScanner(),
+    largeAllocatedSizeThreshold: Int64 = SystemLibraryAnalyzer.defaultLargeAllocatedSizeThreshold
+) -> SystemLibraryAnalyzer {
+    SystemLibraryAnalyzer(
+        systemLibraryURL: root,
+        scanner: scanner,
+        largeAllocatedSizeThreshold: largeAllocatedSizeThreshold
+    )
+}
+
+@discardableResult
+private func makeSystemLibraryDirectory(
+    named name: String,
+    fileSize: Int,
+    in root: URL
+) throws -> URL {
+    let directory = root.appendingPathComponent(name, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+    try Data(repeating: UInt8(fileSize % 251), count: fileSize).write(
+        to: directory.appendingPathComponent("payload.dat")
+    )
+    return directory
+}
+
+private func systemLibraryNode(at path: String, in root: StorageNode) -> StorageNode? {
+    var pending = [root]
+    while let candidate = pending.popLast() {
+        if candidate.absolutePath == path { return candidate }
+        pending.append(contentsOf: candidate.children)
+    }
+    return nil
+}
+
+private func flattenedSystemLibraryTree(_ root: StorageNode) -> [StorageNode] {
+    var nodes: [StorageNode] = []
+    var pending = [root]
+    while let node = pending.popLast() {
+        nodes.append(node)
+        pending.append(contentsOf: node.children)
+    }
+    return nodes
+}
+
+private func systemLibraryOrdering(_ left: StorageNode, _ right: StorageNode) -> Bool {
+    if left.allocatedSize != right.allocatedSize {
+        return left.allocatedSize > right.allocatedSize
+    }
+    if left.logicalSize != right.logicalSize {
+        return left.logicalSize > right.logicalSize
+    }
+    return left.absolutePath < right.absolutePath
+}
+
+private func syntheticSystemLibraryNode(
+    name: String,
+    path: String,
+    logicalSize: Int64,
+    allocatedSize: Int64,
+    ownLogicalSize: Int64,
+    ownAllocatedSize: Int64,
+    itemType: StorageItemType,
+    children: [StorageNode] = [],
+    accessibility: StorageAccessibility = .accessible,
+    issues: [StorageScanIssue] = [],
+    isCounted: Bool = true
+) -> StorageNode {
+    StorageNode(
+        name: name,
+        absolutePath: path,
+        logicalSize: logicalSize,
+        allocatedSize: allocatedSize,
+        ownLogicalSize: ownLogicalSize,
+        ownAllocatedSize: ownAllocatedSize,
+        itemType: itemType,
+        children: children,
+        accessibility: accessibility,
+        scanIssues: issues,
+        isHidden: false,
+        isSymbolicLink: false,
+        isCountedInParentTotals: isCounted,
+        metadata: StorageAnalysisMetadata()
+    )
+}
+
+private func systemLibraryStatValues(for path: String) throws -> (logical: Int64, allocated: Int64) {
+    var metadata = stat()
+    guard lstat(path, &metadata) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: Darwin.errno) ?? .EIO)
+    }
+    return (
+        logical: Int64(metadata.st_size),
+        allocated: Int64(metadata.st_blocks) * 512
+    )
+}
+
+private func systemLibraryStatMode(for path: String) throws -> mode_t {
+    var metadata = stat()
+    guard lstat(path, &metadata) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: Darwin.errno) ?? .EIO)
+    }
+    return metadata.st_mode
+}

--- a/PureMacTests/TargetedCoverageGapMeasurementTests.swift
+++ b/PureMacTests/TargetedCoverageGapMeasurementTests.swift
@@ -1,0 +1,503 @@
+import XCTest
+@testable import PureMac
+
+final class TargetedCoverageGapMeasurementTests: XCTestCase {
+    private var tempDirectory: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TargetedCoverageGapMeasurementTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempDirectory {
+            try? FileManager.default.removeItem(at: tempDirectory)
+        }
+        super.tearDown()
+    }
+
+    // MARK: - 1. Hidden Home Gap Measured
+    func testHiddenHomeGapMeasured() async throws {
+        let fakeHome = tempDirectory.appendingPathComponent("UserHome")
+        let hiddenCache = fakeHome.appendingPathComponent(".test_cache")
+        try FileManager.default.createDirectory(at: hiddenCache, withIntermediateDirectories: true)
+
+        let testFile = hiddenCache.appendingPathComponent("data.bin")
+        let testData = Data(repeating: 0xAB, count: 64 * 1024) // 64 KB
+        try testData.write(to: testFile)
+
+        let analyzer = CoverageExpansionAnalyzer(
+            homeDirectoryURL: fakeHome,
+            dataVolumeURL: tempDirectory.appendingPathComponent("FakeDataVolume")
+        )
+        let report = await analyzer.analyze()
+
+        let candidate = report.candidates.first { $0.name == ".test_cache" }
+        XCTAssertNotNil(candidate)
+        XCTAssertEqual(candidate?.scope, .hiddenHome)
+        XCTAssertEqual(candidate?.status, .measured)
+        XCTAssertTrue(candidate?.contributesToExplainedBytes == true)
+        XCTAssertGreaterThan(candidate?.allocatedBytes ?? 0, 0)
+    }
+
+    // MARK: - 2. Unspecialized ~/Library Gap Measured
+    func testUnspecializedUserLibraryGapMeasured() async throws {
+        let fakeHome = tempDirectory.appendingPathComponent("UserHome")
+        let libraryURL = fakeHome.appendingPathComponent("Library")
+        let customCache = libraryURL.appendingPathComponent("CustomFrameworkCache")
+        try FileManager.default.createDirectory(at: customCache, withIntermediateDirectories: true)
+
+        let fileURL = customCache.appendingPathComponent("cache.db")
+        let data = Data(repeating: 0x55, count: 128 * 1024)
+        try data.write(to: fileURL)
+
+        let analyzer = CoverageExpansionAnalyzer(
+            homeDirectoryURL: fakeHome,
+            dataVolumeURL: tempDirectory.appendingPathComponent("FakeDataVolume")
+        )
+        let report = await analyzer.analyze()
+
+        let candidate = report.candidates.first { $0.name == "CustomFrameworkCache" }
+        XCTAssertNotNil(candidate)
+        XCTAssertEqual(candidate?.scope, .userLibrary)
+        XCTAssertEqual(candidate?.status, .measured)
+        XCTAssertTrue(candidate?.contributesToExplainedBytes == true)
+        XCTAssertGreaterThan(candidate?.allocatedBytes ?? 0, 0)
+    }
+
+    // MARK: - 3. Specialized Library Roots Excluded
+    func testSpecializedUserLibraryRootsExcluded() async throws {
+        let fakeHome = tempDirectory.appendingPathComponent("UserHome")
+        let libraryURL = fakeHome.appendingPathComponent("Library")
+        let appSupport = libraryURL.appendingPathComponent("Application Support")
+        let containers = libraryURL.appendingPathComponent("Containers")
+        let groupContainers = libraryURL.appendingPathComponent("Group Containers")
+
+        try FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: containers, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: groupContainers, withIntermediateDirectories: true)
+
+        let appSupportFile = appSupport.appendingPathComponent("app.data")
+        try Data(repeating: 0x11, count: 10 * 1024).write(to: appSupportFile)
+
+        let analyzer = CoverageExpansionAnalyzer(
+            homeDirectoryURL: fakeHome,
+            dataVolumeURL: tempDirectory.appendingPathComponent("FakeDataVolume")
+        )
+        let report = await analyzer.analyze()
+
+        let appSupportCandidate = report.candidates.first { $0.name == "Application Support" }
+        let containersCandidate = report.candidates.first { $0.name == "Containers" }
+        let groupContainersCandidate = report.candidates.first { $0.name == "Group Containers" }
+
+        XCTAssertNil(appSupportCandidate, "Application Support must be excluded from unspecialized gaps")
+        XCTAssertNil(containersCandidate, "Containers must be excluded from unspecialized gaps")
+        XCTAssertNil(groupContainersCandidate, "Group Containers must be excluded from unspecialized gaps")
+    }
+
+    // MARK: - 4. Already-Owned Path Excluded
+    func testAlreadyOwnedPathExcluded() async throws {
+        let fakeHome = tempDirectory.appendingPathComponent("UserHome")
+        let hiddenFolder = fakeHome.appendingPathComponent(".already_owned_tool")
+        try FileManager.default.createDirectory(at: hiddenFolder, withIntermediateDirectories: true)
+
+        let file = hiddenFolder.appendingPathComponent("config.json")
+        try Data(repeating: 0x22, count: 4096).write(to: file)
+
+        let analyzer = CoverageExpansionAnalyzer(
+            homeDirectoryURL: fakeHome,
+            dataVolumeURL: tempDirectory.appendingPathComponent("FakeDataVolume"),
+            extraExcludedCanonicalPaths: [hiddenFolder.path]
+        )
+        let report = await analyzer.analyze()
+
+        let candidate = report.candidates.first { $0.name == ".already_owned_tool" }
+        XCTAssertNotNil(candidate)
+        XCTAssertEqual(candidate?.status, .excludedAlreadyAccounted)
+        XCTAssertFalse(candidate?.contributesToExplainedBytes ?? true)
+        XCTAssertEqual(candidate?.allocatedBytes, nil)
+    }
+
+    // MARK: - 5. Canonical Alias Normalization and Deduplication
+    func testCanonicalAliasNormalizationAndDeduplication() {
+        let path1 = "/System/Volumes/Data/private/var/log"
+        let path2 = "/private/var/log"
+        let path3 = "/var/log"
+
+        let norm1 = StoragePathNormalizer.normalize(path1)
+        let norm2 = StoragePathNormalizer.normalize(path2)
+        let norm3 = StoragePathNormalizer.normalize(path3)
+
+        XCTAssertEqual(norm1, "/private/var/log")
+        XCTAssertEqual(norm2, "/private/var/log")
+        XCTAssertEqual(norm3, "/private/var/log")
+        XCTAssertTrue(StoragePathNormalizer.pathsOverlap(path1, path2))
+        XCTAssertTrue(StoragePathNormalizer.pathsOverlap(path2, path3))
+    }
+
+    // MARK: - 6. Ancestor and Descendant Overlap Prevention via Coordinator
+    func testAncestorDescendantOverlapPrevention() async {
+        let childCandidate = StorageCoverageCandidate(
+            originalPath: "/Users/test/Documents/Subfolder",
+            normalizedPath: "/Users/test/Documents/Subfolder",
+            name: "Subfolder",
+            scope: .other,
+            status: .measured,
+            allocatedBytes: 20_000_000,
+            logicalBytes: 20_000_000,
+            issue: nil,
+            exclusionReason: nil,
+            contributesToExplainedBytes: true
+        )
+
+        let expansionReport = StorageCoverageExpansionReport(
+            totalNewlyMeasuredBytes: 20_000_000,
+            measuredCandidateCount: 1,
+            excludedOverlapCount: 0,
+            inaccessibleCandidateCount: 0,
+            differentVolumeBoundaryCount: 0,
+            failedCandidateCount: 0,
+            candidates: [childCandidate],
+            largestDiscoveredRegions: [childCandidate],
+            treeResults: [],
+            wasCancelled: false,
+            issues: []
+        )
+
+        let userHome = UserHomeStorageAnalyzer.makeReport(
+            makeResult(path: "/Users/test", allocated: 100_000_000, children: [makeNode(path: "/Users/test/Documents", allocated: 100_000_000)]),
+            homeDirectoryURL: URL(fileURLWithPath: "/Users/test"),
+            largeAllocatedSizeThreshold: 1_073_741_824
+        )
+        let coordinator = makeStubCoordinator(userHome: userHome, coverageExpansion: expansionReport)
+        let report = await coordinator.analyze()
+
+        let parentContrib = report.filesystemContributions.first { $0.normalizedPath == "/Users/test/Documents" }
+        let childContrib = report.filesystemContributions.first { $0.normalizedPath == "/Users/test/Documents/Subfolder" }
+
+        XCTAssertEqual(parentContrib?.relationship, .canonicalUnique)
+        XCTAssertEqual(parentContrib?.accountedAllocatedBytes, 100_000_000)
+
+        XCTAssertEqual(childContrib?.relationship, .excludedNestedPath)
+        XCTAssertEqual(childContrib?.accountedAllocatedBytes, 0, "Nested child must not double-count bytes")
+    }
+
+    // MARK: - 7. Hard Links Do Not Double Count
+    func testHardLinksDoNotDoubleCount() async throws {
+        let fakeHome = tempDirectory.appendingPathComponent("UserHome")
+        let hiddenFolder = fakeHome.appendingPathComponent(".test_hardlinks")
+        try FileManager.default.createDirectory(at: hiddenFolder, withIntermediateDirectories: true)
+
+        let originalFile = hiddenFolder.appendingPathComponent("original.bin")
+        let linkedFile = hiddenFolder.appendingPathComponent("hardlink.bin")
+
+        let fileData = Data(repeating: 0x99, count: 50 * 1024) // 50 KB
+        try fileData.write(to: originalFile)
+        try FileManager.default.linkItem(at: originalFile, to: linkedFile)
+
+        let analyzer = CoverageExpansionAnalyzer(
+            homeDirectoryURL: fakeHome,
+            dataVolumeURL: tempDirectory.appendingPathComponent("FakeDataVolume")
+        )
+        let report = await analyzer.analyze()
+
+        let candidate = report.candidates.first { $0.name == ".test_hardlinks" }
+        XCTAssertNotNil(candidate)
+        XCTAssertEqual(candidate?.status, .measured)
+        XCTAssertLessThanOrEqual(candidate?.allocatedBytes ?? 0, 65536)
+    }
+
+    // MARK: - 8. Symlinks Are Not Followed
+    func testSymlinksAreNotFollowed() async throws {
+        let fakeHome = tempDirectory.appendingPathComponent("UserHome")
+        try FileManager.default.createDirectory(at: fakeHome, withIntermediateDirectories: true)
+
+        let targetDir = tempDirectory.appendingPathComponent("ExternalBigFolder")
+        try FileManager.default.createDirectory(at: targetDir, withIntermediateDirectories: true)
+        try Data(repeating: 0x44, count: 1024 * 1024).write(to: targetDir.appendingPathComponent("big.bin"))
+
+        let symlinkURL = fakeHome.appendingPathComponent(".symlink_gap")
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: targetDir)
+
+        let analyzer = CoverageExpansionAnalyzer(
+            homeDirectoryURL: fakeHome,
+            dataVolumeURL: tempDirectory.appendingPathComponent("FakeDataVolume")
+        )
+        let report = await analyzer.analyze()
+
+        let candidate = report.candidates.first { $0.name == ".symlink_gap" }
+        XCTAssertNotNil(candidate)
+        XCTAssertEqual(candidate?.status, .excludedSymlink)
+        XCTAssertFalse(candidate?.contributesToExplainedBytes ?? true)
+        XCTAssertEqual(candidate?.allocatedBytes, nil)
+    }
+
+    // MARK: - 9. Filesystem Boundaries Enforced
+    func testFilesystemBoundariesEnforced() {
+        let candidate = StorageCoverageCandidate(
+            originalPath: "/Volumes/External/Data",
+            normalizedPath: "/Volumes/External/Data",
+            name: "Data",
+            scope: .other,
+            status: .excludedDifferentVolume,
+            allocatedBytes: nil,
+            logicalBytes: nil,
+            issue: nil,
+            exclusionReason: "Located on a different filesystem volume boundary.",
+            contributesToExplainedBytes: false
+        )
+
+        XCTAssertFalse(candidate.contributesToExplainedBytes)
+        XCTAssertEqual(candidate.status, .excludedDifferentVolume)
+    }
+
+    // MARK: - 10. Inaccessible Gap Contributes Zero Fabricated Bytes
+    func testInaccessibleGapContributesZeroFabricatedBytes() {
+        let candidate = StorageCoverageCandidate(
+            originalPath: "/Library/Application Support/Restricted",
+            normalizedPath: "/Library/Application Support/Restricted",
+            name: "Restricted",
+            scope: .userLibrary,
+            status: .inaccessible,
+            allocatedBytes: 0,
+            logicalBytes: 0,
+            issue: StorageScanIssue(path: "/Library/Application Support/Restricted", kind: .permissionDenied, message: "Permission denied", posixErrorCode: 13),
+            exclusionReason: "Permission denied.",
+            contributesToExplainedBytes: false
+        )
+
+        XCTAssertFalse(candidate.contributesToExplainedBytes)
+        XCTAssertEqual(candidate.status, .inaccessible)
+        XCTAssertEqual(candidate.allocatedBytes, 0)
+    }
+
+    // MARK: - 11. Cancellation Handling
+    func testCancellationHandling() async {
+        let task = Task { () -> StorageCoverageExpansionReport in
+            let fakeHome = self.tempDirectory.appendingPathComponent("UserHome")
+            let analyzer = CoverageExpansionAnalyzer(homeDirectoryURL: fakeHome)
+            return await analyzer.analyze()
+        }
+        task.cancel()
+        let report = await task.value
+        XCTAssertTrue(report.wasCancelled || report.candidates.isEmpty)
+    }
+
+    // MARK: - 12. Deterministic Ordering
+    func testDeterministicOrdering() {
+        let statusList: [StorageCoverageCandidateStatus] = [
+            .eligible, .measured, .partiallyMeasured, .inaccessible,
+            .skippedAlreadyOwned, .skippedNonAdditive, .skippedUnsafeOverlap,
+            .excludedAlreadyAccounted, .excludedNested, .excludedSymlink,
+            .excludedDifferentVolume, .excludedProtectedSystem, .failed, .cancelled
+        ]
+
+        for status in statusList {
+            XCTAssertFalse(status.displayName.isEmpty)
+        }
+        XCTAssertTrue(StorageCoverageCandidateStatus.measured.isMeasuredOrPartial)
+        XCTAssertTrue(StorageCoverageCandidateStatus.partiallyMeasured.isMeasuredOrPartial)
+        XCTAssertFalse(StorageCoverageCandidateStatus.inaccessible.isMeasuredOrPartial)
+    }
+
+    // MARK: - 13. Reconciliation Additive Math
+    func testReconciliationAdditiveMath() async {
+        let gapCandidate = StorageCoverageCandidate(
+            originalPath: "/Users/test/.test_cache",
+            normalizedPath: "/Users/test/.test_cache",
+            name: ".test_cache",
+            scope: .hiddenHome,
+            status: .measured,
+            allocatedBytes: 25_000_000,
+            logicalBytes: 25_000_000,
+            issue: nil,
+            exclusionReason: nil,
+            contributesToExplainedBytes: true
+        )
+
+        let expansionReport = StorageCoverageExpansionReport(
+            totalNewlyMeasuredBytes: 25_000_000,
+            measuredCandidateCount: 1,
+            excludedOverlapCount: 0,
+            inaccessibleCandidateCount: 0,
+            differentVolumeBoundaryCount: 0,
+            failedCandidateCount: 0,
+            candidates: [gapCandidate],
+            largestDiscoveredRegions: [gapCandidate],
+            treeResults: [],
+            wasCancelled: false,
+            issues: []
+        )
+
+        let userHome = UserHomeStorageAnalyzer.makeReport(
+            makeResult(path: "/Users/test", allocated: 100_000_000, children: [makeNode(path: "/Users/test/Documents", allocated: 100_000_000)]),
+            homeDirectoryURL: URL(fileURLWithPath: "/Users/test"),
+            largeAllocatedSizeThreshold: 1_073_741_824
+        )
+        let coordinator = makeStubCoordinator(
+            userHome: userHome,
+            apfs: makeAPFSReport(used: 200_000_000),
+            coverageExpansion: expansionReport
+        )
+
+        let report = await coordinator.analyze()
+
+        XCTAssertEqual(report.explainedAllocatedBytes, 125_000_000)
+        XCTAssertEqual(report.unexplainedBytes, 75_000_000)
+    }
+
+    // MARK: - 14. Non-Additive APFS and Docker Preservation
+    func testNonAdditiveAPFSAndDockerPreservation() async {
+        let coordinator = makeStubCoordinator(
+            apfs: makeAPFSReport(used: 200_000_000, snapshotSize: 15_000_000)
+        )
+
+        let report = await coordinator.analyze()
+
+        XCTAssertEqual(report.analyzerResults.apfsStorage?.snapshots.first?.size, 15_000_000)
+        XCTAssertEqual(report.explainedAllocatedBytes, 0)
+        XCTAssertEqual(report.unexplainedBytes, 200_000_000)
+    }
+
+    // MARK: - 15. Read-Only Verification
+    func testReadOnlyVerification() async throws {
+        let fakeHome = tempDirectory.appendingPathComponent("UserHome")
+        let hiddenDir = fakeHome.appendingPathComponent(".read_only_test")
+        try FileManager.default.createDirectory(at: hiddenDir, withIntermediateDirectories: true)
+        let sampleFile = hiddenDir.appendingPathComponent("file.txt")
+        let originalContent = "PureMac read-only invariant test"
+        try originalContent.write(to: sampleFile, atomically: true, encoding: .utf8)
+
+        let initialAttrs = try FileManager.default.attributesOfItem(atPath: sampleFile.path)
+        let initialModDate = initialAttrs[.modificationDate] as? Date
+
+        let analyzer = CoverageExpansionAnalyzer(homeDirectoryURL: fakeHome)
+        _ = await analyzer.analyze()
+
+        let postAttrs = try FileManager.default.attributesOfItem(atPath: sampleFile.path)
+        let postModDate = postAttrs[.modificationDate] as? Date
+        let postContent = try String(contentsOf: sampleFile, encoding: .utf8)
+
+        XCTAssertEqual(originalContent, postContent)
+        XCTAssertEqual(initialModDate, postModDate)
+    }
+
+    // MARK: - Helpers
+    private func makeResult(
+        path: String,
+        allocated: Int64,
+        children: [StorageNode] = []
+    ) -> StorageAnalysisResult {
+        let date = Date(timeIntervalSince1970: 1)
+        return StorageAnalysisResult(
+            root: makeNode(path: path, allocated: allocated, children: children),
+            startedAt: date,
+            completedAt: date,
+            rootDeviceIdentifier: 1,
+            wasCancelled: false,
+            issues: []
+        )
+    }
+
+    private func makeNode(
+        path: String,
+        allocated: Int64,
+        children: [StorageNode] = []
+    ) -> StorageNode {
+        StorageNode(
+            name: URL(fileURLWithPath: path).lastPathComponent,
+            absolutePath: path,
+            logicalSize: allocated,
+            allocatedSize: allocated,
+            ownLogicalSize: allocated,
+            ownAllocatedSize: allocated,
+            itemType: .directory,
+            children: children,
+            accessibility: .accessible,
+            scanIssues: [],
+            isHidden: false,
+            isSymbolicLink: false,
+            isCountedInParentTotals: true,
+            metadata: StorageAnalysisMetadata()
+        )
+    }
+
+    private func makeAPFSReport(used: Int64, snapshotSize: Int64? = nil) -> APFSStorageReport {
+        let snapshot = snapshotSize.map {
+            APFSSnapshotInformation(
+                identifier: "snapshot",
+                name: "snapshot",
+                uuid: nil,
+                creationDate: nil,
+                size: $0,
+                sizeKnowledge: .reportedBySystem,
+                type: .timeMachine,
+                source: .diskutil,
+                storageRelationship: .sharedNonAdditive
+            )
+        }
+        return APFSStorageReport(
+            volume: APFSVolumeInformation(
+                name: "Data",
+                volumeIdentifier: "disk-test",
+                volumeUUID: nil,
+                containerIdentifier: nil,
+                volumeGroupIdentifier: nil,
+                filesystemType: "apfs",
+                filesystemKind: .apfs,
+                mountPoint: "/",
+                dataVolumeRelationship: .dataVolume,
+                capacity: APFSVolumeCapacity(
+                    totalCapacity: used + 200,
+                    availableCapacity: 200,
+                    usedCapacity: used,
+                    availableCapacityForImportantUsage: 300,
+                    availableCapacityForOpportunisticUsage: nil,
+                    purgeableEstimate: 100,
+                    purgeableEstimateKnowledge: .estimated
+                )
+            ),
+            snapshots: snapshot.map { [$0] } ?? [],
+            state: .complete,
+            accountingRelationship: .volumeMetadataAndSnapshotsAreNonAdditiveToFilesystemTrees,
+            wasCancelled: false,
+            issues: []
+        )
+    }
+
+    private struct TestFailure: Error {}
+
+    private func makeStubCoordinator(
+        userHome: UserHomeStorageReport? = nil,
+        apfs: APFSStorageReport? = nil,
+        coverageExpansion: StorageCoverageExpansionReport? = nil
+    ) -> StorageAnalysisCoordinator {
+        StorageAnalysisCoordinator(
+            maxConcurrentAnalyzers: 2,
+            userHomeStorageAnalysis: {
+                guard let userHome else { throw TestFailure() }
+                return userHome
+            },
+            applicationsAnalysis: { throw TestFailure() },
+            applicationSupportAnalysis: { throw TestFailure() },
+            containersAnalysis: { throw TestFailure() },
+            groupContainersAnalysis: { throw TestFailure() },
+            systemLibraryAnalysis: { throw TestFailure() },
+            privateStorageAnalysis: { throw TestFailure() },
+            dataVolumeHiddenStorageAnalysis: { throw TestFailure() },
+            developerSystemStorageAnalysis: { throw TestFailure() },
+            dockerStorageAnalysis: { throw TestFailure() },
+            apfsStorageAnalysis: {
+                guard let apfs else { throw TestFailure() }
+                return apfs
+            },
+            coverageExpansionAnalysis: {
+                guard let coverageExpansion else { throw TestFailure() }
+                return coverageExpansion
+            },
+            coverageDiscovery: { .empty(homeDirectoryPath: "/Users/test") }
+        )
+    }
+}

--- a/PureMacTests/UserHomeStorageAnalyzerTests.swift
+++ b/PureMacTests/UserHomeStorageAnalyzerTests.swift
@@ -1,0 +1,441 @@
+import Darwin
+import XCTest
+@testable import PureMac
+
+final class UserHomeStorageAnalyzerTests: XCTestCase {
+    func testDesktopIsAnalyzed() async throws {
+        try await assertStandardDirectory(.desktop)
+    }
+
+    func testDocumentsIsAnalyzed() async throws {
+        try await assertStandardDirectory(.documents)
+    }
+
+    func testDownloadsIsAnalyzed() async throws {
+        try await assertStandardDirectory(.downloads)
+    }
+
+    func testMoviesIsAnalyzed() async throws {
+        try await assertStandardDirectory(.movies)
+    }
+
+    func testMusicIsAnalyzed() async throws {
+        try await assertStandardDirectory(.music)
+    }
+
+    func testPicturesIsAnalyzed() async throws {
+        try await assertStandardDirectory(.pictures)
+    }
+
+    func testPublicIsAnalyzed() async throws {
+        try await assertStandardDirectory(.public)
+    }
+
+    func testCustomVisibleHomeFolderIsAnalyzedWithoutCleanupClassification() async throws {
+        let home = try UserHomeTestDirectory()
+        let projects = try makeFolder(named: "Projects", fileSize: 4_096, in: home.url)
+
+        let report = await makeAnalyzer(home: home.url).analyze()
+        let root = try XCTUnwrap(report.roots.first { $0.node.absolutePath == projects.path })
+
+        XCTAssertNil(root.standardDirectory)
+        XCTAssertEqual(root.node.metadata.attributes[UserHomeStorageAnalyzer.MetadataKey.rootKind], "custom")
+        XCTAssertNil(root.node.metadata.safetyClassificationIdentifier)
+        XCTAssertTrue(root.node.metadata.explanation?.contains("no cleanup classification") == true)
+    }
+
+    func testHiddenTopLevelFolderIsExcluded() async throws {
+        let home = try UserHomeTestDirectory()
+        let hidden = try makeFolder(named: ".private-project", fileSize: 8_192, in: home.url)
+
+        let report = await makeAnalyzer(home: home.url).analyze()
+
+        XCTAssertNil(storageNode(at: hidden.path, in: report.result.root))
+        XCTAssertFalse(report.roots.contains { $0.node.absolutePath == hidden.path })
+    }
+
+    func testLibraryIsNotRecursivelyScanned() async throws {
+        let home = try UserHomeTestDirectory()
+        let library = home.url.appendingPathComponent("Library", isDirectory: true)
+        let support = library.appendingPathComponent("Application Support", isDirectory: true)
+        try FileManager.default.createDirectory(at: support, withIntermediateDirectories: true)
+        let payload = support.appendingPathComponent("large.dat")
+        try Data(repeating: 0x31, count: 1_048_576).write(to: payload)
+        _ = try makeFolder(named: "Documents", fileSize: 1_024, in: home.url)
+
+        let report = await makeAnalyzer(home: home.url).analyze()
+
+        XCTAssertNil(storageNode(at: library.path, in: report.result.root))
+        XCTAssertNil(storageNode(at: payload.path, in: report.result.root))
+        XCTAssertLessThan(report.combinedUniqueLogicalSize, 1_048_576)
+    }
+
+    func testSpecializedLibraryRootsAreExplicitlyExcluded() async throws {
+        let home = try UserHomeTestDirectory()
+        let report = await makeAnalyzer(home: home.url).analyze()
+        let library = home.url.appendingPathComponent("Library", isDirectory: true)
+
+        XCTAssertEqual(Set(report.excludedCanonicalPaths), Set([
+            library.path,
+            library.appendingPathComponent("Application Support").path,
+            library.appendingPathComponent("Containers").path,
+            library.appendingPathComponent("Group Containers").path,
+        ]))
+    }
+
+    func testTopLevelRootsSortByAllocatedSizeDescending() async throws {
+        let home = try UserHomeTestDirectory()
+        _ = try makeFolder(named: "Small", fileSize: 4_096, in: home.url)
+        _ = try makeFolder(named: "Large", fileSize: 1_048_576, in: home.url)
+        _ = try makeFolder(named: "Medium", fileSize: 131_072, in: home.url)
+
+        let report = await UserHomeStorageAnalyzer(
+            homeDirectoryURL: home.url,
+            largeAllocatedSizeThreshold: 1
+        ).analyze()
+
+        XCTAssertEqual(report.roots.map(\.node.name), ["Large", "Medium", "Small"])
+        XCTAssertTrue(zip(report.roots, report.roots.dropFirst()).allSatisfy {
+            $0.node.allocatedSize >= $1.node.allocatedSize
+        })
+        XCTAssertTrue(report.roots.allSatisfy { $0.node.metadata.isUnusuallyLarge == true })
+    }
+
+    func testCompleteHierarchyIsPreserved() async throws {
+        let home = try UserHomeTestDirectory()
+        let documents = home.url.appendingPathComponent("Documents", isDirectory: true)
+        let project = documents.appendingPathComponent("Project", isDirectory: true)
+        let nested = project.appendingPathComponent("Sources", isDirectory: true)
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        let file = nested.appendingPathComponent("main.swift")
+        try Data(repeating: 0x42, count: 2_048).write(to: file)
+
+        let report = await makeAnalyzer(home: home.url).analyze()
+
+        XCTAssertNotNil(storageNode(at: documents.path, in: report.result.root))
+        XCTAssertNotNil(storageNode(at: project.path, in: report.result.root))
+        XCTAssertNotNil(storageNode(at: nested.path, in: report.result.root))
+        XCTAssertEqual(storageNode(at: file.path, in: report.result.root)?.ownLogicalSize, 2_048)
+    }
+
+    func testHiddenDescendantsWithinVisibleFolderAreIncluded() async throws {
+        let home = try UserHomeTestDirectory()
+        let documents = try makeFolder(named: "Documents", fileSize: 0, in: home.url)
+        let hidden = documents.appendingPathComponent(".project-state")
+        try Data(repeating: 0x43, count: 1_024).write(to: hidden)
+
+        let report = await makeAnalyzer(home: home.url).analyze()
+        let node = try XCTUnwrap(storageNode(at: hidden.path, in: report.result.root))
+
+        XCTAssertTrue(node.isHidden)
+        XCTAssertEqual(node.ownLogicalSize, 1_024)
+    }
+
+    func testLogicalAndAllocatedSizesMatchFilesystemMetadata() async throws {
+        let home = try UserHomeTestDirectory()
+        let documents = try makeFolder(named: "Documents", fileSize: 0, in: home.url)
+        let file = documents.appendingPathComponent("data.bin")
+        try Data(repeating: 0x44, count: 70_000).write(to: file)
+        let expected = try userHomeStatValues(for: file.path)
+
+        let report = await makeAnalyzer(home: home.url).analyze()
+        let node = try XCTUnwrap(storageNode(at: file.path, in: report.result.root))
+
+        XCTAssertEqual(node.ownLogicalSize, expected.logical)
+        XCTAssertEqual(node.ownAllocatedSize, expected.allocated)
+    }
+
+    func testSparseFilePreservesLogicalAndAllocatedDistinction() async throws {
+        let home = try UserHomeTestDirectory()
+        let movies = try makeFolder(named: "Movies", fileSize: 0, in: home.url)
+        let disk = movies.appendingPathComponent("virtual-machine.raw")
+        XCTAssertTrue(FileManager.default.createFile(atPath: disk.path, contents: nil))
+        let handle = try FileHandle(forWritingTo: disk)
+        try handle.truncate(atOffset: 32 * 1_024 * 1_024)
+        try handle.close()
+
+        let report = await makeAnalyzer(home: home.url).analyze()
+        let node = try XCTUnwrap(storageNode(at: disk.path, in: report.result.root))
+
+        XCTAssertEqual(node.ownLogicalSize, 32 * 1_024 * 1_024)
+        XCTAssertLessThanOrEqual(node.ownAllocatedSize, node.ownLogicalSize)
+        if node.ownAllocatedSize >= node.ownLogicalSize {
+            throw XCTSkip("The test filesystem eagerly allocated the sparse file.")
+        }
+    }
+
+    func testSymbolicLinkIsVisibleButTargetIsNotTraversed() async throws {
+        let home = try UserHomeTestDirectory()
+        let outside = try UserHomeTestDirectory()
+        let documents = try makeFolder(named: "Documents", fileSize: 0, in: home.url)
+        let target = try makeFolder(named: "Target", fileSize: 1_048_576, in: outside.url)
+        let link = documents.appendingPathComponent("External")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        let report = await makeAnalyzer(home: home.url).analyze()
+        let node = try XCTUnwrap(storageNode(at: link.path, in: report.result.root))
+
+        XCTAssertTrue(node.isSymbolicLink)
+        XCTAssertEqual(node.itemType, .symbolicLink)
+        XCTAssertTrue(node.children.isEmpty)
+        XCTAssertNil(storageNode(at: target.appendingPathComponent("payload.dat").path, in: report.result.root))
+    }
+
+    func testHardLinksAcrossVisibleRootsAreCountedOnce() async throws {
+        let home = try UserHomeTestDirectory()
+        let documents = try makeFolder(named: "Documents", fileSize: 0, in: home.url)
+        let downloads = try makeFolder(named: "Downloads", fileSize: 0, in: home.url)
+        let original = documents.appendingPathComponent("shared.dat")
+        let link = downloads.appendingPathComponent("shared.dat")
+        try Data(repeating: 0x45, count: 16_384).write(to: original)
+        try FileManager.default.linkItem(at: original, to: link)
+
+        let report = await makeAnalyzer(home: home.url).analyze()
+        let nodes = [
+            try XCTUnwrap(storageNode(at: original.path, in: report.result.root)),
+            try XCTUnwrap(storageNode(at: link.path, in: report.result.root)),
+        ]
+
+        XCTAssertEqual(nodes.filter(\.isCountedInParentTotals).count, 1)
+        XCTAssertEqual(
+            nodes.filter(\.isCountedInParentTotals).reduce(Int64(0)) { $0 + $1.ownAllocatedSize },
+            nodes[0].ownAllocatedSize
+        )
+    }
+
+    func testFilesystemBoundaryStateIsPreservedWithoutBytes() throws {
+        let home = URL(fileURLWithPath: "/Users/test")
+        let issue = StorageScanIssue(
+            path: "/Users/test/ExternalVolume",
+            kind: .differentVolume,
+            message: "Skipped mounted filesystem.",
+            posixErrorCode: nil
+        )
+        let boundary = syntheticUserHomeNode(
+            path: issue.path,
+            itemType: .volumeBoundary,
+            accessibility: .skippedDifferentVolume,
+            issues: [issue],
+            isCounted: false
+        )
+        let input = syntheticUserHomeResult(home: home, children: [boundary], issues: [issue])
+
+        let report = UserHomeStorageAnalyzer.makeReport(
+            input,
+            homeDirectoryURL: home,
+            largeAllocatedSizeThreshold: 1
+        )
+        let preserved = try XCTUnwrap(report.roots.first?.node)
+
+        XCTAssertEqual(preserved.itemType, .volumeBoundary)
+        XCTAssertEqual(preserved.accessibility, .skippedDifferentVolume)
+        XCTAssertEqual(preserved.allocatedSize, 0)
+        XCTAssertEqual(report.issues.first?.kind, .differentVolume)
+    }
+
+    func testPermissionDeniedFolderIsReported() async throws {
+        guard geteuid() != 0 else { throw XCTSkip("Root can read mode-000 directories.") }
+        let home = try UserHomeTestDirectory()
+        let documents = try makeFolder(named: "Documents", fileSize: 0, in: home.url)
+        let protected = try makeFolder(named: "Protected", fileSize: 128, in: documents)
+        XCTAssertEqual(chmod(protected.path, 0), 0)
+        defer { _ = chmod(protected.path, mode_t(S_IRWXU)) }
+
+        let report = await makeAnalyzer(home: home.url).analyze()
+        let node = try XCTUnwrap(storageNode(at: protected.path, in: report.result.root))
+
+        XCTAssertEqual(node.accessibility, .inaccessible)
+        XCTAssertTrue(report.issues.contains {
+            $0.path == protected.path && $0.kind == .permissionDenied
+        })
+    }
+
+    func testCancellationReturnsPartialMarkedReport() async throws {
+        let home = try UserHomeTestDirectory()
+        let documents = try makeFolder(named: "Documents", fileSize: 0, in: home.url)
+        for index in 0..<300 {
+            _ = try makeFolder(named: "Folder-\(index)", fileSize: 64, in: documents)
+        }
+        let analyzer = makeAnalyzer(
+            home: home.url,
+            scanner: FileTreeScanner(configuration: .init(maxConcurrentDirectoryReads: 1))
+        )
+        let task = Task { await analyzer.analyze() }
+        task.cancel()
+
+        let report = await task.value
+
+        XCTAssertTrue(report.wasCancelled)
+        XCTAssertTrue(report.issues.contains { $0.kind == .cancelled })
+    }
+
+    func testMissingOptionalStandardFoldersAreExplicit() async throws {
+        let home = try UserHomeTestDirectory()
+        _ = try makeFolder(named: "Documents", fileSize: 0, in: home.url)
+
+        let report = await makeAnalyzer(home: home.url).analyze()
+
+        XCTAssertEqual(status(.documents, in: report)?.state, .present)
+        XCTAssertEqual(status(.downloads, in: report)?.state, .missing)
+        XCTAssertEqual(status(.pictures, in: report)?.state, .missing)
+    }
+
+    func testEmptyHomeReturnsNoRootsAndZeroSelectedBytes() async throws {
+        let home = try UserHomeTestDirectory()
+
+        let report = await makeAnalyzer(home: home.url).analyze()
+
+        XCTAssertTrue(report.roots.isEmpty)
+        XCTAssertEqual(report.combinedUniqueLogicalSize, 0)
+        XCTAssertEqual(report.combinedUniqueAllocatedSize, 0)
+        XCTAssertTrue(report.standardDirectories.allSatisfy { $0.state == .missing })
+    }
+
+    func testSyntheticCloudPlaceholderUsesAllocatedBytesAsLocalConsumption() async throws {
+        let home = try UserHomeTestDirectory()
+        let cloud = try makeFolder(named: "Cloud Projects", fileSize: 0, in: home.url)
+        let placeholder = cloud.appendingPathComponent("remote-video.mov")
+        XCTAssertTrue(FileManager.default.createFile(atPath: placeholder.path, contents: nil))
+        let handle = try FileHandle(forWritingTo: placeholder)
+        try handle.truncate(atOffset: 64 * 1_024 * 1_024)
+        try handle.close()
+
+        let report = await makeAnalyzer(home: home.url).analyze()
+        let node = try XCTUnwrap(storageNode(at: placeholder.path, in: report.result.root))
+
+        XCTAssertEqual(node.ownLogicalSize, 64 * 1_024 * 1_024)
+        XCTAssertLessThanOrEqual(node.ownAllocatedSize, node.ownLogicalSize)
+        XCTAssertEqual(
+            report.result.root.metadata.attributes[UserHomeStorageAnalyzer.MetadataKey.localDiskAccounting],
+            "allocated-size-only"
+        )
+    }
+
+    func testAnalysisDoesNotMutateFiles() async throws {
+        let home = try UserHomeTestDirectory()
+        let documents = try makeFolder(named: "Documents", fileSize: 0, in: home.url)
+        let file = documents.appendingPathComponent("important.txt")
+        let original = Data("do not change".utf8)
+        try original.write(to: file)
+        let attributesBefore = try FileManager.default.attributesOfItem(atPath: file.path)
+
+        _ = await makeAnalyzer(home: home.url).analyze()
+
+        XCTAssertEqual(try Data(contentsOf: file), original)
+        XCTAssertEqual(
+            attributesBefore[.size] as? NSNumber,
+            try FileManager.default.attributesOfItem(atPath: file.path)[.size] as? NSNumber
+        )
+    }
+
+    private func assertStandardDirectory(_ directory: UserHomeStandardDirectory) async throws {
+        let home = try UserHomeTestDirectory()
+        let folder = try makeFolder(named: directory.rawValue, fileSize: 1_024, in: home.url)
+
+        let report = await makeAnalyzer(home: home.url).analyze()
+        let root = try XCTUnwrap(report.roots.first { $0.node.absolutePath == folder.path })
+
+        XCTAssertEqual(root.standardDirectory, directory)
+        XCTAssertEqual(status(directory, in: report)?.state, .present)
+        XCTAssertGreaterThanOrEqual(root.node.logicalSize, 1_024)
+    }
+}
+
+private final class UserHomeTestDirectory {
+    let url: URL
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PureMac-UserHomeStorageAnalyzerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+private func makeAnalyzer(
+    home: URL,
+    scanner: FileTreeScanner = FileTreeScanner()
+) -> UserHomeStorageAnalyzer {
+    UserHomeStorageAnalyzer(homeDirectoryURL: home, scanner: scanner)
+}
+
+@discardableResult
+private func makeFolder(named name: String, fileSize: Int, in root: URL) throws -> URL {
+    let folder = root.appendingPathComponent(name, isDirectory: true)
+    try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: false)
+    if fileSize > 0 {
+        try Data(repeating: UInt8(fileSize % 251), count: fileSize).write(
+            to: folder.appendingPathComponent("payload.dat")
+        )
+    }
+    return folder
+}
+
+private func status(
+    _ directory: UserHomeStandardDirectory,
+    in report: UserHomeStorageReport
+) -> UserHomeStandardDirectoryStatus? {
+    report.standardDirectories.first { $0.directory == directory }
+}
+
+private func storageNode(at path: String, in root: StorageNode) -> StorageNode? {
+    var pending = [root]
+    while let candidate = pending.popLast() {
+        if candidate.absolutePath == path { return candidate }
+        pending.append(contentsOf: candidate.children)
+    }
+    return nil
+}
+
+private func userHomeStatValues(for path: String) throws -> (logical: Int64, allocated: Int64) {
+    var metadata = stat()
+    guard lstat(path, &metadata) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: Darwin.errno) ?? .EIO)
+    }
+    return (Int64(metadata.st_size), Int64(metadata.st_blocks) * 512)
+}
+
+private func syntheticUserHomeNode(
+    path: String,
+    itemType: StorageItemType = .directory,
+    accessibility: StorageAccessibility = .accessible,
+    issues: [StorageScanIssue] = [],
+    children: [StorageNode] = [],
+    isCounted: Bool = true
+) -> StorageNode {
+    StorageNode(
+        name: URL(fileURLWithPath: path).lastPathComponent,
+        absolutePath: path,
+        logicalSize: 0,
+        allocatedSize: 0,
+        ownLogicalSize: 0,
+        ownAllocatedSize: 0,
+        itemType: itemType,
+        children: children,
+        accessibility: accessibility,
+        scanIssues: issues,
+        isHidden: false,
+        isSymbolicLink: false,
+        isCountedInParentTotals: isCounted,
+        metadata: StorageAnalysisMetadata()
+    )
+}
+
+private func syntheticUserHomeResult(
+    home: URL,
+    children: [StorageNode],
+    issues: [StorageScanIssue]
+) -> StorageAnalysisResult {
+    let date = Date(timeIntervalSince1970: 1)
+    return StorageAnalysisResult(
+        root: syntheticUserHomeNode(path: home.path, children: children, isCounted: false),
+        startedAt: date,
+        completedAt: date,
+        rootDeviceIdentifier: 1,
+        wasCancelled: false,
+        issues: issues
+    )
+}


### PR DESCRIPTION
## Overview

This PR significantly expands PureMac's Storage Intelligence subsystem with deeper filesystem coverage, physical storage reconciliation, diagnostics, attribution, and performance improvements.

The work remains focused on read-only storage analysis. No destructive cleanup behavior was added or modified.

## Major additions

### Storage coverage & diagnostics
- Added deeper Data-volume coverage diagnostics.
- Added top-level Data-volume safety-net discovery.
- Added targeted measurement for previously uncovered filesystem regions.
- Added structured diagnostics for inaccessible and partially measured paths.
- Added evidence-based unexplained-storage attribution.

### APFS & physical reconciliation
- Added APFS physical storage reconciliation.
- Improved explained vs. unexplained physical storage accounting.
- Preserved non-additive treatment of snapshots, purgeable capacity, clones, and shared extents.
- No fabricated sizes are used for inaccessible or unknown regions.

### Canonical path handling
- Added canonical path normalization for macOS Data-volume/firmlink aliases.
- Prevents paths such as `/Applications` and `/System/Volumes/Data/Applications` from being treated as independent physical storage.

### Filesystem scan reuse
- Added a run-scoped shared scan cache.
- Added subtree reuse across overlapping analyzers.
- Added diagnostics for physical traversals, cache hits, misses, and avoided traversals.

### Applications package-boundary aggregation
Application bundles are still recursively measured for accurate logical and allocated bytes, but their internal descendants no longer need to be materialized as individual `StorageNode` objects.

Real-machine benchmark:

Before:
- Applications scan: 242.11s
- ~457,636 entries
- ~43 GB

After:
- Applications scan: 23.03s
- 2,685 materialized entries
- 42.74 GB
- 38 application bundles aggregated
- 454,970 descendants physically measured
- 454,970 StorageNode allocations avoided

This reduced the Applications stage by roughly 90% while preserving recursive byte accounting.

### Post-scan UI performance
The Storage Intelligence presentation layer was changed to avoid eagerly materializing the complete filesystem tree and search index when analysis completes.

Final real-machine result:
- 1,274,579 StorageNodes received
- 1,098 presentation nodes initially created
- 11 initially visible rows
- Search-index startup cost: ~0s
- Total post-scan presentation: 0.98s

Search is performed asynchronously/on demand instead of eagerly indexing the complete tree.

### UI stability
- Fixed a DashboardView layout feedback/recursion issue.
- Improved diagnostics presentation for incomplete coverage and unexplained storage.

## Overall real-machine performance

Initial measured full analysis:
- 713.64s (~11m 54s)

Final measured full analysis:
- 288.42s (~4m 48s)

This is approximately a 60% reduction in total wall-clock analysis time on the test machine.

Further optimization of large development trees such as `node_modules` was intentionally left out of this PR.

## Verification

- 471/471 tests passing
- 0 test failures
- Debug build: succeeded
- Release build: succeeded
- `git diff --check`: clean
- No new compiler warnings
- No hardcoded local paths or credentials detected

## Safety

The new storage-analysis functionality is read-only.

This PR does not add or modify:
- file deletion
- Trash operations
- chmod/chown behavior
- Docker mutation/pruning
- APFS mutation
- destructive cleanup behavior

Filesystem boundaries, symlink handling, hard-link deduplication, cancellation, and partial-access semantics are preserved.