### PR TITLE
fix(brew): Rename postflight to postflight_steps for puremac cask

### DIFF
--- a/homebrew/puremac.rb
+++ b/homebrew/puremac.rb
@@ -13,7 +13,7 @@ cask "puremac" do
 
   # Refresh LaunchServices so the Dock/Launchpad icon updates immediately on
   # (re)install instead of showing a stale cached icon (issue #111).
-  postflight do
+  postflight_steps do
     system_command "/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister",
                    args: ["-f", "#{appdir}/PureMac.app"]
   end


### PR DESCRIPTION
`postflight` is deprecated. Changed to `postflight_steps` to suppress brew warning while updating:

```bash
Warning: Calling `postflight` is deprecated! Use `postflight_steps` instead.
Please report this issue to the momenbasel/homebrew-tap tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/momenbasel/homebrew-tap/Casks/puremac.rb:16
```

## What does this PR do?
Replace deprecated postflight with postflight_steps in homebrew script

<!-- Brief description of the change -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] UI/UX enhancement
- [ ] Documentation
- [ ] Other (describe)

## Testing

- [ ] Tested on macOS Ventura (13.x)
- [ ] Tested on macOS Sonoma (14.x)
- [ ] Tested on macOS Sequoia (15.x)

## Screenshots

<!-- If applicable, add screenshots -->
