### PR TITLE
feat: safely clean stale Git worktrees

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,20 @@ jobs:
       - name: Generate Xcode project
         run: xcodegen generate
 
+      - name: Test
+        run: |
+          xcodebuild -project PureMac.xcodeproj \
+            -scheme PureMac \
+            -configuration Debug \
+            -derivedDataPath build/tests \
+            -destination "platform=macOS" \
+            test \
+            ARCHS="$(uname -m)" \
+            ONLY_ACTIVE_ARCH=YES \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
+
       - name: Build (Universal Binary)
         run: |
           xcodebuild -project PureMac.xcodeproj \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, feature/ai-dead-worktree-cleanup]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   workflow_dispatch:
   push:
-    branches: [main, feature/ai-dead-worktree-cleanup]
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install XcodeGen
         run: brew install xcodegen

--- a/PureMac.xcodeproj/project.pbxproj
+++ b/PureMac.xcodeproj/project.pbxproj
@@ -14,7 +14,9 @@
 		27F449EDD1B082FE11FEC9DF /* SchedulerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28181F034530331A550C6A3D /* SchedulerService.swift */; };
 		340E424F759ACCDE7372F99F /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5ADDC35F31E40780FB5D017 /* Theme.swift */; };
 		39BEE5E2BEC526CCADFC9DDD /* ServicesMenu.strings in Resources */ = {isa = PBXBuildFile; fileRef = 57FBBF8C7EF27C8E09126ED5 /* ServicesMenu.strings */; };
+		3F9F0BF014FE1CBB1EA9DACD /* GitWorktreeScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE2E4F04F1786EBAFC611C1 /* GitWorktreeScannerTests.swift */; };
 		41B27CACD7C6C7471EFD03F9 /* UpdateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022D0EAEE2B6E54069FC2CBE /* UpdateService.swift */; };
+		4489E1FA82AF5E1D43E5898C /* GitWorktreeScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A64B3290A5E869004494017 /* GitWorktreeScanner.swift */; };
 		47C5ECD49C4DD75F271DB6CE /* StringNormalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3AC5F17D7CA94FAB1E8D7A /* StringNormalization.swift */; };
 		48D1431A7C99C19EEBDB056B /* CleaningEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A8DE5D45BA19E2670B57DC5 /* CleaningEngine.swift */; };
 		4F754D89F4CE5142BE384062 /* AppConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31F91226CDCFBB8E303B7DA /* AppConstants.swift */; };
@@ -87,6 +89,7 @@
 		0A544093C897FBCBA8E256F9 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		10B0AF194677EAC1D5568785 /* CategoryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDetailView.swift; sourceTree = "<group>"; };
 		155CE1B8CDCCCA6F9FD028C1 /* LocalizationFilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationFilesTests.swift; sourceTree = "<group>"; };
+		1A64B3290A5E869004494017 /* GitWorktreeScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitWorktreeScanner.swift; sourceTree = "<group>"; };
 		1AB003A7751F05727DBFD1A5 /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
 		1C0D9A6F75D0B8ADDB32FC2A /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Localizable.strings; sourceTree = "<group>"; };
 		1D3AC5F17D7CA94FAB1E8D7A /* StringNormalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringNormalization.swift; sourceTree = "<group>"; };
@@ -96,6 +99,7 @@
 		2641C6376DD6F5889F35510E /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		28181F034530331A550C6A3D /* SchedulerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulerService.swift; sourceTree = "<group>"; };
 		2A8DE5D45BA19E2670B57DC5 /* CleaningEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleaningEngine.swift; sourceTree = "<group>"; };
+		2AE2E4F04F1786EBAFC611C1 /* GitWorktreeScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitWorktreeScannerTests.swift; sourceTree = "<group>"; };
 		2D3F9FEDC493A8E49E910F67 /* AppBundleDragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBundleDragHandle.swift; sourceTree = "<group>"; };
 		311078221878708524283765 /* PureMac.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PureMac.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		340D303C60FF878B019056B6 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -185,6 +189,7 @@
 			children = (
 				491771F923C93FD61A263893 /* AppLanguagePreferencesTests.swift */,
 				752603285F7DBBA12BB3AA91 /* AppStateTests.swift */,
+				2AE2E4F04F1786EBAFC611C1 /* GitWorktreeScannerTests.swift */,
 				155CE1B8CDCCCA6F9FD028C1 /* LocalizationFilesTests.swift */,
 				C7D81BE7EA5DB17F4A0300AD /* SimulatorRuntimeSupportTests.swift */,
 				55CE234DB2DB54ED53A4EFD6 /* ThemeManagerTests.swift */,
@@ -350,6 +355,7 @@
 				23486A54A82EE3865B784D1C /* AppInfoFetcher.swift */,
 				AC0FEE7141871ED5F9E36121 /* AppPathFinder.swift */,
 				CB94E06E145558123BB5BFB3 /* Conditions.swift */,
+				1A64B3290A5E869004494017 /* GitWorktreeScanner.swift */,
 				C0899FE169D270DF95334905 /* LanguageFilesScanner.swift */,
 				77D3D9A9BC52839E6D0A22BC /* Locations.swift */,
 				1D3AC5F17D7CA94FAB1E8D7A /* StringNormalization.swift */,
@@ -502,6 +508,7 @@
 				25E2304A3FF257F1740E304B /* FileProtection.swift in Sources */,
 				B51E5A95BB49A6C0F5273E21 /* FileSize.swift in Sources */,
 				2253F11BDF561B617439C96B /* FullDiskAccessManager.swift in Sources */,
+				4489E1FA82AF5E1D43E5898C /* GitWorktreeScanner.swift in Sources */,
 				A549D8A39A9E5E70D91B90A6 /* Haptics.swift in Sources */,
 				9E87638A3F12C12D93995DA7 /* LanguageFilesScanner.swift in Sources */,
 				E60B0A2C5D0A6CAE35BF4DFB /* Locations.swift in Sources */,
