### PR TITLE
cli: add Claude Desktop, ChatGPT & Hugging Face caches to `clean ai`

### DIFF
--- a/cli/Sources/puremac/Core/Catalog.swift
+++ b/cli/Sources/puremac/Core/Catalog.swift
@@ -67,6 +67,9 @@ enum Catalog {
             Target(tool: "Ollama (logs/cache)", paths: [h(".ollama/logs"), h("Library/Caches/ollama"), h("Library/Caches/com.electron.ollama")]),
             Target(tool: "LM Studio (logs)", paths: [h(".lmstudio/server-logs")]),
             Target(tool: "Cursor (cache)", paths: [h("Library/Application Support/Cursor/Cache"), h("Library/Application Support/Cursor/CachedData"), h("Library/Application Support/Cursor/logs")]),
+            Target(tool: "Claude Desktop (cache)", paths: [h("Library/Application Support/Claude/Cache"), h("Library/Application Support/Claude/Code Cache"), h("Library/Application Support/Claude/GPUCache"), h("Library/Application Support/Claude/DawnGraphiteCache"), h("Library/Application Support/Claude/DawnWebGPUCache")]),
+            Target(tool: "ChatGPT Desktop (cache)", paths: [h("Library/Application Support/com.openai.chat/Cache"), h("Library/Application Support/com.openai.chat/Code Cache"), h("Library/Application Support/com.openai.chat/GPUCache")]),
+            Target(tool: "Hugging Face (~/.cache/huggingface — may hold large model downloads)", paths: [h(".cache/huggingface")], selectedByDefault: false),
         ]
     }
 


### PR DESCRIPTION
## What

Extends the `ai` catalog (`puremac clean ai`) alongside the existing Ollama /
LM Studio / Cursor entries:

| Tool | Paths | Notes |
|---|---|---|
| Claude Desktop | `~/Library/Application Support/Claude/{Cache,Code Cache,GPUCache,DawnGraphiteCache,DawnWebGPUCache}` | Electron caches; `Cache` + `Code Cache` alone are commonly 200 MB+ |
| ChatGPT Desktop | `~/Library/Application Support/com.openai.chat/{Cache,Code Cache,GPUCache}` | Electron caches |
| Hugging Face | `~/.cache/huggingface` | model/dataset cache — `selectedByDefault: false`, mirroring the existing Maven / NuGet "may hold local installs" convention |

## Why

Electron-based AI desktop apps are now as common as the editors already covered,
and their Chromium cache dirs grow the same way. Only cache directories are
targeted — no chat history, no config, and no model roots (`~/.ollama`,
`~/.lmstudio` are already denylisted in `Safety`).

## Testing

`swiftc -parse` on the changed file is clean. Full `swift build` could not run
locally (Command Line Tools only; `PackageDescription` manifest fails to link
against the macOS 26 SDK, unrelated to this change). Please confirm via CI.
Data-only additions to `Catalog.ai`.

## Scope

One focused change to `Catalog.swift`.
