### PR TITLE
Add file and folder scan exclusions

### DIFF
--- a/PureMac/Models/Models.swift
+++ b/PureMac/Models/Models.swift
@@ -191,6 +191,94 @@ struct CategoryResult: Identifiable {
     var itemCount: Int { items.count }
 }
 
+// MARK: - Scan Exclusions
+
+/// Persistent file-system paths the user never wants cleaning scans to offer.
+/// The legacy key is merged on read so exclusions created before files were
+/// supported continue to work.
+enum ScanExclusions {
+    static let pathsKey = "settings.cleaning.excludedPaths"
+    static let legacyFoldersKey = "settings.cleaning.largeFileExcludedFolders"
+
+    static func paths(in defaults: UserDefaults = .standard) -> [String] {
+        let savedPaths = defaults.stringArray(forKey: pathsKey) ?? []
+        let legacyFolders = defaults.stringArray(forKey: legacyFoldersKey) ?? []
+
+        return normalizedPaths(savedPaths + legacyFolders)
+    }
+
+    static func save(_ paths: [String], in defaults: UserDefaults = .standard) {
+        defaults.set(normalizedPaths(paths), forKey: pathsKey)
+        defaults.removeObject(forKey: legacyFoldersKey)
+    }
+
+    static func excludes(_ path: String, excludedPaths: [String]) -> Bool {
+        guard !path.isEmpty, !path.hasPrefix(CleanableItem.simctlRuntimePathPrefix) else {
+            return false
+        }
+
+        let candidate = normalize(path)
+        return excludedPaths.contains { excludedPath in
+            let exclusion = normalize(excludedPath)
+            guard !exclusion.isEmpty else { return false }
+
+            // The second direction protects an excluded descendant when a
+            // scanner offers one of its ancestor folders as a single row.
+            return isSameOrDescendant(candidate, of: exclusion)
+                || isSameOrDescendant(exclusion, of: candidate)
+        }
+    }
+
+    static func contains(_ path: String, excludedPaths: [String]) -> Bool {
+        guard !path.isEmpty else { return false }
+        let candidate = normalize(path)
+        return excludedPaths.contains {
+            isSameOrDescendant(candidate, of: normalize($0))
+        }
+    }
+
+    static func filtering(_ result: CategoryResult, excludedPaths: [String]) -> CategoryResult {
+        guard !excludedPaths.isEmpty else { return result }
+        let items = result.items.filter { !excludes($0.path, excludedPaths: excludedPaths) }
+        return CategoryResult(
+            category: result.category,
+            items: items,
+            totalSize: items.reduce(0) { $0 + $1.size }
+        )
+    }
+
+    private static func normalizedPaths(_ paths: [String]) -> [String] {
+        Array(Set(paths.map(normalize).filter { !$0.isEmpty })).sorted()
+    }
+
+    private static func normalize(_ path: String) -> String {
+        guard !path.isEmpty else { return "" }
+        let expandedPath = (path as NSString).expandingTildeInPath
+        var existingPrefix = URL(fileURLWithPath: expandedPath).standardizedFileURL
+        var missingComponents: [String] = []
+
+        // resolvingSymlinksInPath() stops resolving when the leaf is missing.
+        // Resolve the nearest existing ancestor instead, then restore the tail
+        // so persisted exclusions remain canonical after a file is removed.
+        while existingPrefix.path != "/",
+              !FileManager.default.fileExists(atPath: existingPrefix.path) {
+            missingComponents.insert(existingPrefix.lastPathComponent, at: 0)
+            existingPrefix.deleteLastPathComponent()
+        }
+
+        return missingComponents.reduce(existingPrefix.resolvingSymlinksInPath()) {
+            $0.appendingPathComponent($1)
+        }
+        .standardizedFileURL.path
+    }
+
+    private static func isSameOrDescendant(_ path: String, of parent: String) -> Bool {
+        if path == parent { return true }
+        if parent == "/" { return path.hasPrefix("/") }
+        return path.hasPrefix(parent + "/")
+    }
+}
+
 // MARK: - Schedule Settings
 
 enum ScheduleInterval: String, CaseIterable, Identifiable, Codable {

--- a/PureMac/Services/ScanEngine.swift
+++ b/PureMac/Services/ScanEngine.swift
@@ -42,36 +42,42 @@ actor ScanEngine {
     ) async -> CategoryResult {
         self.onPath = onPath
         defer { self.onPath = nil }
+        let excludedPaths = ScanExclusions.paths()
+        let result: CategoryResult
         switch category {
         case .smartScan:
-            return CategoryResult(category: category, items: [], totalSize: 0)
+            result = CategoryResult(category: category, items: [], totalSize: 0)
         case .systemJunk:
-            return scanSystemJunk()
+            result = scanSystemJunk()
         case .userCache:
-            return scanUserCache()
+            result = scanUserCache()
         case .aiApps:
-            return scanAIApps()
+            result = scanAIApps()
         case .mailAttachments:
-            return scanMailAttachments()
+            result = scanMailAttachments()
         case .trashBins:
-            return scanTrash()
+            result = scanTrash()
         case .largeFiles:
-            return scanLargeFiles()
+            result = scanLargeFiles(excludedPaths: excludedPaths)
         case .purgeableSpace:
-            return scanPurgeableSpace()
+            result = scanPurgeableSpace()
         case .xcodeJunk:
-            return scanXcodeJunk()
+            result = scanXcodeJunk()
         case .brewCache:
-            return scanBrewCache()
+            result = scanBrewCache()
         case .nodeCache:
-            return scanNodeCache()
+            result = scanNodeCache()
         case .dockerCache:
-            return scanDockerCache()
+            result = scanDockerCache()
         case .universalBinaries:
-            return scanUniversalBinaries()
+            result = scanUniversalBinaries()
         case .languageFiles:
-            return scanLanguageFiles()
+            result = scanLanguageFiles()
         }
+        // An exclusion can be added from the still-visible previous results
+        // while this scan is running. Reload at the handoff boundary so a
+        // stale snapshot cannot put that item back into the UI.
+        return ScanExclusions.filtering(result, excludedPaths: ScanExclusions.paths())
     }
 
     func getDiskInfo() -> DiskInfo {
@@ -306,7 +312,7 @@ actor ScanEngine {
         return CategoryResult(category: .trashBins, items: items, totalSize: totalSize)
     }
 
-    private func scanLargeFiles() -> CategoryResult {
+    private func scanLargeFiles(excludedPaths: [String]) -> CategoryResult {
         var items: [CleanableItem] = []
 
         // Honor the thresholds the user set in Settings → Cleaning. These keys
@@ -319,14 +325,6 @@ actor ScanEngine {
         let oldCutoff = Calendar.current.date(byAdding: .month, value: -max(1, oldFileMonths), to: Date())
             ?? Date.distantPast
 
-        // Folders the user excluded from the large-file scan (issue #121) —
-        // e.g. VM images, media libraries, project assets they never want
-        // surfaced. Files anywhere inside an excluded folder are skipped, and
-        // the directory subtree is pruned so we don't even walk it.
-        let excludedFolders = (defaults.stringArray(forKey: "settings.cleaning.largeFileExcludedFolders") ?? [])
-            .map(normalizePath)
-            .filter { !$0.isEmpty }
-
         // Honor the "Skip hidden files during scan" toggle, which was a dead
         // control until now (no scanner read it). Default true preserves the
         // previous always-skip behavior.
@@ -335,8 +333,7 @@ actor ScanEngine {
         if skipHidden { enumerationOptions.insert(.skipsHiddenFiles) }
 
         func isExcluded(_ path: String) -> Bool {
-            let normalized = normalizePath(path)
-            return excludedFolders.contains { normalized == $0 || normalized.hasPrefix($0 + "/") }
+            ScanExclusions.contains(path, excludedPaths: excludedPaths)
         }
 
         let searchPaths = [
@@ -360,7 +357,7 @@ actor ScanEngine {
                 // Prune excluded subtrees: hitting the excluded directory itself
                 // skips its whole contents; for files the call is a harmless no-op.
                 // Skip the path normalization entirely when nothing is excluded.
-                if !excludedFolders.isEmpty, isExcluded(fileURL.path) {
+                if !excludedPaths.isEmpty, isExcluded(fileURL.path) {
                     enumerator.skipDescendants()
                     continue
                 }

--- a/PureMac/ViewModels/AppState.swift
+++ b/PureMac/ViewModels/AppState.swift
@@ -78,6 +78,7 @@ final class AppState: ObservableObject {
     /// operation after the user grants Full Disk Access without forcing them
     /// to re-select anything.
     @Published var pendingPermissionRetryItems: [CleanableItem] = []
+    @Published private(set) var excludedScanPaths = ScanExclusions.paths()
 
     // MARK: - App Uninstaller State
 
@@ -635,6 +636,41 @@ final class AppState: ObservableObject {
         }
     }
 
+    // MARK: - Scan Exclusions
+
+    func addScanExclusion(for item: CleanableItem) {
+        guard !item.isActionItem else { return }
+        let updatedPaths = ScanExclusions.paths() + [item.path]
+        ScanExclusions.save(updatedPaths)
+        excludedScanPaths = ScanExclusions.paths()
+        removeExcludedItemsFromCurrentResults()
+        Logger.shared.log("Added scan exclusion: \(item.path)", level: .info)
+    }
+
+    func addScanExclusions(paths: [String]) {
+        guard !paths.isEmpty else { return }
+        ScanExclusions.save(ScanExclusions.paths() + paths)
+        excludedScanPaths = ScanExclusions.paths()
+        removeExcludedItemsFromCurrentResults()
+    }
+
+    func removeScanExclusion(_ path: String) {
+        let remaining = excludedScanPaths.filter { $0 != path }
+        ScanExclusions.save(remaining)
+        excludedScanPaths = ScanExclusions.paths()
+    }
+
+    private func removeExcludedItemsFromCurrentResults() {
+        for (category, result) in categoryResults {
+            let filtered = ScanExclusions.filtering(result, excludedPaths: excludedScanPaths)
+            let removedIDs = Set(result.items.map(\.id)).subtracting(filtered.items.map(\.id))
+            selectedCleanupItems.subtract(removedIDs)
+            deselectedItems.subtract(removedIDs)
+            categoryResults[category] = filtered
+        }
+        totalJunkSize = categoryResults.values.reduce(0) { $0 + $1.totalSize }
+    }
+
     func selectedSizeInCategory(_ category: CleaningCategory) -> Int64 {
         guard let result = categoryResults[category] else { return 0 }
         return result.items.filter { isItemSelected($0) }.reduce(0) { $0 + $1.size }
@@ -799,6 +835,10 @@ final class AppState: ObservableObject {
 
     // MARK: - Scanning
 
+    private func applyCurrentScanExclusions(to result: CategoryResult) -> CategoryResult {
+        ScanExclusions.filtering(result, excludedPaths: excludedScanPaths)
+    }
+
     func startSmartScan() {
         guard !scanState.isActive else { return }
 
@@ -823,8 +863,9 @@ final class AppState: ObservableObject {
                         self?.scanTicker.path = path
                     }
                 }
-                categoryResults[category] = result
-                totalJunkSize += result.totalSize
+                let filteredResult = applyCurrentScanExclusions(to: result)
+                categoryResults[category] = filteredResult
+                totalJunkSize += filteredResult.totalSize
             }
 
             scanProgress = 1.0
@@ -850,7 +891,7 @@ final class AppState: ObservableObject {
                     self?.scanTicker.path = path
                 }
             }
-            categoryResults[category] = result
+            categoryResults[category] = applyCurrentScanExclusions(to: result)
 
             totalJunkSize = categoryResults.values.reduce(0) { $0 + $1.totalSize }
             scanProgress = 1.0
@@ -1069,16 +1110,16 @@ final class AppState: ObservableObject {
         // installed apps behind the user's back.
         let categories = scheduler.config.categoriesToScan
             .filter { !CleaningCategory.appModifying.contains($0) }
-        var totalFound: Int64 = 0
         clearSelectionState()
         categoryResults = [:]
 
         for category in categories {
             let result = await scanEngine.scanCategory(category)
-            categoryResults[category] = result
-            totalFound += result.totalSize
+            let filteredResult = applyCurrentScanExclusions(to: result)
+            categoryResults[category] = filteredResult
         }
 
+        let totalFound = categoryResults.values.reduce(0) { $0 + $1.totalSize }
         totalJunkSize = totalFound
 
         if scheduler.config.autoClean && totalFound >= scheduler.config.minimumCleanSize {

--- a/PureMac/Views/CategoryDetailView.swift
+++ b/PureMac/Views/CategoryDetailView.swift
@@ -328,6 +328,11 @@ private struct FileRowView: View {
                 Button("Reveal in Finder") {
                     NSWorkspace.shared.selectFile(item.path, inFileViewerRootedAtPath: "")
                 }
+                Button {
+                    appState.addScanExclusion(for: item)
+                } label: {
+                    Label("Add to Exclusions", systemImage: "eye.slash")
+                }
             }
         }
     }

--- a/PureMac/Views/Settings/SettingsView.swift
+++ b/PureMac/Views/Settings/SettingsView.swift
@@ -183,9 +183,6 @@ struct CleaningSettingsView: View {
     @AppStorage("settings.cleaning.largeFileThreshold") private var largeFileThresholdMB: Int = 100
     @AppStorage("settings.cleaning.oldFileMonths") private var oldFileMonths: Int = 12
 
-    private static let excludedFoldersKey = "settings.cleaning.largeFileExcludedFolders"
-    @State private var excludedFolders: [String] = []
-
     var body: some View {
         Form {
             Section("File Discovery") {
@@ -206,23 +203,23 @@ struct CleaningSettingsView: View {
                 )
             }
 
-            Section("Excluded Folders") {
-                if excludedFolders.isEmpty {
-                    Text("Files inside these folders are skipped from the Large & Old Files scan (Downloads, Documents, Desktop).")
+            Section("Excluded Items") {
+                if appState.excludedScanPaths.isEmpty {
+                    Text("Files and folders in this list are hidden from future cleaning scans.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 } else {
-                    ForEach(excludedFolders, id: \.self) { folder in
+                    ForEach(appState.excludedScanPaths, id: \.self) { path in
                         HStack(spacing: 8) {
-                            Image(systemName: "folder")
+                            Image(systemName: exclusionIcon(for: path))
                                 .foregroundStyle(.secondary)
-                            Text((folder as NSString).abbreviatingWithTildeInPath)
+                            Text((path as NSString).abbreviatingWithTildeInPath)
                                 .lineLimit(1)
                                 .truncationMode(.middle)
-                                .help(folder)
+                                .help(path)
                             Spacer()
                             Button {
-                                removeExcludedFolder(folder)
+                                appState.removeScanExclusion(path)
                             } label: {
                                 Image(systemName: "minus.circle.fill")
                                     .foregroundStyle(.secondary)
@@ -232,7 +229,7 @@ struct CleaningSettingsView: View {
                         }
                     }
                 }
-                Button("Add Folder…") { addExcludedFolder() }
+                Button("Add File or Folder…") { addExcludedItems() }
             }
 
             Section("Orphan Finder") {
@@ -256,31 +253,24 @@ struct CleaningSettingsView: View {
             }
         }
         .formStyle(.grouped)
-        .onAppear {
-            excludedFolders = UserDefaults.standard.stringArray(forKey: Self.excludedFoldersKey) ?? []
-        }
     }
 
-    private func persistExcludedFolders() {
-        UserDefaults.standard.set(excludedFolders, forKey: Self.excludedFoldersKey)
-    }
-
-    private func addExcludedFolder() {
+    private func addExcludedItems() {
         let panel = NSOpenPanel()
         panel.canChooseDirectories = true
-        panel.canChooseFiles = false
+        panel.canChooseFiles = true
         panel.allowsMultipleSelection = true
-        panel.prompt = String(localized: "Add Folder…")
+        panel.prompt = String(localized: "Add File or Folder…")
         guard panel.runModal() == .OK else { return }
-        for url in panel.urls where !excludedFolders.contains(url.path) {
-            excludedFolders.append(url.path)
-        }
-        persistExcludedFolders()
+        appState.addScanExclusions(paths: panel.urls.map(\.path))
     }
 
-    private func removeExcludedFolder(_ folder: String) {
-        excludedFolders.removeAll { $0 == folder }
-        persistExcludedFolders()
+    private func exclusionIcon(for path: String) -> String {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) else {
+            return "doc"
+        }
+        return isDirectory.boolValue ? "folder" : "doc"
     }
 }
 

--- a/PureMac/ar.lproj/Localizable.strings
+++ b/PureMac/ar.lproj/Localizable.strings
@@ -385,6 +385,10 @@
 "Files inside these folders are skipped from the Large & Old Files scan (Downloads, Documents, Desktop)." = "يتم تخطّي الملفات داخل هذه المجلدات في فحص الملفات الكبيرة والقديمة (التنزيلات، المستندات، سطح المكتب).";
 "Remove from exclusions" = "إزالة من المستثناة";
 "Add Folder…" = "إضافة مجلد…";
+"Excluded Items" = "العناصر المستثناة";
+"Files and folders in this list are hidden from future cleaning scans." = "سيتم إخفاء الملفات والمجلدات في هذه القائمة من عمليات فحص التنظيف المستقبلية.";
+"Add File or Folder…" = "إضافة ملف أو مجلد…";
+"Add to Exclusions" = "إضافة إلى الاستثناءات";
 
 /* v2.8.2: orphan ignore list (#114) */
 "Always Ignore" = "تجاهل دائمًا";

--- a/PureMac/en.lproj/Localizable.strings
+++ b/PureMac/en.lproj/Localizable.strings
@@ -385,6 +385,10 @@
 "Files inside these folders are skipped from the Large & Old Files scan (Downloads, Documents, Desktop)." = "Files inside these folders are skipped from the Large & Old Files scan (Downloads, Documents, Desktop).";
 "Remove from exclusions" = "Remove from exclusions";
 "Add Folder…" = "Add Folder…";
+"Excluded Items" = "Excluded Items";
+"Files and folders in this list are hidden from future cleaning scans." = "Files and folders in this list are hidden from future cleaning scans.";
+"Add File or Folder…" = "Add File or Folder…";
+"Add to Exclusions" = "Add to Exclusions";
 
 /* v2.8.2: orphan ignore list (#114) */
 "Always Ignore" = "Always Ignore";

--- a/PureMac/es.lproj/Localizable.strings
+++ b/PureMac/es.lproj/Localizable.strings
@@ -385,6 +385,10 @@
 "Files inside these folders are skipped from the Large & Old Files scan (Downloads, Documents, Desktop)." = "Los archivos dentro de estas carpetas se omiten en el análisis de archivos grandes y antiguos (Descargas, Documentos, Escritorio).";
 "Remove from exclusions" = "Quitar de las exclusiones";
 "Add Folder…" = "Añadir carpeta…";
+"Excluded Items" = "Elementos excluidos";
+"Files and folders in this list are hidden from future cleaning scans." = "Los archivos y carpetas de esta lista se ocultan en futuros análisis de limpieza.";
+"Add File or Folder…" = "Añadir archivo o carpeta…";
+"Add to Exclusions" = "Añadir a exclusiones";
 
 /* v2.8.2: orphan ignore list (#114) */
 "Always Ignore" = "Ignorar siempre";

--- a/PureMac/fr.lproj/Localizable.strings
+++ b/PureMac/fr.lproj/Localizable.strings
@@ -356,6 +356,10 @@
 "Files inside these folders are skipped from the Large & Old Files scan (Downloads, Documents, Desktop)." = "Les fichiers de ces dossiers sont ignorés lors de l'analyse Fichiers volumineux et anciens (Téléchargements, Documents, Bureau).";
 "Remove from exclusions" = "Retirer des exclusions";
 "Add Folder…" = "Ajouter un dossier…";
+"Excluded Items" = "Éléments exclus";
+"Files and folders in this list are hidden from future cleaning scans." = "Les fichiers et dossiers de cette liste sont masqués lors des prochaines analyses de nettoyage.";
+"Add File or Folder…" = "Ajouter un fichier ou un dossier…";
+"Add to Exclusions" = "Ajouter aux exclusions";
 
 /* v2.8.2: orphan ignore list (#114) */
 "Always Ignore" = "Toujours ignorer";

--- a/PureMac/ja.lproj/Localizable.strings
+++ b/PureMac/ja.lproj/Localizable.strings
@@ -385,6 +385,10 @@
 "Files inside these folders are skipped from the Large & Old Files scan (Downloads, Documents, Desktop)." = "これらのフォルダ内のファイルは「大きい/古いファイル」スキャン（ダウンロード、書類、デスクトップ）でスキップされます。";
 "Remove from exclusions" = "除外から削除";
 "Add Folder…" = "フォルダを追加…";
+"Excluded Items" = "除外する項目";
+"Files and folders in this list are hidden from future cleaning scans." = "このリストのファイルとフォルダは、今後のクリーンアップスキャンに表示されません。";
+"Add File or Folder…" = "ファイルまたはフォルダを追加…";
+"Add to Exclusions" = "除外リストに追加";
 
 /* v2.8.2: orphan ignore list (#114) */
 "Always Ignore" = "常に無視";

--- a/PureMac/pl.lproj/Localizable.strings
+++ b/PureMac/pl.lproj/Localizable.strings
@@ -385,6 +385,10 @@
 "Files inside these folders are skipped from the Large & Old Files scan (Downloads, Documents, Desktop)." = "Pliki w tych folderach są pomijane podczas skanowania Dużych i starych plików (Pobrane, Dokumenty, Biurko).";
 "Remove from exclusions" = "Usuń z wykluczeń";
 "Add Folder…" = "Dodaj folder…";
+"Excluded Items" = "Wykluczone elementy";
+"Files and folders in this list are hidden from future cleaning scans." = "Pliki i foldery z tej listy będą ukryte podczas przyszłych skanów czyszczenia.";
+"Add File or Folder…" = "Dodaj plik lub folder…";
+"Add to Exclusions" = "Dodaj do wykluczeń";
 
 /* v2.8.2: orphan ignore list (#114) */
 "Always Ignore" = "Zawsze ignoruj";

--- a/PureMac/pt-BR.lproj/Localizable.strings
+++ b/PureMac/pt-BR.lproj/Localizable.strings
@@ -385,6 +385,10 @@
 "Files inside these folders are skipped from the Large & Old Files scan (Downloads, Documents, Desktop)." = "Arquivos dentro destas pastas são ignorados na verificação de Arquivos Grandes e Antigos (Downloads, Documentos, Mesa).";
 "Remove from exclusions" = "Remover das exclusões";
 "Add Folder…" = "Adicionar pasta…";
+"Excluded Items" = "Itens excluídos";
+"Files and folders in this list are hidden from future cleaning scans." = "Os arquivos e pastas desta lista ficam ocultos em futuras verificações de limpeza.";
+"Add File or Folder…" = "Adicionar arquivo ou pasta…";
+"Add to Exclusions" = "Adicionar às exclusões";
 
 /* v2.8.2: orphan ignore list (#114) */
 "Always Ignore" = "Ignorar sempre";

--- a/PureMac/ru.lproj/Localizable.strings
+++ b/PureMac/ru.lproj/Localizable.strings
@@ -385,6 +385,10 @@
 "Files inside these folders are skipped from the Large & Old Files scan (Downloads, Documents, Desktop)." = "Файлы в этих папках пропускаются при поиске больших и старых файлов («Загрузки», «Документы», «Рабочий стол»).";
 "Remove from exclusions" = "Убрать из исключений";
 "Add Folder…" = "Добавить папку…";
+"Excluded Items" = "Исключения";
+"Files and folders in this list are hidden from future cleaning scans." = "Файлы и папки из этого списка не будут отображаться при последующих сканированиях очистки.";
+"Add File or Folder…" = "Добавить файл или папку…";
+"Add to Exclusions" = "Добавить в исключения";
 
 /* v2.8.2: orphan ignore list (#114) */
 "Always Ignore" = "Всегда игнорировать";

--- a/PureMac/uk.lproj/Localizable.strings
+++ b/PureMac/uk.lproj/Localizable.strings
@@ -385,6 +385,10 @@
 "Files inside these folders are skipped from the Large & Old Files scan (Downloads, Documents, Desktop)." = "Файли в цих папках пропускаються під час пошуку великих і старих файлів (Викачане, Документи, Робочий стіл).";
 "Remove from exclusions" = "Вилучити з винятків";
 "Add Folder…" = "Додати папку…";
+"Excluded Items" = "Винятки";
+"Files and folders in this list are hidden from future cleaning scans." = "Файли й папки з цього списку не відображатимуться під час наступних сканувань очищення.";
+"Add File or Folder…" = "Додати файл або папку…";
+"Add to Exclusions" = "Додати до винятків";
 
 /* v2.8.2: orphan ignore list (#114) */
 "Always Ignore" = "Завжди ігнорувати";

--- a/PureMac/zh-Hans.lproj/Localizable.strings
+++ b/PureMac/zh-Hans.lproj/Localizable.strings
@@ -385,6 +385,10 @@
 "Files inside these folders are skipped from the Large & Old Files scan (Downloads, Documents, Desktop)." = "这些文件夹中的文件会在“大文件和旧文件”扫描（下载、文稿、桌面）中被跳过。";
 "Remove from exclusions" = "从排除项中移除";
 "Add Folder…" = "添加文件夹…";
+"Excluded Items" = "排除的项目";
+"Files and folders in this list are hidden from future cleaning scans." = "此列表中的文件和文件夹不会显示在今后的清理扫描中。";
+"Add File or Folder…" = "添加文件或文件夹…";
+"Add to Exclusions" = "添加到排除项";
 
 /* v2.8.2: orphan ignore list (#114) */
 "Always Ignore" = "始终忽略";

--- a/PureMac/zh-Hant.lproj/Localizable.strings
+++ b/PureMac/zh-Hant.lproj/Localizable.strings
@@ -385,6 +385,10 @@
 "Files inside these folders are skipped from the Large & Old Files scan (Downloads, Documents, Desktop)." = "這些資料夾中的檔案會在「大型與舊檔案」掃描（下載、文件、桌面）中被略過。";
 "Remove from exclusions" = "從排除項目中移除";
 "Add Folder…" = "加入資料夾…";
+"Excluded Items" = "排除的項目";
+"Files and folders in this list are hidden from future cleaning scans." = "此列表中的檔案和資料夾不會顯示在之後的清理掃描中。";
+"Add File or Folder…" = "加入檔案或資料夾…";
+"Add to Exclusions" = "加入排除項目";
 
 /* v2.8.2: orphan ignore list (#114) */
 "Always Ignore" = "永遠忽略";

--- a/PureMacTests/AppStateTests.swift
+++ b/PureMacTests/AppStateTests.swift
@@ -41,6 +41,80 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(appState.currentAppFileSearchLocationCount, urls.count)
     }
 
+    func testScanExclusionsMergeLegacyPathsAndMigrateOnSave() throws {
+        let suiteName = "ScanExclusionsTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(["/tmp/legacy-folder"], forKey: ScanExclusions.legacyFoldersKey)
+        defaults.set(["/tmp/file", "/tmp/file"], forKey: ScanExclusions.pathsKey)
+        let expectedPaths = ["/tmp/file", "/tmp/legacy-folder"]
+            .map { URL(fileURLWithPath: $0).resolvingSymlinksInPath().path }
+            .sorted()
+
+        XCTAssertEqual(
+            ScanExclusions.paths(in: defaults),
+            expectedPaths
+        )
+
+        ScanExclusions.save(ScanExclusions.paths(in: defaults), in: defaults)
+
+        XCTAssertNil(defaults.object(forKey: ScanExclusions.legacyFoldersKey))
+        XCTAssertEqual(
+            defaults.stringArray(forKey: ScanExclusions.pathsKey),
+            expectedPaths
+        )
+    }
+
+    func testScanExclusionsRespectPathComponentBoundariesAndProtectAncestors() {
+        let exclusions = ["/tmp/cache/keep.txt"]
+
+        XCTAssertTrue(ScanExclusions.contains("/tmp/cache/keep.txt", excludedPaths: exclusions))
+        XCTAssertFalse(ScanExclusions.contains("/tmp/cache/keep.txt.bak", excludedPaths: exclusions))
+        XCTAssertTrue(ScanExclusions.excludes("/tmp/cache", excludedPaths: exclusions))
+        XCTAssertFalse(ScanExclusions.excludes("/tmp/cache-old", excludedPaths: exclusions))
+    }
+
+    func testScanExclusionsCanonicalizeSymlinkAliases() {
+        let uniqueName = "PureMac-scan-exclusion-\(UUID().uuidString)"
+
+        XCTAssertTrue(
+            ScanExclusions.contains(
+                "/private/tmp/\(uniqueName)",
+                excludedPaths: ["/tmp/\(uniqueName)"]
+            )
+        )
+    }
+
+    func testFilteringRecalculatesCategoryTotal() {
+        let kept = CleanableItem(
+            name: "keep.log",
+            path: "/tmp/keep.log",
+            size: 100,
+            category: .systemJunk,
+            isSelected: true,
+            lastModified: nil
+        )
+        let excluded = CleanableItem(
+            name: "excluded.log",
+            path: "/tmp/excluded.log",
+            size: 200,
+            category: .systemJunk,
+            isSelected: true,
+            lastModified: nil
+        )
+        let result = CategoryResult(
+            category: .systemJunk,
+            items: [kept, excluded],
+            totalSize: 300
+        )
+
+        let filtered = ScanExclusions.filtering(result, excludedPaths: [excluded.path])
+
+        XCTAssertEqual(filtered.items, [kept])
+        XCTAssertEqual(filtered.totalSize, kept.size)
+    }
+
     private func makeApp() -> InstalledApp {
         InstalledApp(
             id: UUID(),

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Smart Scan runs every category in parallel. Each category is its own deliberate 
 - **Node Cache** - npm, yarn classic, pnpm content-addressable store
 - **Docker Cache** - images, containers, build cache
 
+Right-click any file or folder in the scan results to add it to the cleaning exclusions. Excluded paths stay hidden from future scans and can be managed in **Settings → Cleaning**.
+
 > **On "purgeable space":** PureMac shows your APFS purgeable space in the storage breakdown for transparency, but it deliberately does **not** list it as junk to delete. Purgeable space is reserved and reclaimed by macOS itself - no third-party app can reliably free it, and even the Finder's purgeable figure is known to be inaccurate. Cleaners that claim to "reclaim purgeable space" are overpromising. We'd rather be honest than impressive.
 
 ### Scheduled Cleaning


### PR DESCRIPTION
## What does this PR do?

Adds an **Add to Exclusions** action to the context menu for file and folder scan results.

- Persists excluded paths and removes them from the current result immediately.
- Applies exclusions to manual, smart, and scheduled cleaning scans.
- Preserves and migrates the existing Large & Old Files folder exclusions.
- Lets users manage excluded files and folders in Settings → Cleaning.
- Documents the behavior in the README and localizes the new UI strings.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [x] UI/UX enhancement
- [x] Documentation
- [ ] Other (describe)

## Testing

- [ ] Tested on macOS Ventura (13.x)
- [ ] Tested on macOS Sonoma (14.x)
- [ ] Tested on macOS Sequoia (15.x)
- [x] All 27 macOS unit tests pass on macOS 26.5.2

Ventura hardware or a Ventura VM was not available in the development environment, so that checkbox is intentionally left unchecked. The project continues to target macOS 13.0+.

## Screenshots

Not included. The visible change is a single context-menu action plus the existing Cleaning settings list expanded to accept files as well as folders.