@@ -537,6 +544,7 @@
 			files = (
 				59B3096E2AE8ED0397B16798 /* AppLanguagePreferencesTests.swift in Sources */,
 				E2403D82F00D749C9AD4A6D4 /* AppStateTests.swift in Sources */,
+				3F9F0BF014FE1CBB1EA9DACD /* GitWorktreeScannerTests.swift in Sources */,
 				CFA64F54CDBF8A4765E0068D /* LocalizationFilesTests.swift in Sources */,
 				F4F02F966001A1504C2B4D33 /* SimulatorRuntimeSupportTests.swift in Sources */,
 				ABE3B80279483DB90B8EC1BC /* ThemeManagerTests.swift in Sources */,

--- a/PureMac/Logic/Scanning/GitWorktreeScanner.swift
+++ b/PureMac/Logic/Scanning/GitWorktreeScanner.swift
@@ -567,6 +567,10 @@ struct GitWorktreeScanner {
             return "Claude Code"
         }
         if normalized.contains("/.cursor/worktrees/") { return "Cursor" }
+        if normalized.contains("/.herdr/worktrees/")
+            || normalized.contains("/herdr-worktrees/") {
+            return "Herdr"
+        }
         if normalized.contains("/.omp/wt/") { return "Oh My Pi" }
         if normalized.contains("/.pi/") || normalized.contains("/.git/worktrees/")
             || normalized.contains("/.worktrees/") || normalized.contains("/.worktree/") {

--- a/PureMac/Logic/Scanning/GitWorktreeScanner.swift
+++ b/PureMac/Logic/Scanning/GitWorktreeScanner.swift
@@ -1,0 +1,594 @@
+import Foundation
+
+/// Finds old, clean linked worktrees across the user's home and writable local
+/// mounted volumes, then removes them through Git rather than unlinking their
+/// directories directly. Git remains the source of truth for registration,
+/// locks, dirty state, branches, and detached commits.
+struct GitWorktreeScanner {
+    static let defaultInactivityInterval: TimeInterval = 30 * 24 * 60 * 60
+
+    struct CommandResult {
+        let status: Int32
+        let stdout: Data
+        let stderr: Data
+    }
+
+    struct WorktreeRecord: Equatable {
+        let path: String
+        let head: String?
+        let branch: String?
+        let isDetached: Bool
+        let isBare: Bool
+        let isLocked: Bool
+        let isPrunable: Bool
+    }
+
+    struct RemovalResult {
+        let removed: Bool
+        let error: String?
+    }
+
+    typealias CommandRunner = (_ executablePath: String, _ arguments: [String]) -> CommandResult
+
+    private struct WorktreeMetrics {
+        let size: Int64
+        let lastModified: Date
+    }
+
+    private struct WorktreeRecordBuilder {
+        var path: String?
+        var head: String?
+        var branch: String?
+        var isDetached = false
+        var isBare = false
+        var isLocked = false
+        var isPrunable = false
+    }
+
+    private let fileManager: FileManager
+    private let homeURL: URL
+    /// `nil` discovers mounted volumes at scan time. Tests can pass an explicit
+    /// list (including an empty one) to keep discovery deterministic.
+    private let mountedVolumeURLs: [URL]?
+    private let now: Date
+    private let inactivityInterval: TimeInterval
+    private let gitExecutablePath: String?
+    private let commandRunner: CommandRunner
+
+    init(
+        fileManager: FileManager = .default,
+        homeURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+        mountedVolumeURLs: [URL]? = nil,
+        now: Date = Date(),
+        inactivityInterval: TimeInterval = GitWorktreeScanner.defaultInactivityInterval,
+        gitExecutablePath: String? = GitWorktreeScanner.defaultGitExecutablePath(),
+        commandRunner: @escaping CommandRunner = GitWorktreeScanner.runCommand
+    ) {
+        self.fileManager = fileManager
+        self.homeURL = homeURL.standardizedFileURL
+        self.mountedVolumeURLs = mountedVolumeURLs?.map(\.standardizedFileURL)
+        self.now = now
+        self.inactivityInterval = inactivityInterval
+        self.gitExecutablePath = gitExecutablePath
+        self.commandRunner = commandRunner
+    }
+
+    /// Returns opt-in cleanup rows for linked worktrees that are:
+    /// - at least 30 days inactive by default,
+    /// - registered and unlocked,
+    /// - clean according to Git, and
+    /// - backed by a branch/ref so removing the checkout cannot orphan commits.
+    func scan(
+        report: ((String) -> Void)? = nil,
+        isCancelled: () -> Bool = { false }
+    ) -> [CleanableItem] {
+        guard let gitExecutablePath else { return [] }
+
+        var lastReportedAt = Date.distantPast
+        let throttledReport: (String) -> Void = { path in
+            guard let report else { return }
+            let reportDate = Date()
+            guard reportDate.timeIntervalSince(lastReportedAt) > 0.1 else { return }
+            lastReportedAt = reportDate
+            report(path)
+        }
+
+        let repositoryRoots = discoverRepositoryRoots(report: throttledReport, isCancelled: isCancelled)
+        var seenCommonDirectories: Set<String> = []
+        var seenWorktreePaths: Set<String> = []
+        var items: [CleanableItem] = []
+        let staleBefore = now.addingTimeInterval(-inactivityInterval)
+
+        for repositoryRoot in repositoryRoots.sorted() {
+            if isCancelled() { break }
+            guard let commonDirectory = commonGitDirectory(
+                for: repositoryRoot,
+                gitExecutablePath: gitExecutablePath
+            ), seenCommonDirectories.insert(commonDirectory).inserted else {
+                continue
+            }
+
+            let listResult = runGit(
+                ["--git-dir", commonDirectory, "worktree", "list", "--porcelain", "-z"],
+                gitExecutablePath: gitExecutablePath
+            )
+            guard listResult.status == 0 else { continue }
+
+            let repositoryName = Self.repositoryName(forCommonDirectory: commonDirectory)
+            for record in Self.parseWorktreeList(listResult.stdout) {
+                if isCancelled() { break }
+                let normalizedPath = Self.normalizePath(record.path)
+                guard seenWorktreePaths.insert(normalizedPath).inserted,
+                      isLinkedWorktree(at: normalizedPath),
+                      isSafeToRemove(
+                        record,
+                        commonDirectory: commonDirectory,
+                        gitExecutablePath: gitExecutablePath
+                      ) else {
+                    continue
+                }
+
+                throttledReport(normalizedPath)
+                let metrics = worktreeMetrics(
+                    at: normalizedPath,
+                    report: throttledReport,
+                    isCancelled: isCancelled
+                )
+                guard metrics.size > 1024, metrics.lastModified <= staleBefore else { continue }
+
+                let provider = Self.providerName(for: normalizedPath)
+                let name = String(
+                    format: String(localized: "%@ Worktree — %@"),
+                    provider,
+                    repositoryName
+                )
+                items.append(CleanableItem(
+                    name: name,
+                    path: CleanableItem.gitWorktreePathPrefix + normalizedPath,
+                    size: metrics.size,
+                    category: .aiApps,
+                    isSelected: false,
+                    lastModified: metrics.lastModified
+                ))
+            }
+        }
+
+        return items.sorted {
+            if $0.size != $1.size { return $0.size > $1.size }
+            return $0.name.localizedStandardCompare($1.name) == .orderedAscending
+        }
+    }
+
+    /// Re-checks every scan invariant immediately before asking Git to remove
+    /// the linked worktree. `--force` is deliberately never used.
+    func removeWorktree(at path: String) -> RemovalResult {
+        guard let gitExecutablePath else {
+            return RemovalResult(removed: false, error: "Git is not available")
+        }
+
+        let normalizedPath = Self.normalizePath(path)
+        guard isLinkedWorktree(at: normalizedPath),
+              let commonDirectory = commonGitDirectory(
+                for: normalizedPath,
+                gitExecutablePath: gitExecutablePath
+              ) else {
+            return RemovalResult(removed: false, error: "Not a registered linked worktree")
+        }
+
+        let listResult = runGit(
+            ["--git-dir", commonDirectory, "worktree", "list", "--porcelain", "-z"],
+            gitExecutablePath: gitExecutablePath
+        )
+        guard listResult.status == 0,
+              let record = Self.parseWorktreeList(listResult.stdout).first(where: {
+                Self.normalizePath($0.path) == normalizedPath
+              }),
+              isSafeToRemove(
+                record,
+                commonDirectory: commonDirectory,
+                gitExecutablePath: gitExecutablePath
+              ) else {
+            return RemovalResult(
+                removed: false,
+                error: "Worktree is active, changed, locked, or contains unreferenced commits"
+            )
+        }
+
+        let removeResult = runGit(
+            ["--git-dir", commonDirectory, "worktree", "remove", normalizedPath],
+            gitExecutablePath: gitExecutablePath
+        )
+        guard removeResult.status == 0 else {
+            let detail = Self.string(from: removeResult.stderr)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return RemovalResult(
+                removed: false,
+                error: detail.isEmpty ? "Git refused to remove the worktree" : detail
+            )
+        }
+
+        guard !fileManager.fileExists(atPath: normalizedPath) else {
+            return RemovalResult(removed: false, error: "Worktree still exists after Git cleanup")
+        }
+        return RemovalResult(removed: true, error: nil)
+    }
+
+    // MARK: - Discovery
+
+    private func discoverRepositoryRoots(
+        report: ((String) -> Void)?,
+        isCancelled: () -> Bool
+    ) -> Set<String> {
+        var roots: Set<String> = []
+        var discoveryRoots = [homeURL]
+        discoveryRoots.append(contentsOf: mountedVolumeURLs ?? discoverMountedVolumeURLs())
+
+        let environment = ProcessInfo.processInfo.environment
+        if let codexHome = expandedAbsolutePath(environment["CODEX_HOME"]) {
+            discoveryRoots.append(URL(fileURLWithPath: codexHome).appendingPathComponent("worktrees"))
+        }
+        if let ompWorktrees = expandedAbsolutePath(environment["OMP_WORKTREE_DIR"]) {
+            discoveryRoots.append(URL(fileURLWithPath: ompWorktrees))
+        }
+
+        for discoveryRoot in Set(discoveryRoots.map(\.standardizedFileURL)) {
+            if isCancelled() { break }
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: discoveryRoot.path, isDirectory: &isDirectory),
+                  isDirectory.boolValue else {
+                continue
+            }
+
+            if hasGitMarker(at: discoveryRoot) {
+                roots.insert(discoveryRoot.path)
+                continue
+            }
+
+            let keys: [URLResourceKey] = [.isDirectoryKey, .isSymbolicLinkKey]
+            guard let enumerator = fileManager.enumerator(
+                at: discoveryRoot,
+                includingPropertiesForKeys: keys,
+                options: [.skipsPackageDescendants],
+                errorHandler: { _, _ in true }
+            ) else {
+                continue
+            }
+
+            while let url = enumerator.nextObject() as? URL {
+                if isCancelled() { break }
+                report?(url.path)
+                guard let values = try? url.resourceValues(forKeys: Set(keys)) else { continue }
+
+                if values.isSymbolicLink == true {
+                    enumerator.skipDescendants()
+                    continue
+                }
+                guard values.isDirectory == true else { continue }
+
+                if shouldPruneDirectory(url, discoveryRoot: discoveryRoot) {
+                    enumerator.skipDescendants()
+                    continue
+                }
+                if hasGitMarker(at: url) {
+                    roots.insert(url.standardizedFileURL.path)
+                    enumerator.skipDescendants()
+                }
+            }
+        }
+
+        return roots
+    }
+    private func discoverMountedVolumeURLs() -> [URL] {
+        let keys: Set<URLResourceKey> = [
+            .volumeIsBrowsableKey,
+            .volumeIsLocalKey,
+            .volumeIsReadOnlyKey,
+        ]
+        let volumes = fileManager.mountedVolumeURLs(
+            includingResourceValuesForKeys: Array(keys),
+            options: [.skipHiddenVolumes]
+        ) ?? []
+
+        return volumes.compactMap { volumeURL in
+            let volume = volumeURL.standardizedFileURL
+            let path = volume.path
+
+            // The startup volume is already covered by the user's home. APFS
+            // support volumes are implementation details, not user disks.
+            guard path != "/", !path.hasPrefix("/System/Volumes/") else { return nil }
+            guard let values = try? volume.resourceValues(forKeys: keys) else { return nil }
+            guard values.volumeIsBrowsable != false,
+                  values.volumeIsLocal != false,
+                  values.volumeIsReadOnly != true else {
+                return nil
+            }
+            return volume
+        }
+    }
+
+    private func hasGitMarker(at directory: URL) -> Bool {
+        let markerPath = directory.appendingPathComponent(".git", isDirectory: false).path
+        guard let attributes = try? fileManager.attributesOfItem(atPath: markerPath),
+              let type = attributes[.type] as? FileAttributeType else {
+            return false
+        }
+        return type == .typeDirectory || type == .typeRegular
+    }
+
+    private func isLinkedWorktree(at path: String) -> Bool {
+        let markerPath = (path as NSString).appendingPathComponent(".git")
+        guard let attributes = try? fileManager.attributesOfItem(atPath: markerPath),
+              let type = attributes[.type] as? FileAttributeType else {
+            return false
+        }
+        return type == .typeRegular
+    }
+
+    private func shouldPruneDirectory(_ url: URL, discoveryRoot: URL) -> Bool {
+        let name = url.lastPathComponent
+        let generatedDirectoryNames: Set<String> = [
+            "node_modules", "DerivedData", "Pods", ".build", "build", "dist",
+            "target", ".swiftpm", ".venv", "venv", "vendor", ".cache", ".npm",
+        ]
+        if generatedDirectoryNames.contains(name) { return true }
+
+        if url.deletingLastPathComponent().standardizedFileURL == homeURL {
+            let nonDevelopmentHomeDirectories: Set<String> = [
+                "Library", "Applications", "Movies", "Music", "Pictures", "Public", ".Trash",
+            ]
+            if nonDevelopmentHomeDirectories.contains(name) { return true }
+        }
+
+        if url.deletingLastPathComponent().standardizedFileURL == discoveryRoot.standardizedFileURL {
+            let volumeMetadataDirectories: Set<String> = [
+                ".DocumentRevisions-V100", ".Spotlight-V100", ".TemporaryItems",
+                ".Trashes", ".fseventsd", "Backups.backupdb", "System Volume Information",
+                "lost+found",
+            ]
+            if volumeMetadataDirectories.contains(name) { return true }
+        }
+
+        return false
+    }
+
+    private func expandedAbsolutePath(_ rawPath: String?) -> String? {
+        guard let rawPath, !rawPath.isEmpty else { return nil }
+        let expanded = (rawPath as NSString).expandingTildeInPath
+        guard expanded.hasPrefix("/") else { return nil }
+        return Self.normalizePath(expanded)
+    }
+
+    // MARK: - Safety checks
+
+    private func commonGitDirectory(for repositoryPath: String, gitExecutablePath: String) -> String? {
+        let result = runGit(
+            ["-C", repositoryPath, "rev-parse", "--git-common-dir"],
+            gitExecutablePath: gitExecutablePath
+        )
+        guard result.status == 0 else { return nil }
+
+        let rawPath = Self.string(from: result.stdout).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawPath.isEmpty else { return nil }
+        if rawPath.hasPrefix("/") { return Self.normalizePath(rawPath) }
+        return URL(fileURLWithPath: rawPath, relativeTo: URL(fileURLWithPath: repositoryPath, isDirectory: true))
+            .standardizedFileURL
+            .path
+    }
+
+    private func isSafeToRemove(
+        _ record: WorktreeRecord,
+        commonDirectory: String,
+        gitExecutablePath: String
+    ) -> Bool {
+        guard !record.isBare, !record.isLocked, !record.isPrunable,
+              fileManager.fileExists(atPath: record.path),
+              isGitClean(at: record.path, gitExecutablePath: gitExecutablePath),
+              headIsPreserved(
+                record,
+                commonDirectory: commonDirectory,
+                gitExecutablePath: gitExecutablePath
+              ) else {
+            return false
+        }
+        return true
+    }
+
+    private func isGitClean(at path: String, gitExecutablePath: String) -> Bool {
+        let result = runGit(
+            ["-C", path, "status", "--porcelain=v1", "-z", "--untracked-files=normal", "--ignore-submodules=none"],
+            gitExecutablePath: gitExecutablePath
+        )
+        return result.status == 0 && result.stdout.isEmpty
+    }
+
+    private func headIsPreserved(
+        _ record: WorktreeRecord,
+        commonDirectory: String,
+        gitExecutablePath: String
+    ) -> Bool {
+        if let branch = record.branch {
+            let result = runGit(
+                ["--git-dir", commonDirectory, "show-ref", "--verify", "--quiet", branch],
+                gitExecutablePath: gitExecutablePath
+            )
+            return result.status == 0
+        }
+
+        guard record.isDetached, let head = record.head,
+              !head.isEmpty, !head.allSatisfy({ $0 == "0" }) else {
+            return false
+        }
+        let result = runGit(
+            [
+                "--git-dir", commonDirectory,
+                "for-each-ref", "--format=%(refname)", "--contains=\(head)",
+                "refs/heads", "refs/remotes", "refs/tags",
+            ],
+            gitExecutablePath: gitExecutablePath
+        )
+        return result.status == 0 && !result.stdout.isEmpty
+    }
+
+    // MARK: - Size and activity
+
+    private func worktreeMetrics(
+        at path: String,
+        report: ((String) -> Void)?,
+        isCancelled: () -> Bool
+    ) -> WorktreeMetrics {
+        let rootDate = (try? fileManager.attributesOfItem(atPath: path)[.modificationDate] as? Date) ?? .distantPast
+        var latestModification = rootDate
+        var totalSize: Int64 = 0
+        let rootURL = URL(fileURLWithPath: path, isDirectory: true)
+        let keys: Set<URLResourceKey> = [
+            .totalFileAllocatedSizeKey,
+            .fileSizeKey,
+            .isRegularFileKey,
+            .isSymbolicLinkKey,
+            .contentModificationDateKey,
+        ]
+
+        guard let enumerator = fileManager.enumerator(
+            at: rootURL,
+            includingPropertiesForKeys: Array(keys),
+            options: [],
+            errorHandler: { _, _ in true }
+        ) else {
+            return WorktreeMetrics(size: 0, lastModified: latestModification)
+        }
+
+        while let fileURL = enumerator.nextObject() as? URL {
+            if isCancelled() { break }
+            report?(fileURL.path)
+            if fileURL.lastPathComponent == ".git",
+               Self.normalizePath(fileURL.deletingLastPathComponent().path) == Self.normalizePath(path) {
+                continue
+            }
+            guard let values = try? fileURL.resourceValues(forKeys: keys) else { continue }
+            if values.isSymbolicLink == true {
+                enumerator.skipDescendants()
+                continue
+            }
+            guard values.isRegularFile == true else { continue }
+            totalSize += Int64(values.totalFileAllocatedSize ?? values.fileSize ?? 0)
+            if let date = values.contentModificationDate, date > latestModification {
+                latestModification = date
+            }
+        }
+
+        return WorktreeMetrics(size: totalSize, lastModified: latestModification)
+    }
+
+    // MARK: - Porcelain parsing and process I/O
+
+    static func parseWorktreeList(_ data: Data) -> [WorktreeRecord] {
+        var records: [WorktreeRecord] = []
+        var current = WorktreeRecordBuilder()
+
+        func appendCurrent() {
+            guard let path = current.path else { return }
+            records.append(WorktreeRecord(
+                path: path,
+                head: current.head,
+                branch: current.branch,
+                isDetached: current.isDetached,
+                isBare: current.isBare,
+                isLocked: current.isLocked,
+                isPrunable: current.isPrunable
+            ))
+            current = WorktreeRecordBuilder()
+        }
+
+        for fieldData in data.split(separator: 0, omittingEmptySubsequences: false) {
+            guard !fieldData.isEmpty else {
+                appendCurrent()
+                continue
+            }
+            let field = String(decoding: fieldData, as: UTF8.self)
+            if field.hasPrefix("worktree ") {
+                if current.path != nil { appendCurrent() }
+                current.path = String(field.dropFirst("worktree ".count))
+            } else if field.hasPrefix("HEAD ") {
+                current.head = String(field.dropFirst("HEAD ".count))
+            } else if field.hasPrefix("branch ") {
+                current.branch = String(field.dropFirst("branch ".count))
+            } else if field == "detached" {
+                current.isDetached = true
+            } else if field == "bare" {
+                current.isBare = true
+            } else if field == "locked" || field.hasPrefix("locked ") {
+                current.isLocked = true
+            } else if field == "prunable" || field.hasPrefix("prunable ") {
+                current.isPrunable = true
+            }
+        }
+        appendCurrent()
+        return records
+    }
+
+    private func runGit(_ arguments: [String], gitExecutablePath: String) -> CommandResult {
+        commandRunner(gitExecutablePath, arguments)
+    }
+
+    static func runCommand(_ executablePath: String, _ arguments: [String]) -> CommandResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            return CommandResult(status: -1, stdout: Data(), stderr: Data(error.localizedDescription.utf8))
+        }
+        let stdout = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderr = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return CommandResult(status: process.terminationStatus, stdout: stdout, stderr: stderr)
+    }
+
+    static func defaultGitExecutablePath(fileManager: FileManager = .default) -> String? {
+        for path in ["/opt/homebrew/bin/git", "/usr/local/bin/git"] where fileManager.isExecutableFile(atPath: path) {
+            return path
+        }
+
+        guard fileManager.isExecutableFile(atPath: "/usr/bin/git") else { return nil }
+        let developerDirectory = runCommand("/usr/bin/xcode-select", ["-p"])
+        return developerDirectory.status == 0 ? "/usr/bin/git" : nil
+    }
+
+    private static func providerName(for path: String) -> String {
+        let normalized = normalizePath(path)
+        if normalized.contains("/.codex/worktrees/") { return "Codex" }
+        if normalized.contains("/.claude/worktrees/") || normalized.contains("/.claude-worktrees/") {
+            return "Claude Code"
+        }
+        if normalized.contains("/.cursor/worktrees/") { return "Cursor" }
+        if normalized.contains("/.omp/wt/") { return "Oh My Pi" }
+        if normalized.contains("/.pi/") || normalized.contains("/.git/worktrees/")
+            || normalized.contains("/.worktrees/") || normalized.contains("/.worktree/") {
+            return "Pi"
+        }
+        return "Git"
+    }
+
+    private static func repositoryName(forCommonDirectory path: String) -> String {
+        let url = URL(fileURLWithPath: path)
+        if url.lastPathComponent == ".git" {
+            return url.deletingLastPathComponent().lastPathComponent
+        }
+        let name = url.lastPathComponent
+        return name.hasSuffix(".git") ? String(name.dropLast(4)) : name
+    }
+
+    private static func normalizePath(_ path: String) -> String {
+        (path as NSString).standardizingPath
+    }
+
+    private static func string(from data: Data) -> String {
+        String(data: data, encoding: .utf8) ?? ""
+    }
+}

