### PR TITLE
feat(xcode): safely clean XcodeBuildMCP DerivedData

### DIFF
--- a/PureMac.xcodeproj/project.pbxproj
+++ b/PureMac.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		013EF7B96BF046D4DB38FBC5 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 241E0895B09C71AB423B2F9E /* Localizable.strings */; };
+		0E0A5149C01BA4B013F85E2D /* XcodeBuildMCPDerivedDataSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC5F44AB9CA4CD2DE774973 /* XcodeBuildMCPDerivedDataSupport.swift */; };
 		1B0D043102FDB245312A5147 /* AppFilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 798B80977D14647A5691B0A0 /* AppFilesView.swift */; };
 		2253F11BDF561B617439C96B /* FullDiskAccessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E866A1541D289C69144A5E62 /* FullDiskAccessManager.swift */; };
 		25E2304A3FF257F1740E304B /* FileProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7953B398E47A4C603DE287F1 /* FileProtection.swift */; };
@@ -90,6 +91,7 @@
 		1AB003A7751F05727DBFD1A5 /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
 		1C0D9A6F75D0B8ADDB32FC2A /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Localizable.strings; sourceTree = "<group>"; };
 		1D3AC5F17D7CA94FAB1E8D7A /* StringNormalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringNormalization.swift; sourceTree = "<group>"; };
+		1FC5F44AB9CA4CD2DE774973 /* XcodeBuildMCPDerivedDataSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeBuildMCPDerivedDataSupport.swift; sourceTree = "<group>"; };
 		231FF7CBB5F621B66F2AB8A5 /* FDADemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FDADemoView.swift; sourceTree = "<group>"; };
 		23486A54A82EE3865B784D1C /* AppInfoFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoFetcher.swift; sourceTree = "<group>"; };
 		25D1CF5248C1D471BCBD212F /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/ServicesMenu.strings; sourceTree = "<group>"; };
@@ -319,6 +321,7 @@
 				4AE790496C936424EF98320A /* OrphanSafetyPolicy.swift */,
 				8AFB912A9A6CFDCB972E978F /* ProviderPaths.swift */,
 				D74E66594478F53363BCB0F9 /* SimulatorRuntimeSupport.swift */,
+				1FC5F44AB9CA4CD2DE774973 /* XcodeBuildMCPDerivedDataSupport.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -528,6 +531,7 @@
 				340E424F759ACCDE7372F99F /* Theme.swift in Sources */,
 				6D449325D54B9850FC6C119F /* UniversalBinaryScanner.swift in Sources */,
 				41B27CACD7C6C7471EFD03F9 /* UpdateService.swift in Sources */,
