### PR TITLE
cli: add Puppeteer, Playwright, node-gyp & Electron caches to `clean dev`

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -49,8 +49,9 @@ Flags on `clean` and `purge`:
 
 Homebrew, npm, Yarn, pnpm, pip, Cargo, Go, CocoaPods, VS Code, JetBrains, Maven,
 Gradle, Poetry, uv, Bun, Deno, mise, Flutter/Dart, NuGet/.NET, Swift Package
-Manager, Docker, and OrbStack. Only precise cache and build directories are
-targeted, never a whole config directory such as `~/.cargo` or `~/.docker`.
+Manager, Puppeteer, Playwright, node-gyp, Electron, Docker, and OrbStack. Only
+precise cache and build directories are targeted, never a whole config directory
+such as `~/.cargo` or `~/.docker`.
 
 ## What `purge` finds
 

--- a/cli/Sources/puremac/Core/Catalog.swift
+++ b/cli/Sources/puremac/Core/Catalog.swift
@@ -16,7 +16,7 @@ enum Catalog {
         [
 
             Target(tool: "Homebrew", paths: [h("Library/Caches/Homebrew")]),
-            Target(tool: "npm", paths: [h(".npm/_cacache")]),
+            Target(tool: "npm", paths: [h(".npm/_cacache"), h(".npm/_logs")]),
             Target(tool: "Yarn", paths: [h("Library/Caches/Yarn"), h(".cache/yarn"), h(".yarn/berry/cache")]),
             Target(tool: "pnpm", paths: [h("Library/pnpm/store"), h(".pnpm-store"), h(".cache/pnpm")]),
             Target(tool: "pip", paths: [h("Library/Caches/pip"), h(".cache/pip")]),
@@ -38,6 +38,11 @@ enum Catalog {
             Target(tool: "NuGet / .NET (~/.nuget — may hold local packages)", paths: [h(".nuget/packages"), h(".local/share/NuGet/http-cache")], selectedByDefault: false),
 
             Target(tool: "Swift Package Manager", paths: [h("Library/Caches/org.swift.swiftpm")]),
+
+            Target(tool: "Puppeteer (browser downloads)", paths: [h(".cache/puppeteer")]),
+            Target(tool: "Playwright (browser downloads)", paths: [h("Library/Caches/ms-playwright"), h(".cache/ms-playwright")]),
+            Target(tool: "node-gyp (cached headers)", paths: [h("Library/Caches/node-gyp"), h(".cache/node-gyp")]),
+            Target(tool: "Electron (download cache)", paths: [h("Library/Caches/electron"), h("Library/Caches/electron-builder")]),
 
             Target(tool: "Docker Desktop", paths: [h("Library/Containers/com.docker.docker/Data/cache"), h("Library/Containers/com.docker.docker/Data/log"), h("Library/Containers/com.docker.docker/Data/tmp"), h("Library/Group Containers/group.com.docker/Caches"), h(".docker/cli-plugins/.cache"), h(".docker/buildx/cache")]),
             Target(tool: "OrbStack", paths: [h(".orbstack/log"), h("Library/Caches/dev.kdrag0n.MacVirt"), h("Library/Logs/OrbStack")]),


### PR DESCRIPTION
## What

Adds four download/build caches to the `dev` catalog (`puremac clean dev`):

| Tool | Paths | What it is |
|---|---|---|
| Puppeteer | `~/.cache/puppeteer` | downloaded Chrome / chrome-headless-shell builds — frequently 0.5–1.5 GB across revisions |
| Playwright | `~/Library/Caches/ms-playwright`, `~/.cache/ms-playwright` | downloaded browser builds |
| node-gyp | `~/Library/Caches/node-gyp`, `~/.cache/node-gyp` | cached Node headers per version |
| Electron | `~/Library/Caches/electron`, `~/Library/Caches/electron-builder` | `@electron/get` download cache |

Also appends `~/.npm/_logs` to the existing npm entry (debug logs, next to `_cacache`).

## Why

These accumulate silently, hold multiple stale versions, and regenerate on demand —
the same profile as the caches already in `dev`. None of them are config roots;
only the precise cache directories are listed.

## Testing

`swiftc -parse` on the changed file is clean. I could **not** run a full
`swift build` locally — this machine has Command Line Tools only, and the
`PackageDescription` manifest currently fails to link against the macOS 26 SDK
(unrelated to this change). Please confirm via CI or a full Xcode toolchain.
Change is data-only additions to `Catalog.dev`, mirroring ~30 existing entries.

## Scope

One focused change. Docs updated (`cli/README.md` — "What `clean dev` covers").