--- a/PureMac/Models/Models.swift
+++ b/PureMac/Models/Models.swift
@@ -44,7 +44,7 @@ enum CleaningCategory: String, CaseIterable, Identifiable, Codable {
         case .smartScan: return "Scan everything at once"
         case .systemJunk: return "System caches, logs, and temporary files"
         case .userCache: return "Application caches and browser data"
-        case .aiApps: return "Local AI app logs, caches, and optional history"
+        case .aiApps: return "Local AI app data and stale coding worktrees"
         case .mailAttachments: return "Downloaded mail attachments"
         case .trashBins: return "Files in your Trash"
         case .largeFiles: return "Files over 100 MB or older than 1 year"
@@ -142,6 +142,10 @@ struct CleanableItem: Identifiable, Hashable {
     /// rather than a filesystem unlink. The UUID after the colon is the
     /// runtime disk-image identifier from `simctl runtime list`.
     static let simctlRuntimePathPrefix = "simctl-runtime:"
+    /// Prefix for linked worktrees that must be removed through
+    /// `git worktree remove`, never a raw filesystem unlink.
+    static let gitWorktreePathPrefix = "git-worktree:"
+
 
     let id = UUID()
     let name: String
@@ -165,6 +169,19 @@ struct CleanableItem: Identifiable, Hashable {
         guard path.hasPrefix(Self.simctlRuntimePathPrefix) else { return nil }
         let id = String(path.dropFirst(Self.simctlRuntimePathPrefix.count))
         return id.isEmpty ? nil : id
+    }
+
+    var gitWorktreePath: String? {
+        guard path.hasPrefix(Self.gitWorktreePathPrefix) else { return nil }
+        let worktreePath = String(path.dropFirst(Self.gitWorktreePathPrefix.count))
+        return worktreePath.isEmpty ? nil : worktreePath
+    }
+
+    /// Real path to show or reveal for both normal files and virtual
+    /// git-worktree cleanup rows.
+    var fileSystemPath: String? {
+        if let gitWorktreePath { return gitWorktreePath }
+        return isActionItem ? nil : path
     }
 
     func hash(into hasher: inout Hasher) {

--- a/PureMac/Services/CleaningEngine.swift
+++ b/PureMac/Services/CleaningEngine.swift
@@ -107,6 +107,24 @@ actor CleaningEngine {
                 continue
             }
 
+            if let worktreePath = item.gitWorktreePath {
+                // Linked worktrees carry shared Git metadata outside the
+                // checkout. Raw removal would leave stale registrations and
+                // could orphan detached commits, so revalidate and delegate to
+                // `git worktree remove` without `--force`.
+                let removal = GitWorktreeScanner().removeWorktree(at: worktreePath)
+                if removal.removed {
+                    result.freedSpace += item.size
+                    result.itemsCleaned += 1
+                    result.cleanedPaths.insert(item.path)
+                } else {
+                    let detail = removal.error ?? "Git refused to remove the worktree"
+                    result.errors.append("\(item.name) at \(worktreePath): \(detail)")
+                    Logger.shared.log("Worktree cleanup failed: \(worktreePath): \(detail)", level: .warning)
+                }
+                continue
+            }
+
             do {
                 let itemURL = URL(fileURLWithPath: item.path)
                 guard fileManager.fileExists(atPath: item.path) else { continue }

--- a/PureMac/Services/ScanEngine.swift
+++ b/PureMac/Services/ScanEngine.swift
@@ -265,7 +265,7 @@ actor ScanEngine {
             ),
         ]
 
-        let items = deduplicatedItems(targets.compactMap { target in
+        var items = targets.compactMap { target in
             makeCleanupItem(
                 name: target.name,
                 path: target.path,
@@ -273,9 +273,23 @@ actor ScanEngine {
                 isSelected: target.isSelected,
                 minimumSize: target.minimumSize
             )
-        })
-        let totalSize = items.reduce(0) { $0 + $1.size }
-        return CategoryResult(category: .aiApps, items: items.sorted { $0.size > $1.size }, totalSize: totalSize)
+        }
+        let worktreeScanner = GitWorktreeScanner(
+            fileManager: fileManager,
+            homeURL: URL(fileURLWithPath: home, isDirectory: true)
+        )
+        items.append(contentsOf: worktreeScanner.scan(
+            report: onPath,
+            isCancelled: { Task.isCancelled }
+        ))
+
+        let uniqueItems = deduplicatedItems(items)
+        let totalSize = uniqueItems.reduce(0) { $0 + $1.size }
+        return CategoryResult(
+            category: .aiApps,
+            items: uniqueItems.sorted { $0.size > $1.size },
+            totalSize: totalSize
+        )
     }
 
     private func scanMailAttachments() -> CategoryResult {

--- a/PureMac/Views/CategoryDetailView.swift
+++ b/PureMac/Views/CategoryDetailView.swift
@@ -263,8 +263,8 @@ private struct FileRowView: View {
                         .lineLimit(1)
                         .truncationMode(.middle)
 
-                    if !item.isActionItem {
-                        Text(item.path)
+                    if let fileSystemPath = item.fileSystemPath {
+                        Text(fileSystemPath)
                             .font(.caption)
                             .foregroundStyle(.tertiary)
                             .lineLimit(1)
@@ -281,9 +281,9 @@ private struct FileRowView: View {
 
                 // Hover-revealed Finder shortcut; stays in the layout so the
                 // trailing size never shifts sideways.
-                if !item.isActionItem {
+                if let fileSystemPath = item.fileSystemPath {
                     Button {
-                        NSWorkspace.shared.selectFile(item.path, inFileViewerRootedAtPath: "")
+                        NSWorkspace.shared.selectFile(fileSystemPath, inFileViewerRootedAtPath: "")
                     } label: {
                         Image(systemName: "folder")
                             .font(.caption)
@@ -324,9 +324,9 @@ private struct FileRowView: View {
         .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: isSelected)
         .onHover { hovering = $0 }
         .contextMenu {
-            if !item.isActionItem {
+            if let fileSystemPath = item.fileSystemPath {
                 Button("Reveal in Finder") {
-                    NSWorkspace.shared.selectFile(item.path, inFileViewerRootedAtPath: "")
+                    NSWorkspace.shared.selectFile(fileSystemPath, inFileViewerRootedAtPath: "")
                 }
             }
         }
@@ -335,6 +335,9 @@ private struct FileRowView: View {
     private var fileIcon: String {
         if item.simctlRuntimeIdentifier != nil {
             return "iphone"
+        }
+        if item.gitWorktreePath != nil {
+            return "arrow.triangle.branch"
         }
         let ext = (item.name as NSString).pathExtension.lowercased()
         switch ext {
@@ -345,7 +348,9 @@ private struct FileRowView: View {
         case "pkg": return "shippingbox"
         default:
             var isDir: ObjCBool = false
-            if FileManager.default.fileExists(atPath: item.path, isDirectory: &isDir), isDir.boolValue {
+            if let fileSystemPath = item.fileSystemPath,
+               FileManager.default.fileExists(atPath: fileSystemPath, isDirectory: &isDir),
+               isDir.boolValue {
                 return "folder"
             }
             return "doc"

--- a/PureMac/ar.lproj/Localizable.strings
+++ b/PureMac/ar.lproj/Localizable.strings
@@ -238,7 +238,8 @@
 "Scan everything at once" = "فحص كل شيء دفعة واحدة";
 "System caches, logs, and temporary files" = "ذاكرات النظام المؤقتة والسجلات والملفات المؤقتة";
 "Application caches and browser data" = "ذاكرات التطبيقات المؤقتة وبيانات المتصفح";
-"Local AI app logs, caches, and optional history" = "سجلات تطبيقات الذكاء الاصطناعي المحلية وذاكراتها المؤقتة والمحفوظات الاختيارية";
+"Local AI app data and stale coding worktrees" = "بيانات تطبيقات الذكاء الاصطناعي المحلية وأشجار العمل البرمجية القديمة";
+"%@ Worktree — %@" = "شجرة عمل %@ — %@";
 "Downloaded mail attachments" = "مرفقات البريد التي تم تنزيلها";
 "Files in your Trash" = "الملفات الموجودة في سلة المهملات";
 "Files over 100 MB or older than 1 year" = "الملفات التي يتجاوز حجمها 100 ميغابايت أو أقدم من سنة";

--- a/PureMac/en.lproj/Localizable.strings
+++ b/PureMac/en.lproj/Localizable.strings
@@ -279,7 +279,8 @@
 "Scan everything at once" = "Scan everything at once";
 "System caches, logs, and temporary files" = "System caches, logs, and temporary files";
 "Application caches and browser data" = "Application caches and browser data";
-"Local AI app logs, caches, and optional history" = "Local AI app logs, caches, and optional history";
+"Local AI app data and stale coding worktrees" = "Local AI app data and stale coding worktrees";
+"%@ Worktree — %@" = "%@ Worktree — %@";
 "Downloaded mail attachments" = "Downloaded mail attachments";
 "Files in your Trash" = "Files in your Trash";
 "Files over 100 MB or older than 1 year" = "Files over 100 MB or older than 1 year";

--- a/PureMac/es.lproj/Localizable.strings
+++ b/PureMac/es.lproj/Localizable.strings
@@ -238,7 +238,8 @@
 "Scan everything at once" = "Analizar todo a la vez";
 "System caches, logs, and temporary files" = "Cachés del sistema, registros y archivos temporales";
 "Application caches and browser data" = "Cachés de aplicaciones y datos del navegador";
-"Local AI app logs, caches, and optional history" = "Registros, cachés e historial opcional de apps de IA locales";
+"Local AI app data and stale coding worktrees" = "Datos de apps de IA locales y árboles de trabajo de código obsoletos";
+"%@ Worktree — %@" = "Árbol de trabajo de %@ — %@";
 "Downloaded mail attachments" = "Adjuntos de correo descargados";
 "Files in your Trash" = "Archivos en la Papelera";
 "Files over 100 MB or older than 1 year" = "Archivos de más de 100 MB o con más de 1 año";

--- a/PureMac/fr.lproj/Localizable.strings
+++ b/PureMac/fr.lproj/Localizable.strings
@@ -263,7 +263,8 @@
 "Scan everything at once" = "Tout analyser d'un coup";
 "System caches, logs, and temporary files" = "Caches système, journaux et fichiers temporaires";
 "Application caches and browser data" = "Caches d'applications et données de navigateur";
-"Local AI app logs, caches, and optional history" = "Journaux, caches et historique optionnel des apps d'IA locales";
+"Local AI app data and stale coding worktrees" = "Données d’apps d’IA locales et anciens arbres de travail de code";
+"%@ Worktree — %@" = "Arbre de travail %@ — %@";
 "Downloaded mail attachments" = "Pièces jointes d'e-mails téléchargées";
 "Files in your Trash" = "Fichiers dans votre corbeille";
 "Files over 100 MB or older than 1 year" = "Fichiers de plus de 100 Mo ou vieux de plus d'un an";

--- a/PureMac/ja.lproj/Localizable.strings
+++ b/PureMac/ja.lproj/Localizable.strings
@@ -238,7 +238,8 @@
 "Scan everything at once" = "すべてを一度にスキャン";
 "System caches, logs, and temporary files" = "システムキャッシュ、ログ、一時ファイル";
 "Application caches and browser data" = "アプリケーションキャッシュとブラウザデータ";
-"Local AI app logs, caches, and optional history" = "ローカルAIアプリのログ、キャッシュ、任意の履歴";
+"Local AI app data and stale coding worktrees" = "ローカルAIアプリのデータと古いコーディング用ワークツリー";
+"%@ Worktree — %@" = "%@ ワークツリー — %@";
 "Downloaded mail attachments" = "ダウンロードしたメール添付ファイル";
 "Files in your Trash" = "ゴミ箱内のファイル";
 "Files over 100 MB or older than 1 year" = "100MB以上または1年以上前のファイル";

--- a/PureMac/pl.lproj/Localizable.strings
+++ b/PureMac/pl.lproj/Localizable.strings
@@ -279,7 +279,8 @@
 "Scan everything at once" = "Skanuj wszystko naraz";
 "System caches, logs, and temporary files" = "Pamięci podręczne systemu, logi i pliki tymczasowe";
 "Application caches and browser data" = "Pamięci podręczne aplikacji i dane przeglądarek";
-"Local AI app logs, caches, and optional history" = "Logi aplikacji AI, pamięci podręczne i historia";
+"Local AI app data and stale coding worktrees" = "Dane lokalnych aplikacji AI i nieaktywne drzewa robocze kodu";
+"%@ Worktree — %@" = "Drzewo robocze %@ — %@";
 "Downloaded mail attachments" = "Pobrane załączniki poczty";
 "Files in your Trash" = "Pliki w koszu";
 "Files over 100 MB or older than 1 year" = "Pliki powyżej 100 MB lub starsze niż 1 rok";

--- a/PureMac/pt-BR.lproj/Localizable.strings
+++ b/PureMac/pt-BR.lproj/Localizable.strings
@@ -238,7 +238,8 @@
 "Scan everything at once" = "Verificar tudo de uma vez";
 "System caches, logs, and temporary files" = "Caches do sistema, logs e arquivos temporários";
 "Application caches and browser data" = "Caches de aplicativos e dados do navegador";
-"Local AI app logs, caches, and optional history" = "Logs, caches e histórico opcional de apps de IA locais";
+"Local AI app data and stale coding worktrees" = "Dados de apps de IA locais e worktrees de código inativas";
+"%@ Worktree — %@" = "Worktree do %@ — %@";
 "Downloaded mail attachments" = "Anexos de e-mail baixados";
 "Files in your Trash" = "Arquivos na sua Lixeira";
 "Files over 100 MB or older than 1 year" = "Arquivos com mais de 100 MB ou mais de 1 ano";

--- a/PureMac/ru.lproj/Localizable.strings
+++ b/PureMac/ru.lproj/Localizable.strings
@@ -279,7 +279,8 @@
 "Scan everything at once" = "Сканирование всех категорий сразу";
 "System caches, logs, and temporary files" = "Системные кэши, журналы и временные файлы";
 "Application caches and browser data" = "Кэши приложений и данные браузеров";
-"Local AI app logs, caches, and optional history" = "Локальные журналы, кэши и необязательная история ИИ-приложений";
+"Local AI app data and stale coding worktrees" = "Данные локальных ИИ-приложений и устаревшие рабочие деревья кода";
+"%@ Worktree — %@" = "Рабочее дерево %@ — %@";
 "Downloaded mail attachments" = "Загруженные почтовые вложения";
 "Files in your Trash" = "Файлы в Корзине";
 "Files over 100 MB or older than 1 year" = "Файлы размером более 100 МБ или старше 1 года";

--- a/PureMac/uk.lproj/Localizable.strings
+++ b/PureMac/uk.lproj/Localizable.strings
@@ -279,7 +279,8 @@
 "Scan everything at once" = "Усе за одне сканування";
 "System caches, logs, and temporary files" = "Системні кеші, журнали й тимчасові файли";
 "Application caches and browser data" = "Кеші програм і дані браузерів";
-"Local AI app logs, caches, and optional history" = "Журнали, кеші та, за бажанням, історія локальних програм ШІ";
+"Local AI app data and stale coding worktrees" = "Дані локальних програм ШІ та застарілі робочі дерева коду";
+"%@ Worktree — %@" = "Робоче дерево %@ — %@";
 "Downloaded mail attachments" = "Викачані вкладення Пошти";
 "Files in your Trash" = "Файли у Смітнику";
 "Files over 100 MB or older than 1 year" = "Файли розміром понад 100 МБ або старші за 1 рік";

--- a/PureMac/zh-Hans.lproj/Localizable.strings
+++ b/PureMac/zh-Hans.lproj/Localizable.strings
@@ -238,7 +238,8 @@
 "Scan everything at once" = "一次扫描所有内容";
 "System caches, logs, and temporary files" = "系统缓存、日志和临时文件";
 "Application caches and browser data" = "应用程序缓存和浏览器数据";
-"Local AI app logs, caches, and optional history" = "本地 AI 应用的日志、缓存和可选历史";
+"Local AI app data and stale coding worktrees" = "本地 AI 应用数据和过期的编码工作树";
+"%@ Worktree — %@" = "%@ 工作树 — %@";
 "Downloaded mail attachments" = "已下载的邮件附件";
 "Files in your Trash" = "废纸篓中的文件";
 "Files over 100 MB or older than 1 year" = "大于 100 MB 或超过 1 年的文件";

--- a/PureMac/zh-Hant.lproj/Localizable.strings
+++ b/PureMac/zh-Hant.lproj/Localizable.strings
@@ -238,7 +238,8 @@
 "Scan everything at once" = "一次掃描所有項目";
 "System caches, logs, and temporary files" = "系統快取、紀錄與暫存檔案";
 "Application caches and browser data" = "應用程式快取與瀏覽器資料";
-"Local AI app logs, caches, and optional history" = "本地 AI 應用程式的紀錄、快取與選用記錄";
+"Local AI app data and stale coding worktrees" = "本地 AI 應用程式資料和過期的程式碼工作樹";
+"%@ Worktree — %@" = "%@ 工作樹 — %@";
 "Downloaded mail attachments" = "已下載的郵件附件";
 "Files in your Trash" = "垃圾桶中的檔案";
 "Files over 100 MB or older than 1 year" = "超過 100 MB 或一年以上的檔案";

--- a/PureMacTests/GitWorktreeScannerTests.swift
+++ b/PureMacTests/GitWorktreeScannerTests.swift
@@ -7,8 +7,8 @@ final class GitWorktreeScannerTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        // Keep destructive Git fixtures on the checkout's own volume. Locally
-        // this is the external T7; CI gets the same-volume build directory.
+        // Keep destructive Git fixtures under the checkout's build directory.
+        // This is portable and keeps every fixture on the checkout's volume.
         let sourceRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()

--- a/PureMacTests/GitWorktreeScannerTests.swift
+++ b/PureMacTests/GitWorktreeScannerTests.swift
@@ -42,13 +42,14 @@ final class GitWorktreeScannerTests: XCTestCase {
         XCTAssertTrue(records[2].isPrunable)
     }
 
-    func testScanFindsCodexClaudeOMPCursorPiAndManualWorktrees() throws {
+    func testScanFindsCodexClaudeHerdrOMPCursorPiAndManualWorktrees() throws {
         let repository = try makeRepository(named: "provider-repo")
         let worktrees = [
             temporaryHome.appendingPathComponent(".codex/worktrees/session/provider-repo"),
             repository.appendingPathComponent(".claude/worktrees/claude-task"),
             temporaryHome.appendingPathComponent(".omp/wt/provider-repo/omp-task"),
             temporaryHome.appendingPathComponent(".cursor/worktrees/session/provider-repo"),
+            temporaryHome.appendingPathComponent(".herdr/worktrees/provider-repo/herdr-task"),
             temporaryHome.appendingPathComponent(".pi/worktrees/pi-task"),
             temporaryHome.appendingPathComponent("Developer/provider-repo-manual"),
         ]
@@ -65,9 +66,10 @@ final class GitWorktreeScannerTests: XCTestCase {
         let items = makeScanner().scan()
         let names = Set(items.map(\.name))
 
-        XCTAssertEqual(items.count, 6)
+        XCTAssertEqual(items.count, 7)
         XCTAssertTrue(names.contains("Codex Worktree — provider-repo"))
         XCTAssertTrue(names.contains("Claude Code Worktree — provider-repo"))
+        XCTAssertTrue(names.contains("Herdr Worktree — provider-repo"))
         XCTAssertTrue(names.contains("Oh My Pi Worktree — provider-repo"))
         XCTAssertTrue(names.contains("Cursor Worktree — provider-repo"))
         XCTAssertTrue(names.contains("Pi Worktree — provider-repo"))

--- a/PureMacTests/GitWorktreeScannerTests.swift
+++ b/PureMacTests/GitWorktreeScannerTests.swift
@@ -1,0 +1,270 @@
+import XCTest
+@testable import PureMac
+
+final class GitWorktreeScannerTests: XCTestCase {
+    private var temporaryHome: URL!
+    private let gitPath = "/usr/bin/git"
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // Keep destructive Git fixtures on the checkout's own volume. Locally
+        // this is the external T7; CI gets the same-volume build directory.
+        let sourceRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        temporaryHome = sourceRoot
+            .appendingPathComponent("build/TestWorktrees", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryHome, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let temporaryHome {
+            try? FileManager.default.removeItem(at: temporaryHome)
+        }
+        try super.tearDownWithError()
+    }
+
+    func testPorcelainParserHandlesNULFieldsReasonsAndDetachedRecords() {
+        let payload = [
+            "worktree /Volumes/Test/main", "HEAD aaaa", "branch refs/heads/main", "",
+            "worktree /Volumes/Test/locked tree", "HEAD bbbb", "detached", "locked agent is running", "",
+            "worktree /Volumes/Test/gone", "HEAD cccc", "detached", "prunable gitdir file points to non-existent location", "",
+        ].joined(separator: "\0") + "\0"
+
+        let records = GitWorktreeScanner.parseWorktreeList(Data(payload.utf8))
+
+        XCTAssertEqual(records.count, 3)
+        XCTAssertEqual(records[0].branch, "refs/heads/main")
+        XCTAssertEqual(records[1].path, "/Volumes/Test/locked tree")
+        XCTAssertTrue(records[1].isDetached)
+        XCTAssertTrue(records[1].isLocked)
+        XCTAssertTrue(records[2].isPrunable)
+    }
+
+    func testScanFindsCodexClaudeOMPCursorPiAndManualWorktrees() throws {
+        let repository = try makeRepository(named: "provider-repo")
+        let worktrees = [
+            temporaryHome.appendingPathComponent(".codex/worktrees/session/provider-repo"),
+            repository.appendingPathComponent(".claude/worktrees/claude-task"),
+            temporaryHome.appendingPathComponent(".omp/wt/provider-repo/omp-task"),
+            temporaryHome.appendingPathComponent(".cursor/worktrees/session/provider-repo"),
+            temporaryHome.appendingPathComponent(".pi/worktrees/pi-task"),
+            temporaryHome.appendingPathComponent("Developer/provider-repo-manual"),
+        ]
+
+        for worktree in worktrees {
+            try FileManager.default.createDirectory(
+                at: worktree.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try runGit(["-C", repository.path, "worktree", "add", "--detach", worktree.path, "HEAD"])
+            try ageContents(of: worktree, byDays: 60)
+        }
+
+        let items = makeScanner().scan()
+        let names = Set(items.map(\.name))
+
+        XCTAssertEqual(items.count, 6)
+        XCTAssertTrue(names.contains("Codex Worktree — provider-repo"))
+        XCTAssertTrue(names.contains("Claude Code Worktree — provider-repo"))
+        XCTAssertTrue(names.contains("Oh My Pi Worktree — provider-repo"))
+        XCTAssertTrue(names.contains("Cursor Worktree — provider-repo"))
+        XCTAssertTrue(names.contains("Pi Worktree — provider-repo"))
+        XCTAssertTrue(names.contains("Git Worktree — provider-repo"))
+        XCTAssertTrue(items.allSatisfy { !$0.isSelected })
+        XCTAssertEqual(Set(items.compactMap(\.gitWorktreePath)), Set(worktrees.map(\.path)))
+    }
+
+    func testScanFindsWorktreesOnConnectedWritableVolumes() throws {
+        let isolatedHome = temporaryHome.appendingPathComponent("Home", isDirectory: true)
+        try FileManager.default.createDirectory(at: isolatedHome, withIntermediateDirectories: true)
+        let connectedVolume = temporaryHome.appendingPathComponent("ConnectedVolume", isDirectory: true)
+        let repository = try makeRepository(named: "volume-repo", under: connectedVolume)
+        let worktree = connectedVolume.appendingPathComponent("Worktrees/old-task", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: worktree.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try runGit(["-C", repository.path, "worktree", "add", "--detach", worktree.path, "HEAD"])
+        try ageContents(of: worktree, byDays: 60)
+        let items = makeScanner(
+            homeURL: isolatedHome,
+            mountedVolumeURLs: [connectedVolume]
+        ).scan()
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items.first?.gitWorktreePath, worktree.path)
+        XCTAssertEqual(items.first?.name, "Git Worktree — volume-repo")
+    }
+
+    func testScanExcludesRecentDirtyLockedAndUnreferencedDetachedWorktrees() throws {
+        let repository = try makeRepository(named: "safety-repo")
+        let recent = temporaryHome.appendingPathComponent("Developer/recent")
+        let dirty = temporaryHome.appendingPathComponent("Developer/dirty")
+        let locked = temporaryHome.appendingPathComponent("Developer/locked")
+        let uniqueCommit = temporaryHome.appendingPathComponent("Developer/unique-commit")
+
+        for worktree in [recent, dirty, locked, uniqueCommit] {
+            try FileManager.default.createDirectory(
+                at: worktree.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try runGit(["-C", repository.path, "worktree", "add", "--detach", worktree.path, "HEAD"])
+        }
+
+        try Data("untracked".utf8).write(to: dirty.appendingPathComponent("notes.txt"))
+        try runGit(["-C", repository.path, "worktree", "lock", locked.path])
+        try Data("committed work".utf8).write(to: uniqueCommit.appendingPathComponent("unique.txt"))
+        try runGit(["-C", uniqueCommit.path, "add", "unique.txt"])
+        try runGit(["-C", uniqueCommit.path, "commit", "-m", "unique detached commit"])
+
+        for worktree in [dirty, locked, uniqueCommit] {
+            try ageContents(of: worktree, byDays: 60)
+        }
+        try ageContents(of: recent, byDays: 2)
+
+        XCTAssertTrue(makeScanner().scan().isEmpty)
+    }
+
+    func testRemoveWorktreePreservesItsBranch() throws {
+        let repository = try makeRepository(named: "branch-repo")
+        let worktree = temporaryHome.appendingPathComponent("Developer/branch-worktree")
+        try FileManager.default.createDirectory(
+            at: worktree.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try runGit(["-C", repository.path, "worktree", "add", "-b", "keep-this-branch", worktree.path, "HEAD"])
+        try ageContents(of: worktree, byDays: 60)
+
+        let scanner = makeScanner()
+        XCTAssertEqual(scanner.scan().count, 1)
+
+        let result = scanner.removeWorktree(at: worktree.path)
+
+        XCTAssertTrue(result.removed, result.error ?? "Expected Git removal to succeed")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: worktree.path))
+        let branchResult = GitWorktreeScanner.runCommand(
+            gitPath,
+            ["-C", repository.path, "show-ref", "--verify", "--quiet", "refs/heads/keep-this-branch"]
+        )
+        XCTAssertEqual(branchResult.status, 0, "Removing a worktree must preserve its branch")
+    }
+
+    func testRemoveWorktreeRechecksDirtyStateAfterScan() throws {
+        let repository = try makeRepository(named: "race-repo")
+        let worktree = temporaryHome.appendingPathComponent("Developer/race-worktree")
+        try FileManager.default.createDirectory(
+            at: worktree.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try runGit(["-C", repository.path, "worktree", "add", "--detach", worktree.path, "HEAD"])
+        try ageContents(of: worktree, byDays: 60)
+
+        let scanner = makeScanner()
+        XCTAssertEqual(scanner.scan().count, 1)
+        try Data("new work".utf8).write(to: worktree.appendingPathComponent("do-not-delete.txt"))
+
+        let result = scanner.removeWorktree(at: worktree.path)
+
+        XCTAssertFalse(result.removed)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: worktree.path))
+        XCTAssertTrue(result.error?.contains("changed") == true)
+    }
+
+    func testCleaningEngineRoutesWorktreeItemsThroughGit() async throws {
+        let repository = try makeRepository(named: "engine-repo")
+        let worktree = temporaryHome.appendingPathComponent("Developer/engine-worktree")
+        try FileManager.default.createDirectory(
+            at: worktree.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try runGit(["-C", repository.path, "worktree", "add", "-b", "engine-branch", worktree.path, "HEAD"])
+        try ageContents(of: worktree, byDays: 60)
+        let item = try XCTUnwrap(makeScanner().scan().first)
+
+        let result = await CleaningEngine().cleanItems([item]) { _ in }
+
+        XCTAssertEqual(result.itemsCleaned, 1)
+        XCTAssertEqual(result.freedSpace, item.size)
+        XCTAssertTrue(result.cleanedPaths.contains(item.path))
+        XCTAssertTrue(result.errors.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: worktree.path))
+    }
+
+    func testCleanableItemExposesRealWorktreePathForFinder() {
+        let item = CleanableItem(
+            name: "Codex Worktree — app",
+            path: CleanableItem.gitWorktreePathPrefix + "/Users/test/.codex/worktrees/task/app",
+            size: 4096,
+            category: .aiApps,
+            isSelected: false,
+            lastModified: nil
+        )
+
+        XCTAssertEqual(item.gitWorktreePath, "/Users/test/.codex/worktrees/task/app")
+        XCTAssertEqual(item.fileSystemPath, "/Users/test/.codex/worktrees/task/app")
+        XCTAssertFalse(item.isActionItem)
+    }
+
+    // MARK: - Fixtures
+
+    private func makeScanner(
+        homeURL: URL? = nil,
+        mountedVolumeURLs: [URL] = []
+    ) -> GitWorktreeScanner {
+        GitWorktreeScanner(
+            homeURL: homeURL ?? temporaryHome,
+            mountedVolumeURLs: mountedVolumeURLs,
+            now: Date(),
+            inactivityInterval: 30 * 24 * 60 * 60,
+            gitExecutablePath: gitPath
+        )
+    }
+
+    private func makeRepository(named name: String, under root: URL? = nil) throws -> URL {
+        let repositoryRoot = root ?? temporaryHome.appendingPathComponent("Developer", isDirectory: true)
+        let repository = repositoryRoot.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: repository, withIntermediateDirectories: true)
+        try runGit(["init", "-b", "main", repository.path])
+        try runGit(["-C", repository.path, "config", "user.name", "PureMac Tests"])
+        try runGit(["-C", repository.path, "config", "user.email", "puremac-tests@example.invalid"])
+        try Data(repeating: 0x41, count: 8192).write(to: repository.appendingPathComponent("seed.bin"))
+        try runGit(["-C", repository.path, "add", "seed.bin"])
+        try runGit(["-C", repository.path, "commit", "-m", "initial"])
+        return repository
+    }
+
+    private func ageContents(of directory: URL, byDays days: Int) throws {
+        let oldDate = Date().addingTimeInterval(-TimeInterval(days) * 24 * 60 * 60)
+        let keys: [URLResourceKey] = [.isDirectoryKey]
+        if let enumerator = FileManager.default.enumerator(
+            at: directory,
+            includingPropertiesForKeys: keys,
+            options: [],
+            errorHandler: { _, _ in true }
+        ) {
+            for case let url as URL in enumerator {
+                if url.lastPathComponent == ".git" && url.deletingLastPathComponent() == directory {
+                    continue
+                }
+                try FileManager.default.setAttributes([.modificationDate: oldDate], ofItemAtPath: url.path)
+            }
+        }
+        try FileManager.default.setAttributes([.modificationDate: oldDate], ofItemAtPath: directory.path)
+    }
+
+    @discardableResult
+    private func runGit(_ arguments: [String]) throws -> GitWorktreeScanner.CommandResult {
+        let result = GitWorktreeScanner.runCommand(gitPath, arguments)
+        guard result.status == 0 else {
+            let stderr = String(data: result.stderr, encoding: .utf8) ?? ""
+            throw NSError(
+                domain: "GitWorktreeScannerTests",
+                code: Int(result.status),
+                userInfo: [NSLocalizedDescriptionKey: "git \(arguments.joined(separator: " ")) failed: \(stderr)"]
+            )
+        }
+        return result
+    }
+}

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Smart Scan runs every category in parallel. Each category is its own deliberate 
 
 - **System Junk** - system caches, logs, temp files
 - **User Cache** - dynamically discovered, no hardcoded app list
-- **AI Apps** - Ollama and LM Studio logs, caches, and opt-in history cleanup, plus clean Git worktrees inactive for 30 days from Codex, Claude Code, Cursor, Oh My Pi, Pi, or manual workflows across the home directory and all connected writable local volumes. Worktrees are never auto-selected; locked, changed, and unreferenced detached worktrees are excluded and removal goes through `git worktree remove` without `--force`.
+- **AI Apps** - Ollama and LM Studio logs, caches, and opt-in history cleanup, plus clean Git worktrees inactive for 30 days from Codex, Claude Code, Cursor, Herdr, Oh My Pi, Pi, or manual workflows across the home directory and all connected writable local volumes. Worktrees are never auto-selected; locked, changed, and unreferenced detached worktrees are excluded and removal goes through `git worktree remove` without `--force`.
 - **Mail Files** - downloaded mail attachments
 - **Trash Bins** - empties all bins, including external volumes
 - **Large & Old Files** - >100 MB or older than 1 year (never auto-selected)

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Smart Scan runs every category in parallel. Each category is its own deliberate 
 
 - **System Junk** - system caches, logs, temp files
 - **User Cache** - dynamically discovered, no hardcoded app list
-- **AI Apps** - Ollama and LM Studio logs, caches, opt-in history cleanup
+- **AI Apps** - Ollama and LM Studio logs, caches, and opt-in history cleanup, plus clean Git worktrees inactive for 30 days from Codex, Claude Code, Cursor, Oh My Pi, Pi, or manual workflows across the home directory and all connected writable local volumes. Worktrees are never auto-selected; locked, changed, and unreferenced detached worktrees are excluded and removal goes through `git worktree remove` without `--force`.
 - **Mail Files** - downloaded mail attachments
 - **Trash Bins** - empties all bins, including external volumes
 - **Large & Old Files** - >100 MB or older than 1 year (never auto-selected)


### PR DESCRIPTION
## What does this PR do?

Extends **AI Apps** cleanup with opt-in discovery and safe removal of stale linked Git worktrees.

- Scans the user home plus every connected writable, browsable local volume, including manually created worktrees.
- Labels known Codex, Claude Code, Cursor, Herdr, Oh My Pi, and Pi worktree layouts while retaining generic Git support.
- Offers only worktrees inactive for at least 30 days; candidates are never preselected.
- Excludes dirty, locked, prunable, missing, recent, and unreferenced detached worktrees.
- Revalidates every safety condition immediately before cleanup and delegates removal to `git worktree remove` without `--force`, preserving branches and shared Git metadata.
- Adds focused scanner/cleaning tests, all supported localizations, and README documentation.
- Runs the macOS test target in CI for future pull requests and main-branch updates; the workflow also supports manual verification runs.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [x] UI/UX enhancement
- [x] Documentation
- [ ] Other (describe)

## Testing

- [ ] Tested on macOS Ventura (13.x)
- [ ] Tested on macOS Sonoma (14.x)
- [x] Tested on macOS Sequoia (15.x)
- [x] Full `PureMacTests` target passed on macOS Sequoia 15: https://github.com/omnibassa/PureMac/actions/runs/33501301809
- [x] Universal Release build passed for `arm64` and `x86_64` in the same run
- [x] Connected-volume discovery, opt-in defaults, Git removal, and branch preservation have portable XCTest coverage
- [x] Codex, Claude Code, Cursor, Herdr, Oh My Pi, Pi, manual, recent, dirty, locked, and detached cases have portable XCTest coverage
- [x] Test fixtures stay under the checkout's ignored `build/TestWorktrees` directory on the current machine's volume
- [x] All 11 localization catalogs pass `plutil` and key/format parity checks
- [x] GitHub Actions workflow validated with `actionlint`

## Screenshots

N/A — no new screens or layout changes.