+				0E0A5149C01BA4B013F85E2D /* XcodeBuildMCPDerivedDataSupport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PureMac/Logic/Utilities/XcodeBuildMCPDerivedDataSupport.swift
+++ b/PureMac/Logic/Utilities/XcodeBuildMCPDerivedDataSupport.swift
@@ -1,0 +1,301 @@
+import Foundation
+import Darwin
+
+/// Discovery and safety policy for XcodeBuildMCP-managed DerivedData.
+///
+/// Matches XcodeBuildMCP's own purge contract: active or recent DerivedData is
+/// protected from unattended cleanup, and deletions must not run while the
+/// workspace filesystem lifecycle lock is held.
+/// See https://www.xcodebuildmcp.com/docs/storage-management
+enum XcodeBuildMCPDerivedDataSupport {
+    static let lifecycleLockDirectoryName = "filesystem-lifecycle.lock"
+    static let lifecycleLockOwnerFileName = "owner.json"
+    /// Same lease window XcodeBuildMCP uses for filesystem-lifecycle locks.
+    static let lifecycleLockLease: TimeInterval = 10 * 60
+    /// Scheduled cleanup only considers build data that has been unused for a
+    /// full week. Manual cleanup remains available for any discovered item.
+    static let scheduledCleanupAge: TimeInterval = 7 * 24 * 60 * 60
+
+    struct LifecycleLock {
+        fileprivate let directory: URL
+        fileprivate let token: String
+    }
+
+    static func canonicalHomeDirectory(_ homeDirectory: URL) -> URL {
+        homeDirectory.resolvingSymlinksInPath().standardizedFileURL
+    }
+
+    static func managedRoot(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> URL {
+        canonicalHomeDirectory(homeDirectory)
+            .appendingPathComponent("Library/Developer/XcodeBuildMCP", isDirectory: true)
+    }
+
+    static func isManagedDerivedDataPath(
+        _ path: String,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> Bool {
+        let normalized = (path as NSString).standardizingPath
+        let root = managedRoot(homeDirectory: homeDirectory).path
+
+        // XcodeBuildMCP before v2.5 used one shared DerivedData directory.
+        if normalized == (root as NSString).appendingPathComponent("DerivedData") {
+            return true
+        }
+
+        let workspacesRoot = (root as NSString).appendingPathComponent("workspaces")
+        let prefix = workspacesRoot + "/"
+        guard normalized.hasPrefix(prefix) else { return false }
+
+        let relative = String(normalized.dropFirst(prefix.count))
+        let components = relative.split(separator: "/", omittingEmptySubsequences: false)
+        return components.count == 2
+            && !components[0].isEmpty
+            && components[1] == "DerivedData"
+    }
+
+    /// Returns whether a managed DerivedData item may participate in scheduled
+    /// cleanup. Ordinary PureMac items remain governed by their selection flag;
+    /// XcodeBuildMCP items additionally need to be old and unlocked.
+    static func isEligibleForScheduledAutoClean(
+        _ item: CleanableItem,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        now: Date = Date(),
+        fileManager: FileManager = .default,
+        isProcessAlive: @escaping (Int32) -> Bool = isProcessAlive
+    ) -> Bool {
+        guard isManagedDerivedDataPath(item.path, homeDirectory: homeDirectory) else {
+            return true
+        }
+        guard let lastModified = item.lastModified,
+              now.timeIntervalSince(lastModified) >= scheduledCleanupAge else {
+            return false
+        }
+        return !isLifecycleLockHeld(
+            forManagedDerivedDataPath: item.path,
+            homeDirectory: homeDirectory,
+            fileManager: fileManager,
+            now: now,
+            isProcessAlive: isProcessAlive
+        )
+    }
+
+    static func workspaceKey(
+        forManagedDerivedDataPath path: String,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> String? {
+        let normalized = (path as NSString).standardizingPath
+        let workspacesRoot = managedRoot(homeDirectory: homeDirectory)
+            .appendingPathComponent("workspaces", isDirectory: true)
+            .path + "/"
+        guard normalized.hasPrefix(workspacesRoot) else { return nil }
+        let relative = String(normalized.dropFirst(workspacesRoot.count))
+        let components = relative.split(separator: "/", omittingEmptySubsequences: false)
+        guard components.count == 2, components[1] == "DerivedData", !components[0].isEmpty else {
+            return nil
+        }
+        return String(components[0])
+    }
+
+    /// True when XcodeBuildMCP's workspace filesystem lifecycle lock is held
+    /// (or cannot be proven free). Legacy shared DerivedData has no per-workspace
+    /// lock and always returns false here.
+    static func isLifecycleLockHeld(
+        forManagedDerivedDataPath path: String,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default,
+        now: Date = Date(),
+        isProcessAlive: (Int32) -> Bool = isProcessAlive
+    ) -> Bool {
+        guard let workspaceKey = workspaceKey(
+            forManagedDerivedDataPath: path,
+            homeDirectory: homeDirectory
+        ) else {
+            return false
+        }
+
+        let lockDir = managedRoot(homeDirectory: homeDirectory)
+            .appendingPathComponent("workspaces/\(workspaceKey)/locks/\(lifecycleLockDirectoryName)", isDirectory: true)
+
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: lockDir.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            return false
+        }
+
+        let ownerURL = lockDir.appendingPathComponent(lifecycleLockOwnerFileName)
+        if let owner = readLockOwner(at: ownerURL) {
+            if owner.expiresAtMs > now.timeIntervalSince1970 * 1000 {
+                return true
+            }
+            if isProcessAlive(Int32(owner.pid)) {
+                return true
+            }
+            // Expired owner whose process is dead — treat as free (matches
+            // XcodeBuildMCP's recoverable-stale-lock policy).
+            return false
+        }
+
+        // No owner.json: if the lock directory is still within the lease window,
+        // assume an active holder rather than racing a live build.
+        guard let attributes = try? fileManager.attributesOfItem(atPath: lockDir.path),
+              let modified = attributes[.modificationDate] as? Date else {
+            return true
+        }
+        return now.timeIntervalSince(modified) <= lifecycleLockLease
+    }
+
+    /// Atomically claims a workspace lifecycle lock for a short, local
+    /// filesystem operation. `mkdir` is used instead of FileManager's
+    /// createDirectory because POSIX mkdir gives us an exclusive EEXIST result
+    /// when XcodeBuildMCP (or another PureMac process) wins the race.
+    ///
+    /// A legacy shared DerivedData path has no workspace lock, so it returns
+    /// nil and must not be deleted by a caller that requires coordination.
+    static func acquireLifecycleLock(
+        forManagedDerivedDataPath path: String,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default
+    ) -> LifecycleLock? {
+        guard let workspaceKey = workspaceKey(
+            forManagedDerivedDataPath: path,
+            homeDirectory: homeDirectory
+        ) else {
+            return nil
+        }
+
+        let lockDirectory = managedRoot(homeDirectory: homeDirectory)
+            .appendingPathComponent(
+                "workspaces/\(workspaceKey)/locks/\(lifecycleLockDirectoryName)",
+                isDirectory: true
+            )
+        do {
+            try fileManager.createDirectory(
+                at: lockDirectory.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+        } catch {
+            return nil
+        }
+
+        guard Darwin.mkdir(lockDirectory.path, S_IRWXU) == 0 else { return nil }
+
+        let token = UUID().uuidString
+        let nowMs = Date().timeIntervalSince1970 * 1000
+        let owner: [String: Any] = [
+            "token": token,
+            "pid": Int(getpid()),
+            "purpose": "filesystem-lifecycle",
+            "acquiredAtMs": nowMs,
+            "expiresAtMs": nowMs + lifecycleLockLease * 1000,
+        ]
+        do {
+            let data = try JSONSerialization.data(withJSONObject: owner)
+            try data.write(
+                to: lockDirectory.appendingPathComponent(lifecycleLockOwnerFileName),
+                options: [.atomic]
+            )
+            return LifecycleLock(directory: lockDirectory, token: token)
+        } catch {
+            try? fileManager.removeItem(at: lockDirectory)
+            return nil
+        }
+    }
+
+    /// Releases only the lock represented by the returned token. This avoids
+    /// deleting a lock that was replaced after an unexpected interruption.
+    static func releaseLifecycleLock(
+        _ lock: LifecycleLock,
+        fileManager: FileManager = .default
+    ) {
+        guard readLockOwner(
+            at: lock.directory.appendingPathComponent(lifecycleLockOwnerFileName)
+        )?.token == lock.token else { return }
+        try? fileManager.removeItem(at: lock.directory)
+    }
+
+    /// Discover managed DerivedData directories under a home. Never follows a
+    /// replaced/symlinked managed root or per-workspace DerivedData link.
+    static func discoverDerivedDataDirectories(
+        homeDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> [(name: String, url: URL)] {
+        let root = managedRoot(homeDirectory: homeDirectory)
+        guard isRealDirectory(root, fileManager: fileManager) else { return [] }
+
+        var results: [(name: String, url: URL)] = []
+
+        let legacyDerivedData = root.appendingPathComponent("DerivedData", isDirectory: true)
+        if isRealDirectory(legacyDerivedData, fileManager: fileManager) {
+            results.append((name: "XcodeBuildMCP: Legacy DerivedData", url: legacyDerivedData))
+        }
+
+        let workspacesRoot = root.appendingPathComponent("workspaces", isDirectory: true)
+        guard isRealDirectory(workspacesRoot, fileManager: fileManager),
+              let workspaces = try? fileManager.contentsOfDirectory(
+                  at: workspacesRoot,
+                  includingPropertiesForKeys: nil,
+                  options: [.skipsHiddenFiles]
+              ) else {
+            return results
+        }
+
+        for workspace in workspaces where isRealDirectory(workspace, fileManager: fileManager) {
+            let derivedData = workspace.appendingPathComponent("DerivedData", isDirectory: true)
+            guard isRealDirectory(derivedData, fileManager: fileManager) else { continue }
+            results.append((
+                name: "XcodeBuildMCP: \(displayName(forWorkspaceKey: workspace.lastPathComponent))",
+                url: derivedData
+            ))
+        }
+
+        return results
+    }
+
+    static func displayName(forWorkspaceKey workspaceKey: String) -> String {
+        guard let separator = workspaceKey.lastIndex(of: "-") else { return workspaceKey }
+        let suffix = workspaceKey[workspaceKey.index(after: separator)...]
+        guard suffix.count == 12, suffix.allSatisfy(\.isHexDigit) else { return workspaceKey }
+        return String(workspaceKey[..<separator])
+    }
+
+    static func isRealDirectory(_ url: URL, fileManager: FileManager = .default) -> Bool {
+        let normalized = url.standardizedFileURL.path
+        guard url.resolvingSymlinksInPath().standardizedFileURL.path == normalized,
+              let attributes = try? fileManager.attributesOfItem(atPath: normalized),
+              attributes[.type] as? FileAttributeType == .typeDirectory else {
+            return false
+        }
+        return true
+    }
+
+    // MARK: - Private
+
+    private struct LockOwner: Decodable {
+        let token: String
+        let pid: Int
+        let purpose: String
+        let acquiredAtMs: Double
+        let expiresAtMs: Double
+    }
+
+    private static func readLockOwner(at url: URL) -> LockOwner? {
+        guard let data = try? Data(contentsOf: url),
+              let owner = try? JSONDecoder().decode(LockOwner.self, from: data),
+              !owner.token.isEmpty,
+              owner.pid > 0,
+              !owner.purpose.isEmpty else {
+            return nil
+        }
+        return owner
+    }
+
+    private static func isProcessAlive(_ pid: Int32) -> Bool {
+        if pid <= 1 { return false }
+        if kill(pid, 0) == 0 { return true }
+        return errno == EPERM
+    }
+}
+
+typealias XcodeBuildMCPStorage = XcodeBuildMCPDerivedDataSupport

--- a/PureMac/Services/CleaningEngine.swift
+++ b/PureMac/Services/CleaningEngine.swift
@@ -2,13 +2,24 @@ import Foundation
 
 actor CleaningEngine {
     private let fileManager = FileManager.default
+    /// Always symlink-resolved so allow-listed roots agree with ScanEngine and
+    /// XcodeBuildMCPDerivedDataSupport path checks on symlinked homes.
+    private let homeDirectory: URL
     private let binaryThinner = BinaryThinner()
+
+    init(homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) {
+        self.homeDirectory = XcodeBuildMCPDerivedDataSupport.canonicalHomeDirectory(homeDirectory)
+    }
 
     struct CleaningResult {
         var freedSpace: Int64 = 0
         var itemsCleaned: Int = 0
         var errors: [String] = []
         var cleanedPaths: Set<String> = []
+        /// Destination paths returned by FileManager.trashItem. Keeping these
+        /// lets callers and tests distinguish recoverable Trash moves from
+        /// irreversible removals.
+        var trashedPaths: Set<String> = []
         // Items that user-level FileManager.removeItem refused with EACCES /
         // EPERM. These are root-owned and need an admin-privileged second
         // pass via cleanWithAdminPrivileges(items:).
@@ -121,14 +132,9 @@ actor CleaningEngine {
                 // Large files surfaced by scanLargeFiles are per-file items
                 // under Downloads/Documents/Desktop; those get a narrower check
                 // instead of the whole-subtree allow-list.
-                let pathAccepted: Bool = {
-                    if item.category == .largeFiles {
-                        return isExplicitSingleFileDeletable(resolvedPath: resolved)
-                    }
-                    // languageFiles never reaches here — it is handled above
-                    // via the staged re-sign flow, not the delete path.
-                    return isSafeToDelete(resolvedPath: resolved)
-                }()
+                // languageFiles never reaches here — it is handled above via
+                // the staged re-sign flow, not the delete path.
+                let pathAccepted = isSafeToDelete(item: item, resolvedPath: resolved)
                 guard pathAccepted else {
                     let msg = "Skipped symlink or unsafe path: \(item.path) -> \(resolved)"
                     Logger.shared.log(msg, level: .warning)
@@ -147,7 +153,40 @@ actor CleaningEngine {
                     continue
                 }
 
-                try fileManager.removeItem(at: resolvedURL)
+                let isManagedDerivedData = XcodeBuildMCPDerivedDataSupport.isManagedDerivedDataPath(
+                    item.path,
+                    homeDirectory: homeDirectory
+                ) || XcodeBuildMCPDerivedDataSupport.isManagedDerivedDataPath(
+                    resolved,
+                    homeDirectory: homeDirectory
+                )
+                if isManagedDerivedData {
+                    guard let lifecycleLock = XcodeBuildMCPDerivedDataSupport.acquireLifecycleLock(
+                        forManagedDerivedDataPath: resolved,
+                        homeDirectory: homeDirectory,
+                        fileManager: fileManager
+                    ) else {
+                        let detail = "Skipped XcodeBuildMCP DerivedData: lifecycle lock is unavailable: \(item.path)"
+                        Logger.shared.log(detail, level: .warning)
+                        result.errors.append(detail)
+                        continue
+                    }
+                    defer {
+                        XcodeBuildMCPDerivedDataSupport.releaseLifecycleLock(
+                            lifecycleLock,
+                            fileManager: fileManager
+                        )
+                    }
+                    // PureMac's safety contract is Trash-only for recoverable
+                    // cleanup. XcodeBuildMCP DerivedData must not be unlinked.
+                    var resulting: NSURL?
+                    try fileManager.trashItem(at: resolvedURL, resultingItemURL: &resulting)
+                    if let resulting {
+                        result.trashedPaths.insert(resulting.path ?? "")
+                    }
+                } else {
+                    try fileManager.removeItem(at: resolvedURL)
+                }
                 result.freedSpace += item.size
                 result.itemsCleaned += 1
                 result.cleanedPaths.insert(item.path)
@@ -160,6 +199,15 @@ actor CleaningEngine {
                     (nsError.domain == NSPOSIXErrorDomain &&
                         (nsError.code == Int(EACCES) || nsError.code == Int(EPERM)))
                 if isPermissionDenied {
+                    if XcodeBuildMCPDerivedDataSupport.isManagedDerivedDataPath(
+                        item.path,
+                        homeDirectory: homeDirectory
+                    ) {
+                        let detail = "Refusing administrator escalation for XcodeBuildMCP DerivedData: \(item.path)"
+                        result.errors.append(detail)
+                        Logger.shared.log(detail, level: .warning)
+                        continue
+                    }
                     // SIP-protected/immutable entries fail even as root, so
                     // escalating them just wastes an auth prompt and produces
                     // a bogus "survived admin removal" error. Record and move on.
@@ -205,16 +253,28 @@ actor CleaningEngine {
         // refuses to escalate.
         let validated: [(item: CleanableItem, resolved: String)] = items.compactMap { item in
             let resolved = URL(fileURLWithPath: item.path).resolvingSymlinksInPath().path
-            let accepted: Bool = {
-                if item.category == .largeFiles {
-                    return isExplicitSingleFileDeletable(resolvedPath: resolved)
-                }
-                // languageFiles is deliberately absent: an admin rm -rf of an
-                // .lproj would break the bundle's signature seal with no
-                // re-sign, so those items never escalate — they only go
-                // through the staged BinaryThinner flow in cleanItems.
-                return isSafeToDelete(resolvedPath: resolved) || isSafeUninstallEscalationPath(resolved)
-            }()
+            let isManaged = XcodeBuildMCPDerivedDataSupport.isManagedDerivedDataPath(
+                item.path,
+                homeDirectory: homeDirectory
+            ) || XcodeBuildMCPDerivedDataSupport.isManagedDerivedDataPath(
+                resolved,
+                homeDirectory: homeDirectory
+            )
+            guard !isManaged else {
+                Logger.shared.log(
+                    "Refusing administrator escalation for XcodeBuildMCP DerivedData: \(item.path)",
+                    level: .warning
+                )
+                return nil
+            }
+            // languageFiles is deliberately absent: an admin rm -rf of an
+            // .lproj would break the bundle's signature seal with no re-sign,
+            // so those items never escalate.
+            let accepted = isSafeToDelete(
+                item: item,
+                resolvedPath: resolved,
+                includeUninstallPaths: true
+            )
             if !accepted {
                 Logger.shared.log("Refusing admin escalation for unsafe path: \(item.path)", level: .warning)
             }
@@ -472,12 +532,49 @@ actor CleaningEngine {
 
     // MARK: - Helpers
 
+    private func isSafeToDelete(
+        item: CleanableItem,
+        resolvedPath: String,
+        includeUninstallPaths: Bool = false
+    ) -> Bool {
+        let originalIsManaged = XcodeBuildMCPDerivedDataSupport.isManagedDerivedDataPath(
+            item.path,
+            homeDirectory: homeDirectory
+        )
+        let resolvedIsManaged = XcodeBuildMCPDerivedDataSupport.isManagedDerivedDataPath(
+            resolvedPath,
+            homeDirectory: homeDirectory
+        )
+
+        // A managed path must remain managed after symlink resolution. Do not
+        // fall through to broader roots such as Application Support: that
+        // would turn a symlinked XcodeBuildMCP root into an allow-list bypass.
+        if originalIsManaged || resolvedIsManaged {
+            let original = (item.path as NSString).standardizingPath
+            let resolved = (resolvedPath as NSString).standardizingPath
+            return originalIsManaged && resolvedIsManaged && original == resolved
+        }
+        if item.category == .largeFiles {
+            return isExplicitSingleFileDeletable(resolvedPath: resolvedPath)
+        }
+        return isSafeToDelete(resolvedPath: resolvedPath)
+            || (includeUninstallPaths && isSafeUninstallEscalationPath(resolvedPath))
+    }
+
     /// Validates that a resolved path is safe to delete.
     /// Prevents symlink attacks where a link in ~/Library/Caches points to ~/.ssh.
     /// Downloads, Documents, and Desktop are intentionally NOT whole-subtree
     /// allow-listed - scanLargeFiles emits per-file items instead, so those
     /// deletions can still happen through the explicit per-item flow.
     private func isSafeToDelete(resolvedPath: String) -> Bool {
+        let home = homeDirectory.path
+        if XcodeBuildMCPDerivedDataSupport.isManagedDerivedDataPath(
+            resolvedPath,
+            homeDirectory: homeDirectory
+        ) {
+            return true
+        }
+
         // Cloud File Provider state is never deletable, whatever category asked
         // and whichever allowed root it happens to sit under (issue #142).
         // Checked before the allowlist because several provider directories live
@@ -491,7 +588,6 @@ actor CleaningEngine {
             return false
         }
 
-        let home = fileManager.homeDirectoryForCurrentUser.path
         let allowedRoots = [
             "\(home)/Library/Caches",
             "\(home)/Library/Logs",

--- a/PureMac/Services/ScanEngine.swift
+++ b/PureMac/Services/ScanEngine.swift
@@ -2,7 +2,11 @@ import Foundation
 
 actor ScanEngine {
     private let fileManager = FileManager.default
-    private let home = FileManager.default.homeDirectoryForCurrentUser.path
+    private let home: String
+
+    init(homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) {
+        home = XcodeBuildMCPDerivedDataSupport.canonicalHomeDirectory(homeDirectory).path
+    }
 
     /// Live path reporter for the dashboard's scanning ticker. Throttled so
     /// a directory with thousands of entries doesn't flood the main actor.
@@ -470,6 +474,24 @@ actor ScanEngine {
                         lastModified: nil
                     ))
                 }
+            }
+        }
+
+        // XcodeBuildMCP DerivedData follows ordinary Xcode DerivedData
+        // selection semantics. Scheduled cleanup applies an additional age and
+        // lifecycle-lock guard in AppState before including these rows.
+        let homeURL = URL(fileURLWithPath: home, isDirectory: true)
+        for discovered in XcodeBuildMCPDerivedDataSupport.discoverDerivedDataDirectories(
+            homeDirectory: homeURL,
+            fileManager: fileManager
+        ) {
+            if let item = makeCleanupItem(
+                name: discovered.name,
+                path: discovered.url.path,
+                category: .xcodeJunk,
+                isSelected: true
+            ) {
+                items.append(item)
             }
         }
 

--- a/PureMac/ViewModels/AppState.swift
+++ b/PureMac/ViewModels/AppState.swift
@@ -863,10 +863,17 @@ final class AppState: ObservableObject {
 
     // MARK: - Cleaning
 
-    func cleanAll() {
+    func cleanAll(scheduled: Bool = false) {
         guard !scanState.isActive else { return }
 
-        let itemsToClean = allResults.flatMap { $0.items }.filter { isItemSelected($0) }
+        let itemsToClean = allResults.flatMap { $0.items }.filter { item in
+            if scheduled && XcodeBuildMCPDerivedDataSupport.isManagedDerivedDataPath(item.path) {
+                // Scheduled XcodeBuildMCP cleanup is intentionally stricter
+                // than ordinary Xcode Junk: only old, unlocked rows qualify.
+                return XcodeBuildMCPDerivedDataSupport.isEligibleForScheduledAutoClean(item)
+            }
+            return isItemSelected(item)
+        }
         guard !itemsToClean.isEmpty else { return }
 
         scanState = .cleaning(progress: 0)
@@ -1082,7 +1089,7 @@ final class AppState: ObservableObject {
         totalJunkSize = totalFound
 
         if scheduler.config.autoClean && totalFound >= scheduler.config.minimumCleanSize {
-            cleanAll()
+            cleanAll(scheduled: true)
         }
 
         // Purgeable space is intentionally NOT auto-purged: macOS reserves and

--- a/PureMacTests/AppStateTests.swift
+++ b/PureMacTests/AppStateTests.swift
@@ -41,6 +41,7 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(appState.currentAppFileSearchLocationCount, urls.count)
     }
 
+
     private func makeApp() -> InstalledApp {
         InstalledApp(
             id: UUID(),
@@ -57,5 +58,590 @@ private final class StubLocations: Locations {
     init(paths: [String]) {
         super.init()
         appSearch = SearchCategory(name: "Apps", paths: paths)
+    }
+}
+
+final class XcodeBuildMCPStorageTests: XCTestCase {
+    func testXcodeJunkIncludesManagedDerivedDataForEachWorkspace() async throws {
+        let fileManager = FileManager.default
+        let temporaryHome = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: temporaryHome) }
+
+        let workspaceRoot = temporaryHome
+            .appendingPathComponent("Library/Developer/XcodeBuildMCP/workspaces/PureMac-59316969cafe", isDirectory: true)
+        let derivedData = workspaceRoot.appendingPathComponent("DerivedData", isDirectory: true)
+        let logs = workspaceRoot.appendingPathComponent("logs", isDirectory: true)
+        let outsideDirectory = temporaryHome.appendingPathComponent("outside", isDirectory: true)
+        let symlinkedDerivedData = temporaryHome
+            .appendingPathComponent("Library/Developer/XcodeBuildMCP/workspaces/Symlinked-111111111111/DerivedData")
+        try fileManager.createDirectory(at: derivedData, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: logs, withIntermediateDirectories: true)
+        try fileManager.createDirectory(
+            at: symlinkedDerivedData.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try fileManager.createDirectory(at: outsideDirectory, withIntermediateDirectories: true)
+        try fileManager.createSymbolicLink(at: symlinkedDerivedData, withDestinationURL: outsideDirectory)
+        try Data(repeating: 0xAB, count: 4_096)
+            .write(to: derivedData.appendingPathComponent("build-product"))
+        try Data(repeating: 0xCD, count: 4_096)
+            .write(to: logs.appendingPathComponent("build.log"))
+        try Data(repeating: 0xEF, count: 4_096)
+            .write(to: outsideDirectory.appendingPathComponent("must-not-be-scanned"))
+
+        let engine = ScanEngine(homeDirectory: temporaryHome)
+        let result = await engine.scanCategory(.xcodeJunk)
+
+        let expectedPath = derivedData.resolvingSymlinksInPath().path
+        let item = try XCTUnwrap(
+            result.items.first {
+                URL(fileURLWithPath: $0.path).resolvingSymlinksInPath().path == expectedPath
+            },
+            "Expected \(expectedPath); scanned: \(result.items.map(\.path))"
+        )
+        XCTAssertEqual(item.name, "XcodeBuildMCP: PureMac")
+        XCTAssertTrue(item.isSelected)
+        XCTAssertFalse(result.items.contains { $0.path == logs.path })
+        XCTAssertFalse(result.items.contains { $0.path == symlinkedDerivedData.path })
+    }
+
+    func testSymlinkedXcodeBuildMCPRootIsNotScanned() async throws {
+        let fileManager = FileManager.default
+        let temporaryHome = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-RootLink-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: temporaryHome) }
+
+        let externalRoot = temporaryHome
+            .appendingPathComponent("Library/Application Support/FakeXcodeBuildMCP", isDirectory: true)
+        let externalDerivedData = externalRoot
+            .appendingPathComponent("workspaces/Foreign-222222222222/DerivedData", isDirectory: true)
+        let developerDirectory = temporaryHome
+            .appendingPathComponent("Library/Developer", isDirectory: true)
+        let managedRoot = developerDirectory.appendingPathComponent("XcodeBuildMCP", isDirectory: true)
+        try fileManager.createDirectory(at: externalDerivedData, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: developerDirectory, withIntermediateDirectories: true)
+        try fileManager.createSymbolicLink(at: managedRoot, withDestinationURL: externalRoot)
+        try Data(repeating: 0xAA, count: 4_096)
+            .write(to: externalDerivedData.appendingPathComponent("foreign-data"))
+
+        let result = await ScanEngine(homeDirectory: temporaryHome).scanCategory(.xcodeJunk)
+
+        XCTAssertFalse(result.items.contains { $0.name.hasPrefix("XcodeBuildMCP:") })
+    }
+
+    func testCleaningRejectsManagedPathWhoseRootResolvesOutsideManagedStorage() async throws {
+        let fileManager = FileManager.default
+        let temporaryHome = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-CleanRootLink-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: temporaryHome) }
+
+        let externalRoot = temporaryHome
+            .appendingPathComponent("Library/Application Support/FakeXcodeBuildMCP", isDirectory: true)
+        let externalDerivedData = externalRoot
+            .appendingPathComponent("workspaces/Foreign-222222222222/DerivedData", isDirectory: true)
+        let developerDirectory = temporaryHome
+            .appendingPathComponent("Library/Developer", isDirectory: true)
+        let managedRoot = developerDirectory.appendingPathComponent("XcodeBuildMCP", isDirectory: true)
+        let apparentDerivedData = managedRoot
+            .appendingPathComponent("workspaces/Foreign-222222222222/DerivedData", isDirectory: true)
+        try fileManager.createDirectory(at: externalDerivedData, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: developerDirectory, withIntermediateDirectories: true)
+        try fileManager.createSymbolicLink(at: managedRoot, withDestinationURL: externalRoot)
+        try Data(repeating: 0xBB, count: 4_096)
+            .write(to: externalDerivedData.appendingPathComponent("foreign-data"))
+
+        let item = CleanableItem(
+            name: "XcodeBuildMCP: Foreign",
+            path: apparentDerivedData.path,
+            size: 4_096,
+            category: .xcodeJunk,
+            isSelected: true,
+            lastModified: nil
+        )
+        let result = await CleaningEngine(homeDirectory: temporaryHome)
+            .cleanItems([item]) { _ in }
+
+        XCTAssertEqual(result.itemsCleaned, 0)
+        XCTAssertTrue(fileManager.fileExists(atPath: externalDerivedData.path))
+    }
+
+    func testXcodeJunkIncludesLegacySharedDerivedData() async throws {
+        let fileManager = FileManager.default
+        let temporaryHome = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-Legacy-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: temporaryHome) }
+
+        let legacyDerivedData = temporaryHome
+            .appendingPathComponent("Library/Developer/XcodeBuildMCP/DerivedData", isDirectory: true)
+        try fileManager.createDirectory(at: legacyDerivedData, withIntermediateDirectories: true)
+        try Data(repeating: 0xEF, count: 4_096)
+            .write(to: legacyDerivedData.appendingPathComponent("legacy-build-product"))
+
+        let result = await ScanEngine(homeDirectory: temporaryHome).scanCategory(.xcodeJunk)
+        let expectedPath = legacyDerivedData.resolvingSymlinksInPath().path
+        let item = try XCTUnwrap(result.items.first {
+            URL(fileURLWithPath: $0.path).resolvingSymlinksInPath().path == expectedPath
+        })
+
+        XCTAssertEqual(item.name, "XcodeBuildMCP: Legacy DerivedData")
+        XCTAssertTrue(item.isSelected)
+    }
+
+    func testCleaningManagedDerivedDataLeavesWorkspaceStateIntact() async throws {
+        let fileManager = FileManager.default
+        let temporaryHome = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-Clean-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: temporaryHome) }
+
+        let workspaceRoot = temporaryHome
+            .appendingPathComponent("Library/Developer/XcodeBuildMCP/workspaces/PureMac-59316969cafe", isDirectory: true)
+        let derivedData = workspaceRoot.appendingPathComponent("DerivedData", isDirectory: true)
+        let preservedDirectories = ["logs", "state", "locks", "result-bundles", "test-products"].map {
+            workspaceRoot.appendingPathComponent($0, isDirectory: true)
+        }
+        try fileManager.createDirectory(at: derivedData, withIntermediateDirectories: true)
+        for directory in preservedDirectories {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            try Data(repeating: 0xCD, count: 256)
+                .write(to: directory.appendingPathComponent("must-survive"))
+        }
+        try Data(repeating: 0xAB, count: 4_096)
+            .write(to: derivedData.appendingPathComponent("build-product"))
+
+        let scan = await ScanEngine(homeDirectory: temporaryHome).scanCategory(.xcodeJunk)
+        let item = try XCTUnwrap(scan.items.first { $0.name == "XcodeBuildMCP: PureMac" })
+        let result = await CleaningEngine(homeDirectory: temporaryHome)
+            .cleanItems([item]) { _ in }
+
+        XCTAssertEqual(result.itemsCleaned, 1)
+        XCTAssertFalse(fileManager.fileExists(atPath: derivedData.path))
+        XCTAssertEqual(result.trashedPaths.count, 1)
+        let trashedPath = try XCTUnwrap(result.trashedPaths.first)
+        XCTAssertTrue(fileManager.fileExists(atPath: trashedPath))
+        XCTAssertTrue(
+            trashedPath.hasPrefix(
+                fileManager.homeDirectoryForCurrentUser
+                    .appendingPathComponent(".Trash", isDirectory: true)
+                    .path + "/"
+            )
+        )
+        try? fileManager.removeItem(atPath: trashedPath)
+        for directory in preservedDirectories {
+            XCTAssertTrue(fileManager.fileExists(atPath: directory.appendingPathComponent("must-survive").path))
+        }
+    }
+
+    func testManagedDerivedDataSafetyOnlyAllowsDerivedDataDirectories() {
+        let home = URL(fileURLWithPath: "/Users/tester", isDirectory: true)
+        let managedRoot = "/Users/tester/Library/Developer/XcodeBuildMCP"
+
+        XCTAssertTrue(XcodeBuildMCPDerivedDataSupport.isManagedDerivedDataPath(
+            "\(managedRoot)/workspaces/PureMac-59316969cafe/DerivedData",
+            homeDirectory: home
+        ))
+        XCTAssertTrue(XcodeBuildMCPDerivedDataSupport.isManagedDerivedDataPath(
+            "\(managedRoot)/DerivedData",
+            homeDirectory: home
+        ))
+        XCTAssertFalse(XcodeBuildMCPDerivedDataSupport.isManagedDerivedDataPath(
+            "\(managedRoot)/workspaces/PureMac-59316969cafe/logs",
+            homeDirectory: home
+        ))
+        XCTAssertFalse(XcodeBuildMCPDerivedDataSupport.isManagedDerivedDataPath(
+            "\(managedRoot)/workspaces/PureMac-59316969cafe",
+            homeDirectory: home
+        ))
+        XCTAssertFalse(XcodeBuildMCPDerivedDataSupport.isManagedDerivedDataPath(
+            "\(managedRoot)-backup/workspaces/PureMac-59316969cafe/DerivedData",
+            homeDirectory: home
+        ))
+    }
+
+    func testSymlinkedHomeScanOutputCanStillBeCleaned() async throws {
+        let fileManager = FileManager.default
+        let container = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-HomeLink-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: container) }
+
+        let realHome = container.appendingPathComponent("real-home", isDirectory: true)
+        let linkedHome = container.appendingPathComponent("linked-home", isDirectory: true)
+        let derivedData = realHome
+            .appendingPathComponent("Library/Developer/XcodeBuildMCP/workspaces/PureMac-59316969cafe/DerivedData", isDirectory: true)
+        try fileManager.createDirectory(at: derivedData, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: container, withIntermediateDirectories: true)
+        try fileManager.createSymbolicLink(at: linkedHome, withDestinationURL: realHome)
+        try Data(repeating: 0xA1, count: 4_096)
+            .write(to: derivedData.appendingPathComponent("build-product"))
+
+        let scan = await ScanEngine(homeDirectory: linkedHome).scanCategory(.xcodeJunk)
+        let item = try XCTUnwrap(scan.items.first { $0.name == "XcodeBuildMCP: PureMac" })
+        let result = await CleaningEngine(homeDirectory: linkedHome).cleanItems([item]) { _ in }
+
+        XCTAssertEqual(result.itemsCleaned, 1)
+        XCTAssertTrue(result.errors.isEmpty)
+        XCTAssertFalse(fileManager.fileExists(atPath: derivedData.path))
+    }
+
+    func testCleaningRejectsDerivedDataSymlinkToAnotherManagedWorkspace() async throws {
+        let fileManager = FileManager.default
+        let temporaryHome = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-ManagedLink-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: temporaryHome) }
+
+        let workspaces = temporaryHome
+            .appendingPathComponent("Library/Developer/XcodeBuildMCP/workspaces", isDirectory: true)
+        let sourceWorkspace = workspaces.appendingPathComponent("Source-111111111111", isDirectory: true)
+        let targetDerivedData = workspaces
+            .appendingPathComponent("Target-222222222222/DerivedData", isDirectory: true)
+        let apparentDerivedData = sourceWorkspace.appendingPathComponent("DerivedData", isDirectory: true)
+        try fileManager.createDirectory(at: sourceWorkspace, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: targetDerivedData, withIntermediateDirectories: true)
+        try Data(repeating: 0xB2, count: 4_096)
+            .write(to: targetDerivedData.appendingPathComponent("must-survive"))
+        try fileManager.createSymbolicLink(at: apparentDerivedData, withDestinationURL: targetDerivedData)
+
+        let item = CleanableItem(
+            name: "XcodeBuildMCP: Source",
+            path: apparentDerivedData.path,
+            size: 4_096,
+            category: .xcodeJunk,
+            isSelected: true,
+            lastModified: nil
+        )
+        let result = await CleaningEngine(homeDirectory: temporaryHome).cleanItems([item]) { _ in }
+
+        XCTAssertEqual(result.itemsCleaned, 0)
+        XCTAssertFalse(result.errors.isEmpty)
+        XCTAssertTrue(fileManager.fileExists(atPath: targetDerivedData.appendingPathComponent("must-survive").path))
+    }
+
+    func testAdministratorCleaningNeverEscalatesManagedDerivedData() async throws {
+        let fileManager = FileManager.default
+        let temporaryHome = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-NoAdmin-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: temporaryHome) }
+
+        let derivedData = temporaryHome
+            .appendingPathComponent("Library/Developer/XcodeBuildMCP/workspaces/PureMac-59316969cafe/DerivedData", isDirectory: true)
+        let marker = derivedData.appendingPathComponent("must-survive")
+        try fileManager.createDirectory(at: derivedData, withIntermediateDirectories: true)
+        try Data(repeating: 0xC3, count: 4_096).write(to: marker)
+        let item = CleanableItem(
+            name: "XcodeBuildMCP: PureMac",
+            path: derivedData.path,
+            size: 4_096,
+            category: .xcodeJunk,
+            isSelected: true,
+            lastModified: nil
+        )
+
+        let result = await CleaningEngine(homeDirectory: temporaryHome)
+            .cleanWithAdminPrivileges(items: [item])
+
+        XCTAssertEqual(result.itemsCleaned, 0)
+        XCTAssertTrue(fileManager.fileExists(atPath: marker.path))
+    }
+
+    func testCleaningSkipsDerivedDataWhenLifecycleLockIsHeld() async throws {
+        let fileManager = FileManager.default
+        let temporaryHome = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-Lock-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: temporaryHome) }
+
+        let workspaceRoot = temporaryHome
+            .appendingPathComponent("Library/Developer/XcodeBuildMCP/workspaces/PureMac-59316969cafe", isDirectory: true)
+        let derivedData = workspaceRoot.appendingPathComponent("DerivedData", isDirectory: true)
+        let lockDir = workspaceRoot
+            .appendingPathComponent("locks/filesystem-lifecycle.lock", isDirectory: true)
+        try fileManager.createDirectory(at: derivedData, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: lockDir, withIntermediateDirectories: true)
+        try Data(repeating: 0xAB, count: 4_096)
+            .write(to: derivedData.appendingPathComponent("build-product"))
+
+        let nowMs = Date().timeIntervalSince1970 * 1000
+        let owner: [String: Any] = [
+            "token": UUID().uuidString,
+            "pid": Int(getpid()),
+            "purpose": "filesystem-lifecycle",
+            "acquiredAtMs": nowMs,
+            "expiresAtMs": nowMs + 600_000,
+        ]
+        let ownerData = try JSONSerialization.data(withJSONObject: owner)
+        try ownerData.write(to: lockDir.appendingPathComponent("owner.json"))
+
+        let item = CleanableItem(
+            name: "XcodeBuildMCP: PureMac",
+            path: derivedData.path,
+            size: 4_096,
+            category: .xcodeJunk,
+            isSelected: true,
+            lastModified: nil
+        )
+        let result = await CleaningEngine(homeDirectory: temporaryHome)
+            .cleanItems([item]) { _ in }
+
+        XCTAssertEqual(result.itemsCleaned, 0)
+        XCTAssertFalse(result.errors.isEmpty)
+        XCTAssertTrue(fileManager.fileExists(atPath: derivedData.appendingPathComponent("build-product").path))
+    }
+
+    func testLifecycleLockDetectionMatchesXcodeBuildMCPOwnerFile() throws {
+        let fileManager = FileManager.default
+        let temporaryHome = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-LockDetect-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: temporaryHome) }
+
+        let derivedData = temporaryHome
+            .appendingPathComponent("Library/Developer/XcodeBuildMCP/workspaces/PureMac-59316969cafe/DerivedData", isDirectory: true)
+        let lockDir = temporaryHome
+            .appendingPathComponent(
+                "Library/Developer/XcodeBuildMCP/workspaces/PureMac-59316969cafe/locks/filesystem-lifecycle.lock",
+                isDirectory: true
+            )
+        try fileManager.createDirectory(at: derivedData, withIntermediateDirectories: true)
+
+        XCTAssertFalse(
+            XcodeBuildMCPDerivedDataSupport.isLifecycleLockHeld(
+                forManagedDerivedDataPath: derivedData.path,
+                homeDirectory: temporaryHome,
+                fileManager: fileManager,
+                isProcessAlive: { _ in false }
+            )
+        )
+
+        try fileManager.createDirectory(at: lockDir, withIntermediateDirectories: true)
+        // A fresh lock directory without owner.json is treated as held — same
+        // conservative stance XcodeBuildMCP takes within the lease window.
+        XCTAssertTrue(
+            XcodeBuildMCPDerivedDataSupport.isLifecycleLockHeld(
+                forManagedDerivedDataPath: derivedData.path,
+                homeDirectory: temporaryHome,
+                fileManager: fileManager,
+                isProcessAlive: { _ in false }
+            )
+        )
+
+        let nowMs = Date().timeIntervalSince1970 * 1000
+        let expiredOwner: [String: Any] = [
+            "token": "abc",
+            "pid": 4242,
+            "purpose": "purge",
+            "acquiredAtMs": nowMs - 1_200_000,
+            "expiresAtMs": nowMs - 600_000,
+        ]
+        try JSONSerialization.data(withJSONObject: expiredOwner)
+            .write(to: lockDir.appendingPathComponent("owner.json"))
+
+        XCTAssertFalse(
+            XcodeBuildMCPDerivedDataSupport.isLifecycleLockHeld(
+                forManagedDerivedDataPath: derivedData.path,
+                homeDirectory: temporaryHome,
+                fileManager: fileManager,
+                isProcessAlive: { _ in false }
+            )
+        )
+
+        let liveOwner: [String: Any] = [
+            "token": "def",
+            "pid": 4242,
+            "purpose": "purge",
+            "acquiredAtMs": nowMs,
+            "expiresAtMs": nowMs + 60_000,
+        ]
+        try JSONSerialization.data(withJSONObject: liveOwner)
+            .write(to: lockDir.appendingPathComponent("owner.json"))
+
+        XCTAssertTrue(
+            XcodeBuildMCPDerivedDataSupport.isLifecycleLockHeld(
+                forManagedDerivedDataPath: derivedData.path,
+                homeDirectory: temporaryHome,
+                fileManager: fileManager,
+                isProcessAlive: { _ in false }
+            )
+        )
+    }
+
+    func testLifecycleLockAcquisitionIsExclusive() throws {
+        let fileManager = FileManager.default
+        let temporaryHome = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-LockAcquire-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: temporaryHome) }
+
+        let derivedData = temporaryHome
+            .appendingPathComponent(
+                "Library/Developer/XcodeBuildMCP/workspaces/PureMac-59316969cafe/DerivedData",
+                isDirectory: true
+            )
+        try fileManager.createDirectory(at: derivedData, withIntermediateDirectories: true)
+
+        let first = XcodeBuildMCPDerivedDataSupport.acquireLifecycleLock(
+            forManagedDerivedDataPath: derivedData.path,
+            homeDirectory: temporaryHome,
+            fileManager: fileManager
+        )
+        XCTAssertNotNil(first)
+        XCTAssertTrue(
+            XcodeBuildMCPDerivedDataSupport.isLifecycleLockHeld(
+                forManagedDerivedDataPath: derivedData.path,
+                homeDirectory: temporaryHome,
+                fileManager: fileManager
+            )
+        )
+
+        let second = XcodeBuildMCPDerivedDataSupport.acquireLifecycleLock(
+            forManagedDerivedDataPath: derivedData.path,
+            homeDirectory: temporaryHome,
+            fileManager: fileManager
+        )
+        XCTAssertNil(second)
+
+        if let first {
+            XcodeBuildMCPDerivedDataSupport.releaseLifecycleLock(
+                first,
+                fileManager: fileManager
+            )
+        }
+        XCTAssertFalse(
+            XcodeBuildMCPDerivedDataSupport.isLifecycleLockHeld(
+                forManagedDerivedDataPath: derivedData.path,
+                homeDirectory: temporaryHome,
+                fileManager: fileManager,
+                isProcessAlive: { _ in false }
+            )
+        )
+    }
+
+    func testSymlinkedHomeAllowlistsOrdinaryCachesConsistently() async throws {
+        let fileManager = FileManager.default
+        let container = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-CacheHome-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: container) }
+
+        let realHome = container.appendingPathComponent("real-home", isDirectory: true)
+        let linkedHome = container.appendingPathComponent("linked-home", isDirectory: true)
+        let cacheDir = realHome.appendingPathComponent("Library/Caches/com.example.junk", isDirectory: true)
+        try fileManager.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: container, withIntermediateDirectories: true)
+        try fileManager.createSymbolicLink(at: linkedHome, withDestinationURL: realHome)
+        try Data(repeating: 0x11, count: 4_096)
+            .write(to: cacheDir.appendingPathComponent("blob"))
+
+        let item = CleanableItem(
+            name: "com.example.junk",
+            path: cacheDir.path,
+            size: 4_096,
+            category: .userCache,
+            isSelected: true,
+            lastModified: nil
+        )
+        let result = await CleaningEngine(homeDirectory: linkedHome).cleanItems([item]) { _ in }
+
+        XCTAssertEqual(result.itemsCleaned, 1)
+        XCTAssertTrue(result.errors.isEmpty)
+        XCTAssertFalse(fileManager.fileExists(atPath: cacheDir.appendingPathComponent("blob").path))
+    }
+
+    func testScheduledAutoCleanAllowsOldUnlockedManagedDerivedData() {
+        let item = CleanableItem(
+            name: "XcodeBuildMCP: PureMac",
+            path: "/Users/tester/Library/Developer/XcodeBuildMCP/workspaces/PureMac-59316969cafe/DerivedData",
+            size: 4_096,
+            category: .xcodeJunk,
+            isSelected: true,
+            lastModified: Date(timeIntervalSince1970: 0)
+        )
+
+        XCTAssertTrue(
+            XcodeBuildMCPDerivedDataSupport.isEligibleForScheduledAutoClean(
+                item,
+                homeDirectory: URL(fileURLWithPath: "/Users/tester", isDirectory: true),
+                now: Date(timeIntervalSince1970: XcodeBuildMCPDerivedDataSupport.scheduledCleanupAge + 1)
+            )
+        )
+    }
+
+    func testScheduledAutoCleanRejectsRecentManagedDerivedData() {
+        let now = Date(timeIntervalSince1970: 10_000_000)
+        let item = CleanableItem(
+            name: "XcodeBuildMCP: PureMac",
+            path: "/Users/tester/Library/Developer/XcodeBuildMCP/workspaces/PureMac-59316969cafe/DerivedData",
+            size: 4_096,
+            category: .xcodeJunk,
+            isSelected: true,
+            lastModified: now.addingTimeInterval(-XcodeBuildMCPDerivedDataSupport.scheduledCleanupAge + 1)
+        )
+
+        XCTAssertFalse(
+            XcodeBuildMCPDerivedDataSupport.isEligibleForScheduledAutoClean(
+                item,
+                homeDirectory: URL(fileURLWithPath: "/Users/tester", isDirectory: true),
+                now: now
+            )
+        )
+    }
+
+    func testScheduledAutoCleanRejectsManagedDerivedDataWithActiveLifecycleLock() throws {
+        let fileManager = FileManager.default
+        let temporaryHome = fileManager.temporaryDirectory
+            .appendingPathComponent("PureMac-XcodeBuildMCP-ScheduledLock-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: temporaryHome) }
+
+        let derivedData = temporaryHome.appendingPathComponent(
+            "Library/Developer/XcodeBuildMCP/workspaces/PureMac-59316969cafe/DerivedData",
+            isDirectory: true
+        )
+        let lockDir = temporaryHome.appendingPathComponent(
+            "Library/Developer/XcodeBuildMCP/workspaces/PureMac-59316969cafe/locks/filesystem-lifecycle.lock",
+            isDirectory: true
+        )
+        try fileManager.createDirectory(at: derivedData, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: lockDir, withIntermediateDirectories: true)
+
+        let now = Date(timeIntervalSince1970: 10_000_000)
+        let owner: [String: Any] = [
+            "token": UUID().uuidString,
+            "pid": 4242,
+            "purpose": "filesystem-lifecycle",
+            "acquiredAtMs": (now.timeIntervalSince1970 - 60) * 1000,
+            "expiresAtMs": (now.timeIntervalSince1970 + 60) * 1000,
+        ]
+        try JSONSerialization.data(withJSONObject: owner)
+            .write(to: lockDir.appendingPathComponent("owner.json"))
+
+        let item = CleanableItem(
+            name: "XcodeBuildMCP: PureMac",
+            path: derivedData.path,
+            size: 4_096,
+            category: .xcodeJunk,
+            isSelected: true,
+            lastModified: now.addingTimeInterval(-XcodeBuildMCPDerivedDataSupport.scheduledCleanupAge - 1)
+        )
+
+        XCTAssertFalse(
+            XcodeBuildMCPDerivedDataSupport.isEligibleForScheduledAutoClean(
+                item,
+                homeDirectory: temporaryHome,
+                now: now,
+                fileManager: fileManager,
+                isProcessAlive: { _ in false }
+            )
+        )
+    }
+
+    func testScheduledAutoCleanKeepsOrdinarySelectionSemantics() {
+        let ordinary = CleanableItem(
+            name: "DerivedData",
+            path: "/Users/tester/Library/Developer/Xcode/DerivedData",
+            size: 4_096,
+            category: .xcodeJunk,
+            isSelected: true,
+            lastModified: nil
+        )
+        let home = URL(fileURLWithPath: "/Users/tester", isDirectory: true)
+
+        XCTAssertTrue(
+            XcodeBuildMCPDerivedDataSupport.isEligibleForScheduledAutoClean(ordinary, homeDirectory: home)
+        )
     }
 }

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Smart Scan runs every category in parallel. Each category is its own deliberate 
 - **Mail Files** - downloaded mail attachments
 - **Trash Bins** - empties all bins, including external volumes
 - **Large & Old Files** - >100 MB or older than 1 year (never auto-selected)
-- **Xcode Junk** - DerivedData, Archives, simulator caches, and downloaded simulator runtimes (deleted via `simctl runtime delete`; never auto-selected)
+- **Xcode Junk** - DerivedData, Archives, simulator caches, downloaded simulator runtimes (deleted via `simctl runtime delete`; never auto-selected), and XcodeBuildMCP DerivedData (scheduled only when older than 7 days and unlocked; Trash-only)
 - **Brew Cache** - respects custom `HOMEBREW_CACHE`
 - **Node Cache** - npm, yarn classic, pnpm content-addressable store
 - **Docker Cache** - images, containers, build cache


### PR DESCRIPTION
## What does this PR do?

Adds XcodeBuildMCP-managed DerivedData to PureMac Xcode Junk cleanup while preserving the existing cleanup safety contract.

- Discovers legacy and per-workspace XcodeBuildMCP DerivedData paths only.
- Uses the same default selection behavior as ordinary Xcode DerivedData.
- Allows scheduled cleanup only for data older than 7 days and without an active lifecycle lock.
- Re-checks and atomically acquires the workspace lifecycle lock before moving data to Trash.
- Keeps workspace logs, state, result bundles, test products, and locks intact.
- Canonicalizes symlinked homes consistently between scanning and cleaning.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] UI/UX enhancement
- [ ] Documentation
- [ ] Other (describe)

## Testing

- [ ] Tested on macOS Ventura (13.x)
- [ ] Tested on macOS Sonoma (14.x)
- [ ] Tested on macOS Sequoia (15.x)
- [x] Full macOS test suite: 40 tests passed
- [x] Regression coverage for recent data, active lifecycle locks, symlinked homes, and workspace state preservation

## Screenshots

Not applicable.